### PR TITLE
Add click on canvas to jumpToEntry in multi-edit mode

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/model/AppConf.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/model/AppConf.kt
@@ -368,6 +368,7 @@ data class AppConf(
         val continuousLabelNames: ContinuousLabelNames = ContinuousLabelNames(),
         val postEditNext: PostEditAction = PostEditAction.DEFAULT_NEXT,
         val postEditDone: PostEditAction = PostEditAction.DEFAULT_DONE,
+        val clickToSwitchCurrentIndex: Boolean = DEFAULT_CLICK_TO_SWITCH_CURRENT_INDEX,
     ) {
 
         /**
@@ -399,6 +400,7 @@ data class AppConf(
             const val DEFAULT_SHOW_STAR = true
             const val DEFAULT_SHOW_TAG = true
             const val DEFAULT_SHOW_EXTRA = true
+            const val DEFAULT_CLICK_TO_SWITCH_CURRENT_INDEX = false
         }
     }
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesPages.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesPages.kt
@@ -730,6 +730,12 @@ object PreferencesPages {
                         select = { it.playerCursorColor },
                         update = { copy(playerCursorColor = it) },
                     )
+                    switch(
+                        title = Strings.PreferencesEditorClickToJumToEntry,
+                        defaultValue = AppConf.Editor.DEFAULT_CLICK_TO_SWITCH_CURRENT_INDEX,
+                        select = { it.clickToSwitchCurrentIndex },
+                        update = { copy(clickToSwitchCurrentIndex = it) },
+                    )
                 }
             }
     }

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerState.kt
@@ -415,6 +415,15 @@ class MarkerState(
         return null
     }
 
+    fun getEntryIndexByCursorPosition(position: Float): Int? {
+        entriesInPixel.forEachIndexed { index, entry ->
+            if (entry.getActualStart(labelerConf) <= position && entry.getActualEnd(labelerConf) >= position) {
+                return index
+            }
+        }
+        return null
+    }
+
     fun isValidCutPosition(position: Float) = entriesInPixel.any { it.isValidCutPosition(position) }
 
     fun isValidPlaybackPosition(position: Float) = position < entryConverter.convertToPixel(sampleLengthMillis)

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
@@ -397,6 +397,7 @@ enum class Strings {
     PreferencesEditor,
     PreferencesEditorDescription,
     PreferencesEditorPlayerCursorColor,
+    PreferencesEditorClickToJumToEntry,
     PreferencesEditorLockedDrag,
     PreferencesEditorLockedDragDescription,
     PreferencesEditorLockedDragUseLabeler,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
@@ -428,6 +428,7 @@ fun Strings.zhHans(): String? = when (this) {
     PreferencesEditor -> "编辑器"
     PreferencesEditorDescription -> "编辑编辑器的外观与行为。"
     PreferencesEditorPlayerCursorColor -> "音频播放光标颜色"
+    PreferencesEditorClickToJumToEntry -> "在多条目编辑模式下，单击画布上的条目即可跳转到该条目"
     PreferencesEditorLockedDrag -> "锁定拖动"
     PreferencesEditorLockedDragDescription ->
         "选择启用锁定拖动的条件。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
@@ -474,6 +474,8 @@ fun Strings.en(): String = when (this) {
     PreferencesEditor -> "Editor"
     PreferencesEditorDescription -> "Customize the editor's appearance and behavior."
     PreferencesEditorPlayerCursorColor -> "Player cursor color"
+    PreferencesEditorClickToJumToEntry ->
+        "Jump to the cursor position entry by clicking it on canvas in multiple entry edit mode"
     PreferencesEditorLockedDrag -> "Fixed-drag"
     PreferencesEditorLockedDragDescription ->
         "Select a condition to enable fixed-drag while you move " +


### PR DESCRIPTION
add click to jumpToEntry in multiple entry edit mode (default is off, and can be turn on in `Preference - Editor`) along with chinese translation
After testing, I found a bug, if your mouse did not move, it would not "jump", I don't know how to fix that, but I would consider it doesn't really affect the actual experience.