### PR TITLE
Added missing Korean strings, fixed wrong format specifier 

### DIFF
--- a/resources/common/labelers/audacity-labeler/labeler.json
+++ b/resources/common/labelers/audacity-labeler/labeler.json
@@ -1,6 +1,6 @@
 {
     "name": "audacity.default",
-    "version": 13,
+    "version": 14,
     "serialVersion": 2,
     "singleFile": false,
     "extension": "txt",
@@ -90,7 +90,8 @@
                 "label": {
                     "en": "Default entry name",
                     "zh": "默认条目名称",
-                    "ja": "デフォルトエントリ名"
+                    "ja": "デフォルトエントリ名",
+                    "ko": "기본 엔트리 이름"
                 },
                 "defaultValue": "pau",
                 "optional": true

--- a/resources/common/labelers/nnsvs-singer-labeler/labeler.json
+++ b/resources/common/labelers/nnsvs-singer-labeler/labeler.json
@@ -1,6 +1,6 @@
 {
     "name": "nnsvs-singer.default",
-    "version": 11,
+    "version": 12,
     "serialVersion": 2,
     "singleFile": false,
     "extension": "lab",
@@ -118,7 +118,8 @@
                 "label": {
                     "en": "Default entry name",
                     "zh": "默认条目名称",
-                    "ja": "デフォルトエントリ名"
+                    "ja": "デフォルトエントリ名",
+                    "ko": "기본 엔트리 이름"
                 },
                 "defaultValue": "pau",
                 "optional": true

--- a/resources/common/labelers/sinsy-labeler/labeler.json
+++ b/resources/common/labelers/sinsy-labeler/labeler.json
@@ -1,6 +1,6 @@
 {
     "name": "sinsy.default",
-    "version": 16,
+    "version": 17,
     "serialVersion": 2,
     "singleFile": false,
     "extension": "lab",
@@ -90,7 +90,8 @@
                 "label": {
                     "en": "Default entry name",
                     "zh": "默认条目名称",
-                    "ja": "デフォルトエントリ名"
+                    "ja": "デフォルトエントリ名",
+                    "ko": "기본 엔트리 이름"
                 },
                 "defaultValue": "pau",
                 "optional": true

--- a/resources/common/plugins/macro/batch-edit-oto-parameter/plugin.json
+++ b/resources/common/plugins/macro/batch-edit-oto-parameter/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "batch-edit-oto-parameter",
-    "version": 8,
+    "version": 9,
     "type": "macro",
     "displayedName": {
         "en": "Batch edit oto parameter",
@@ -45,7 +45,8 @@
                 "label": {
                     "en": "Parameter to edit",
                     "zh": "要编辑的参数",
-                    "ja": "編集するパラメーター"
+                    "ja": "編集するパラメーター",
+                    "ko": "편집할 파라미터"
                 },
                 "defaultValue": "offset",
                 "options": [
@@ -59,27 +60,32 @@
                     {
                         "en": "Offset",
                         "zh": "左边界",
-                        "ja": "左ブランク"
+                        "ja": "左ブランク",
+                        "ko": "오프셋"
                     },
                     {
                         "en": "Overlap",
                         "zh": "重叠",
-                        "ja": "オーバーラップ"
+                        "ja": "オーバーラップ",
+                        "ko": "오버랩"
                     },
                     {
                         "en": "Preutterance",
                         "zh": "先行发声",
-                        "ja": "先行発声"
+                        "ja": "先行発声",
+                        "ko": "선행자음부"
                     },
                     {
                         "en": "Fixed",
                         "zh": "固定",
-                        "ja": "固定範囲"
+                        "ja": "固定範囲",
+                        "ko": "고정자음부"
                     },
                     {
                         "en": "Cutoff",
                         "zh": "右边界",
-                        "ja": "右ブランク"
+                        "ja": "右ブランク",
+                        "ko": "컷오프"
                     }
                 ]
             },
@@ -89,12 +95,14 @@
                 "label": {
                     "en": "Expression",
                     "zh": "表达式",
-                    "ja": "計算式"
+                    "ja": "計算式",
+                    "ko": "식"
                 },
                 "description": {
                     "en": "Expression to calculate the new value. Parameter placeholders such as \"${Offset}\", \"${Overlap} are available in the calculation.",
                     "zh": "用于计算新值的表达式。可以在计算中使用参数占位符，例如 \"${左边界}\", \"${重叠}\"。",
-                    "ja": "新しい値を計算するための式。計算式中にパラメーターのプレースホルダー（例：\"${左ブランク}\", \"${Overlap}\"）を使用できます。"
+                    "ja": "新しい値を計算するための式。計算式中にパラメーターのプレースホルダー（例：\"${左ブランク}\", \"${Overlap}\"）を使用できます。",
+                    "ko": "새로운 값의 계산에 쓰일 식이에요. 계산식에는 \"${오프셋}\", \"${오버랩}\" 등과 같은 플레이스홀더를 사용할 수 있어요."
                 },
                 "defaultValue": "",
                 "optional": false
@@ -105,12 +113,14 @@
                 "label": {
                     "en": "Keep relative positions",
                     "zh": "保持相对位置",
-                    "ja": "相対位置を保持"
+                    "ja": "相対位置を保持",
+                    "ko": "상대적인 위치 유지"
                 },
                 "description": {
                     "en": "Move all the other parameters to keep the distance with the edited parameter.",
                     "zh": "移动所有其他参数以保持与编辑的参数的距离。",
-                    "ja": "編集したパラメーターとの距離を保持するように、他のすべてのパラメーターを移動します。"
+                    "ja": "編集したパラメーターとの距離を保持するように、他のすべてのパラメーターを移動します。",
+                    "ko": "편집된 파라미터와의 거리 유지를 위해 다른 모든 파라미터들을 이동해요."
                 },
                 "defaultValue": false
             }

--- a/resources/common/plugins/macro/batch-edit-oto-parameter/plugin.json
+++ b/resources/common/plugins/macro/batch-edit-oto-parameter/plugin.json
@@ -96,13 +96,13 @@
                     "en": "Expression",
                     "zh": "表达式",
                     "ja": "計算式",
-                    "ko": "식"
+                    "ko": "계산식"
                 },
                 "description": {
                     "en": "Expression to calculate the new value. Parameter placeholders such as \"${Offset}\", \"${Overlap} are available in the calculation.",
                     "zh": "用于计算新值的表达式。可以在计算中使用参数占位符，例如 \"${左边界}\", \"${重叠}\"。",
                     "ja": "新しい値を計算するための式。計算式中にパラメーターのプレースホルダー（例：\"${左ブランク}\", \"${Overlap}\"）を使用できます。",
-                    "ko": "새로운 값의 계산에 쓰일 식이에요. 계산식에는 \"${오프셋}\", \"${오버랩}\" 등과 같은 플레이스홀더를 사용할 수 있어요."
+                    "ko": "새로운 값의 계산에 쓰일 계산식이에요. \"${오프셋}\", \"${오버랩}\" 등과 같은 플레이스홀더를 사용할 수 있어요."
                 },
                 "defaultValue": "",
                 "optional": false

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
@@ -255,7 +255,7 @@ fun Strings.ko(): String? = when (this) {
     PluginEntrySelectorExpressionDescription ->
         "위에 명시된 필터들을 조합하는 논리 표현식이에요. \n" +
             "사용 가능한 표기: `and`, `or`, `not`, `xor`, `(`, `)`, `#1`, `#2`, 등..."
-    EditorSubTitleMultiple -> "샘플 %2s\$의 엔트리 %1d\$개 편집 중 "
+    EditorSubTitleMultiple -> "샘플 %2\$s의 엔트리 %1\$d개 편집 중 "
     FailedToLoadSampleFileError -> "샘플 파일을 불러오지 못했습니다.\n존재하지 않는 파일이거나 지원되지 않는 형식일 수 있습니다."
     PluginRuntimeUnexpectedException ->
         "플러그인 실행 도중 예상치 못한 오류가 발생했어요.\n" +
@@ -742,6 +742,17 @@ fun Strings.ko(): String? = when (this) {
     EntryFilterSetterDialogHeaderTag -> "다음을 포함하는 태그"
     EntryFilterSetterDialogHeaderStar -> "중요"
     EntryFilterSetterDialogHeaderDone -> "완료"
+    FileNameNormalizerDialogTitle -> "vLabeler - 파일명 정규화 도우미"
+    FileNameNormalizerTitle -> "파일명 정규화 도우미"
+    FileNameNormalizerDescription ->
+        "(주로 macOS에서 쓰이는) NFD 인코딩을 (주로 Windows에서 쓰이는) NFC 인코딩으로 변환해 줘요. " +
+            "폴더를 선택해 안에 있는 모든 파일명을 재귀적으로 변환하고, 파일을 선택해 각각의 내용을 변환할 수 있습니다.\n" +
+            "샘플 파일들을 기반으로 한 프로젝트를 이미 만든 상태라면, 프로젝트 파일의 내용과 샘플 파일명 모두를 변환해 주세요."
+    FileNameNormalizerHandleFolderButton -> "폴더 선택"
+    FileNameNormalizerHandleFileContentButton -> "파일 선택"
+    FileNameNormalizerHandleFolderSuccess -> "파일 %d개를 스캔하고, %d개를 변환했어요."
+    FileNameNormalizerHandleFileSuccess -> "파일 내용을 성공적으로 변환했어요."
+    FileNameNormalizerHandleFileNoChange -> "파일 내용 변환이 필요 없어요."
     ReloadLabelDialogTitle -> "라벨 파일 새로고침"
     ReloadLabelDialogModuleNameTemplate -> "하위 프로젝트: %s"
     ReloadLabelDialogShowUnchanged -> "변경되지 않은 상태로 표시"


### PR DESCRIPTION
- Added some missing Korean strings to 3 labelers, 1 plugin, `StringsKorean.kt`.
- There were two wrong format specifiers in `StringsKorean.kt`, so fixed it.