### PR TITLE
窗口标题显示完整文件路径

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/Main.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/Main.kt
@@ -109,7 +109,7 @@ fun main(vararg args: String) = application {
         }
     }
 
-    val windowTitle = string(Strings.AppName) + appState?.project?.projectName?.let { " - $it" }.orEmpty()
+    val windowTitle = string(Strings.AppName) + appState?.project?.projectFile?.absolutePath?.let { " - $it" }.orEmpty()
 
     CompositionLocalProvider(UseCustomFileDialog.provides(appConf.value.misc.useCustomFileDialog)) {
         Window(


### PR DESCRIPTION
以前vlabeler窗口标题只显示文件名，不包括文件路径。如果使用OpenUtau自动调用vlabeler编辑音源，则创建的lbp文件名总是_vlabeler.lbp。窗口标题只显示一个_vlabeler.lbp不知道编辑的是哪个音源