### PR TITLE
Fix ensureDirectories

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/Main.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/Main.kt
@@ -26,6 +26,7 @@ import com.sdercolin.vlabeler.audio.Player
 import com.sdercolin.vlabeler.env.KeyboardViewModel
 import com.sdercolin.vlabeler.env.Log
 import com.sdercolin.vlabeler.env.shouldTogglePlayer
+import com.sdercolin.vlabeler.io.ensureDirectories
 import com.sdercolin.vlabeler.io.produceAppState
 import com.sdercolin.vlabeler.model.AppRecord
 import com.sdercolin.vlabeler.ui.App
@@ -46,6 +47,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 fun main() = application {
+    ensureDirectories()
+    Log.init()
+
     val mainScope = rememberCoroutineScope()
     val appRecordStore = rememberAppRecordStore(mainScope)
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/Main.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/Main.kt
@@ -47,8 +47,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 fun main() = application {
-    ensureDirectories()
     Log.init()
+    ensureDirectories()
 
     val mainScope = rememberCoroutineScope()
     val appRecordStore = rememberAppRecordStore(mainScope)

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/env/Log.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/env/Log.kt
@@ -30,7 +30,7 @@ object Log {
 
     fun init() {
         val loggingDir = File(LoggingPath)
-        if (loggingDir.exists().not()) loggingDir.mkdir()
+        if (loggingDir.exists().not()) loggingDir.mkdirs()
 
         val infoHandler = FileHandler("$LoggingPath/$InfoLogFileName", true)
         infoHandler.formatter = formatter

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/Initialization.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/Initialization.kt
@@ -120,8 +120,6 @@ suspend fun produceAppState(mainScope: CoroutineScope, appRecordStore: AppRecord
     val keyboardViewModel = KeyboardViewModel(mainScope)
     val scrollFitViewModel = ScrollFitViewModel(mainScope)
     val snackbarHostState = SnackbarHostState()
-    ensureDirectories()
-    Log.init()
 
     val appConf = loadAppConf()
     val availableLabelerConfs = loadAvailableLabelerConfs()

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/Initialization.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/Initialization.kt
@@ -99,7 +99,7 @@ private fun File.asLabelerConf(): Result<LabelerConf> {
     return result
 }
 
-suspend fun ensureDirectories() = withContext(Dispatchers.IO) {
+fun ensureDirectories() {
     if (AppDir.exists().not()) {
         AppDir.mkdir()
         Log.info("$AppDir created")


### PR DESCRIPTION
Errors before the first window is created are printed as `Failed to launch JVM"
But it's actually not a JVM problem.