### PR TITLE
Improve loadSampleChunk and renderSpectrogram

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/ChartStore.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/ChartStore.kt
@@ -352,6 +352,6 @@ class ChartStore {
     }
 
     companion object {
-        private const val PaintingAlgorithmVersion = 6
+        private const val PaintingAlgorithmVersion = 7
     }
 }


### PR DESCRIPTION
1. Read all bytes of a chunk (37s -> 29s)
2. Replace CanvasDrawScope by setting pixels in renderSpectrogram (29s -> 24s)