### PR TITLE
Add "batch-edit-oto-preutter" plugin

### DIFF
--- a/resources/common/plugins/macro/batch-edit-oto-parameter/batch-edit-oto-parameter.js
+++ b/resources/common/plugins/macro/batch-edit-oto-parameter/batch-edit-oto-parameter.js
@@ -5,7 +5,7 @@ let keepDistance = params["keepDistance"]
 let nameTexts = [
     ["offset", ["Offset", "左边界", "左ブランク"]],
     ["fixed", ["Fixed", "固定", "固定範囲"]],
-    ["overlap", ["Overlap", "重叠"]],
+    ["overlap", ["Overlap", "重叠", "オーバーラップ"]],
     ["preutterance", ["Preutterance", "先行发声", "先行発声"]],
     ["cutoff", ["Cutoff", "右边界", "右ブランク"]],
 ]

--- a/resources/common/plugins/macro/batch-edit-oto-parameter/plugin.json
+++ b/resources/common/plugins/macro/batch-edit-oto-parameter/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "batch-edit-oto-parameter",
-    "version": 9,
+    "version": 10,
     "type": "macro",
     "displayedName": {
         "en": "Batch edit oto parameter",

--- a/resources/common/plugins/macro/batch-edit-oto-preutter/batch-edit-oto-preutter.js
+++ b/resources/common/plugins/macro/batch-edit-oto-preutter/batch-edit-oto-preutter.js
@@ -1,0 +1,65 @@
+let selectedEntryIndexes = params["selector"]
+let preutterance = params["preutterance"]
+let overlap = params["overlap"]
+
+let nameTexts = [
+    ["offset", ["Offset", "左边界", "左ブランク"]],
+    ["fixed", ["Fixed", "固定", "固定範囲"]],
+    ["overlap", ["Overlap", "重叠", "オーバーラップ"]],
+    ["preutterance", ["Preutterance", "先行发声", "先行発声"]],
+    ["cutoff", ["Cutoff", "右边界", "右ブランク"]],
+]
+
+if (debug) {
+    console.log(`Input entries: ${entries.length}`)
+    console.log(`Selected entries: ${selectedEntryIndexes.length}`)
+}
+
+for (let index of selectedEntryIndexes) {
+    let entry = entries[index]
+    let edited = Object.assign({}, entry)
+
+    function tryParseInt(str) {
+        const num = parseInt(str, 10);
+        if (isNaN(num)) {
+            return { success: false, value: null };
+        }
+        return { success: true, value: num };
+    }
+
+    const result = tryParseInt(preutterance);
+    if (result.success) {
+        let diff = 0;
+        if (preutterance.StartsWith("+") || preutterance.StartsWith("-")) {
+            diff = result.value;
+        } else {
+            diff = result.value - entry.points[1];
+        }
+        // offset
+        edited.points[3] = Math.max(entry.points[3] - diff, 0);
+        // fixed
+        edited.points[0] = entry.points[0] + diff;
+        // preutterance
+        edited.points[1] = entry.points[1] + diff;
+        // overlap
+        edited.points[2] = entry.points[2] + diff;
+        // cutoff
+        if (newValue < 0) {
+            edited.end = entry.end - diff;
+        } else {
+            edited.end = Math.max(entry.end - diff, 0);
+        }
+    }
+
+    result = tryParseInt(overlap);
+    if (result.success && result.value > 0) {
+        edited.points[2] = edited.points[1] / result.value;
+    }
+
+    edited.start = Math.min(...edited.points, edited.start)
+
+    if (debug) {
+        console.log(`Edited: ${JSON.stringify(edited)}`)
+    }
+    entries[index] = edited
+}

--- a/resources/common/plugins/macro/batch-edit-oto-preutter/batch-edit-oto-preutter.js
+++ b/resources/common/plugins/macro/batch-edit-oto-preutter/batch-edit-oto-preutter.js
@@ -7,36 +7,44 @@ if (debug) {
     console.log(`Selected entries: ${selectedEntryIndexes.length}`)
 }
 
+function tryParseInt(str) {
+    if (str === null || str === undefined || str === "") {
+        return { success: false, value: null };
+    }
+    const num = parseInt(str, 10);
+    if (isNaN(num)) {
+        error({
+            en: `Non-numeric characters are entered in the preutterance or overlap`,
+            ja: `先行発声またはオーバーラップに数字以外が入力されています`
+        })
+    }
+    return { success: true, value: num };
+}
+let resultPre = tryParseInt(preutterance);
+let resultOvl = tryParseInt(overlap);
+
 for (let index of selectedEntryIndexes) {
     let entry = entries[index]
     let edited = Object.assign({}, entry)
     let offset = entry.points[3]
     let preutter = entry.points[1] - offset
 
-    function tryParseInt(str) {
-        const num = parseInt(str, 10);
-        if (isNaN(num)) {
-            return { success: false, value: null };
-        }
-        return { success: true, value: num };
-    }
-
-    let result = tryParseInt(preutterance);
-    if (result.success) {
+    if (resultPre.success) {
         let diff = 0;
         if (preutterance.startsWith("+") || preutterance.startsWith("-")) {
-            diff = result.value;
+            diff = resultPre.value;
         } else {
-            diff = result.value - preutter;
+            diff = resultPre.value - preutter;
         }
-        console.log(`diff: ${diff}`)
+        if (debug) {
+            console.log(`diff: ${diff}`)
+        }
         edited.points[3] = Math.max(entry.points[3] - diff, 0);
     }
 
-    result = tryParseInt(overlap);
-    if (result.success && result.value > 0) {
+    if (resultOvl.success && resultOvl.value > 0) {
         preutter = entry.points[1] - edited.points[3];
-        edited.points[2] = edited.points[3] + (preutter / result.value);
+        edited.points[2] = edited.points[3] + (preutter / resultOvl.value);
     }
 
     edited.start = Math.min(...edited.points, edited.start)

--- a/resources/common/plugins/macro/batch-edit-oto-preutter/batch-edit-oto-preutter.js
+++ b/resources/common/plugins/macro/batch-edit-oto-preutter/batch-edit-oto-preutter.js
@@ -2,14 +2,6 @@ let selectedEntryIndexes = params["selector"]
 let preutterance = params["preutterance"]
 let overlap = params["overlap"]
 
-let nameTexts = [
-    ["offset", ["Offset", "左边界", "左ブランク"]],
-    ["fixed", ["Fixed", "固定", "固定範囲"]],
-    ["overlap", ["Overlap", "重叠", "オーバーラップ"]],
-    ["preutterance", ["Preutterance", "先行发声", "先行発声"]],
-    ["cutoff", ["Cutoff", "右边界", "右ブランク"]],
-]
-
 if (debug) {
     console.log(`Input entries: ${entries.length}`)
     console.log(`Selected entries: ${selectedEntryIndexes.length}`)
@@ -18,6 +10,8 @@ if (debug) {
 for (let index of selectedEntryIndexes) {
     let entry = entries[index]
     let edited = Object.assign({}, entry)
+    let offset = entry.points[3]
+    let preutter = entry.points[1] - offset
 
     function tryParseInt(str) {
         const num = parseInt(str, 10);
@@ -27,33 +21,22 @@ for (let index of selectedEntryIndexes) {
         return { success: true, value: num };
     }
 
-    const result = tryParseInt(preutterance);
+    let result = tryParseInt(preutterance);
     if (result.success) {
         let diff = 0;
-        if (preutterance.StartsWith("+") || preutterance.StartsWith("-")) {
+        if (preutterance.startsWith("+") || preutterance.startsWith("-")) {
             diff = result.value;
         } else {
-            diff = result.value - entry.points[1];
+            diff = result.value - preutter;
         }
-        // offset
+        console.log(`diff: ${diff}`)
         edited.points[3] = Math.max(entry.points[3] - diff, 0);
-        // fixed
-        edited.points[0] = entry.points[0] + diff;
-        // preutterance
-        edited.points[1] = entry.points[1] + diff;
-        // overlap
-        edited.points[2] = entry.points[2] + diff;
-        // cutoff
-        if (newValue < 0) {
-            edited.end = entry.end - diff;
-        } else {
-            edited.end = Math.max(entry.end - diff, 0);
-        }
     }
 
     result = tryParseInt(overlap);
     if (result.success && result.value > 0) {
-        edited.points[2] = edited.points[1] / result.value;
+        preutter = entry.points[1] - edited.points[3];
+        edited.points[2] = edited.points[3] + (preutter / result.value);
     }
 
     edited.start = Math.min(...edited.points, edited.start)

--- a/resources/common/plugins/macro/batch-edit-oto-preutter/plugin.json
+++ b/resources/common/plugins/macro/batch-edit-oto-preutter/plugin.json
@@ -6,8 +6,8 @@
         "en": "Batch edit preutterance and overlap",
         "ja": "先行発声とオーバーラップを一括編集"
     },
-    "author": "maiko",
-    "email": "https://maiko3tattun.wixsite.com/mysite",
+    "author": "Maiko",
+    "email": "maikotattun@yahoo.co.jp",
     "description": {
         "en": "Edit the preutterance and overlap in UTAU oto.ini at once.",
         "ja": "UTAU oto.ini の先行発声とオーバーラップを一括編集します。"

--- a/resources/common/plugins/macro/batch-edit-oto-preutter/plugin.json
+++ b/resources/common/plugins/macro/batch-edit-oto-preutter/plugin.json
@@ -34,9 +34,10 @@
                 "defaultValue": {
                     "filters": [
                         {
-                            "field": "name",
-                            "operator": "Regex",
-                            "value": "[aiueonN]"
+                            "type": "text",
+                            "subject": "name",
+                            "matchType": "Regex",
+                            "matcherText": "[aiueonN].+"
                         }
                     ]
                 }
@@ -50,7 +51,7 @@
                 },
                 "description": {
                     "en": "Entering only numbers results in a fixed value. If you put \"+\" or \"-\" at the beginning, it will be calculated. If left blank, the preutterance will not be changed.",
-                    "ja": "数字だけを入力すると固定値になります。先頭に\"+\", \"-\"を付けると計算されます。空欄の場合、先行発声を変更しません。"
+                    "ja": "数字だけを入力すると固定値になります。先頭に半角で \"+\", \"-\" を付けると計算されます。空欄の場合、先行発声を変更しません。"
                 },
                 "defaultValue": "",
                 "optional": true
@@ -64,7 +65,7 @@
                 },
                 "description": {
                     "en": "Adjust the overlap based on the preutterance. \"3\" will set the overlap to 1/3 of the preutterance. If left blank, the overlap is not changed.",
-                    "ja": "先行発声を基準にオーバーラップを調整します。\"3\"と入力すれば先行発声の1/3になります。空欄の場合、オーバーラップを変更しません。"
+                    "ja": "先行発声を基準にオーバーラップを調整します。\"3\" と入力すれば先行発声の1/3になります。空欄の場合、オーバーラップを変更しません。"
                 },
                 "defaultValue": "3",
                 "optional": true

--- a/resources/common/plugins/macro/batch-edit-oto-preutter/plugin.json
+++ b/resources/common/plugins/macro/batch-edit-oto-preutter/plugin.json
@@ -1,0 +1,77 @@
+{
+    "name": "batch-edit-oto-preutter",
+    "version": 1,
+    "type": "macro",
+    "displayedName": {
+        "en": "Batch edit preutterance and overlap",
+        "ja": "先行発声とオーバーラップを一括編集"
+    },
+    "author": "maiko",
+    "email": "https://maiko3tattun.wixsite.com/mysite",
+    "description": {
+        "en": "Edit the preutterance and overlap in UTAU oto.ini at once.",
+        "ja": "UTAU oto.ini の先行発声とオーバーラップを一括編集します。"
+    },
+    "website": "https://github.com/sdercolin/vlabeler/tree/main/resources/common/plugins/macro/batch-edit-oto-preutter",
+    "supportedLabelFileExtension": "ini",
+    "parameters": {
+        "list": [
+            {
+                "type": "entrySelector",
+                "name": "selector",
+                "label": {
+                    "en": "Entry filters",
+                    "zh": "条目筛选器",
+                    "ja": "エントリフィルター",
+                    "ko": "엔트리 필터"
+                },
+                "description": {
+                    "en": "Add filters to select the entries to edit. Leave blank to edit all entries.",
+                    "zh": "添加筛选器以选择要编辑的条目。留空以编辑所有条目。",
+                    "ja": "編集するエントリを選択するフィルターを追加してください。空にしておくことで、すべてのエントリを編集できます。",
+                    "ko": "편집할 엔트리들의 선택에 사용할 필터를 추가해 주세요. 모든 엔트리를 선택하려면 이 칸을 비워 두세요."
+                },
+                "defaultValue": {
+                    "filters": [
+                        {
+                            "field": "name",
+                            "operator": "Regex",
+                            "value": "[aiueonN]"
+                        }
+                    ]
+                }
+            },
+            {
+                "type": "string",
+                "name": "preutterance",
+                "label": {
+                    "en": "New preutterance value",
+                    "ja": "新しい先行発声"
+                },
+                "description": {
+                    "en": "Entering only numbers results in a fixed value. If you put \"+\" or \"-\" at the beginning, it will be calculated. If left blank, the preutterance will not be changed.",
+                    "ja": "数字だけを入力すると固定値になります。先頭に\"+\", \"-\"を付けると計算されます。空欄の場合、先行発声を変更しません。"
+                },
+                "defaultValue": "",
+                "optional": true
+            },
+            {
+                "type": "string",
+                "name": "overlap",
+                "label": {
+                    "en": "Overlap",
+                    "ja": "オーバーラップ"
+                },
+                "description": {
+                    "en": "Adjust the overlap based on the preutterance. \"3\" will set the overlap to 1/3 of the preutterance. If left blank, the overlap is not changed.",
+                    "ja": "先行発声を基準にオーバーラップを調整します。\"3\"と入力すれば先行発声の1/3になります。空欄の場合、オーバーラップを変更しません。"
+                },
+                "defaultValue": "3",
+                "optional": true
+            }
+        ]
+    },
+    "scriptFiles": [
+        "batch-edit-oto-preutter.js"
+    ]
+}


### PR DESCRIPTION
## New Feature:
Batch edit preutterance and overlap
<img width="928" height="682" alt="image" src="https://github.com/user-attachments/assets/d4aec077-1a8d-45b5-b232-58d29c73e01b" />

<img width="712" height="653" alt="image" src="https://github.com/user-attachments/assets/1496337f-cca7-4c4e-b331-1b3c4a66cd4f" />
<img width="817" height="803" alt="image" src="https://github.com/user-attachments/assets/51096d88-2ed7-4594-a143-5a80482a5c12" />
