### PR TITLE
Fix export label file errors being silently swallowed

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/Project.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/Project.kt
@@ -274,33 +274,29 @@ suspend fun ProjectStore.exportProjectModule(
     val inEntryScope = project.labelerConf.writer.scope == LabelerConf.Scope.Entry
     val outputModuleNames = mutableListOf<String>()
     val module = project.modules[moduleIndex]
-    runCatching {
-        if (outputFile.parentFile.exists().not()) {
-            outputFile.parentFile.mkdirs()
-        }
-        val outputText = if (inEntryScope) {
-            outputModuleNames.add(module.name)
-            project.singleModuleToRawLabels(moduleIndex)
-        } else {
-            val relatedModules = project.modules.withIndex().filter {
-                it.value == module || it.value.isParallelTo(module)
-            }
-            outputModuleNames.addAll(relatedModules.map { it.value.name })
-            project.modulesToRawLabels(relatedModules.map { it.index })
-        }
-
-        val charset = project.encoding.let { Charset.forName(it) } ?: Charsets.UTF_8
-        withExporting {
-            outputFile.writeText(outputText, charset)
-            outputFile
-        }
-        Log.debug(
-            "Project module ${outputModuleNames.joinToString { "\"$it\"" }} " +
-                "exported to ${outputFile.absolutePath}",
-        )
-    }.getOrElse {
-        Log.error(it)
+    if (outputFile.parentFile.exists().not()) {
+        outputFile.parentFile.mkdirs()
     }
+    val outputText = if (inEntryScope) {
+        outputModuleNames.add(module.name)
+        project.singleModuleToRawLabels(moduleIndex)
+    } else {
+        val relatedModules = project.modules.withIndex().filter {
+            it.value == module || it.value.isParallelTo(module)
+        }
+        outputModuleNames.addAll(relatedModules.map { it.value.name })
+        project.modulesToRawLabels(relatedModules.map { it.index })
+    }
+
+    val charset = project.encoding.let { Charset.forName(it) } ?: Charsets.UTF_8
+    withExporting {
+        outputFile.writeText(outputText, charset)
+        outputFile
+    }
+    Log.debug(
+        "Project module ${outputModuleNames.joinToString { "\"$it\"" }} " +
+            "exported to ${outputFile.absolutePath}",
+    )
 }
 
 private var saveFileJob: Job? = null
@@ -330,7 +326,11 @@ suspend fun ProjectStore.saveProjectFile(
             Log.debug("Project saved to ${project.projectFile}")
 
             if (allowAutoExport && project.autoExport) {
-                exportProject(project)
+                runCatching {
+                    exportProject(project)
+                }.onFailure {
+                    Log.error(it)
+                }
             }
         }
         saveFileJob?.join()

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/ProjectStore.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/ProjectStore.kt
@@ -652,20 +652,32 @@ class ProjectStoreImpl(
 
     override fun overwriteExportCurrentModule() {
         scope.launch(Dispatchers.IO) {
-            progressState.showProgress()
-            val project = requireProject()
-            val targetFile = requireNotNull(project.currentModule.getRawFile(project))
-            exportProjectModule(project, project.currentModuleIndex, targetFile)
-            progressState.hideProgress()
+            try {
+                progressState.showProgress()
+                val project = requireProject()
+                val targetFile = requireNotNull(project.currentModule.getRawFile(project))
+                exportProjectModule(project, project.currentModuleIndex, targetFile)
+            } catch (e: Exception) {
+                Log.error(e)
+                errorState.showError(e)
+            } finally {
+                progressState.hideProgress()
+            }
         }
     }
 
     override fun overwriteExportAllModules() {
         scope.launch(Dispatchers.IO) {
-            progressState.showProgress()
-            val project = requireProject()
-            exportProject(project)
-            progressState.hideProgress()
+            try {
+                progressState.showProgress()
+                val project = requireProject()
+                exportProject(project)
+            } catch (e: Exception) {
+                Log.error(e)
+                errorState.showError(e)
+            } finally {
+                progressState.hideProgress()
+            }
         }
     }
 
@@ -813,10 +825,13 @@ class ProjectStoreImpl(
 
     override suspend fun withExporting(onSuccess: suspend () -> File) {
         isExporting = true
-        val file = onSuccess()
-        val hash = calculateMD5(file)
-        cachedFileHashMap[file.absolutePath] = hash
-        isExporting = false
+        try {
+            val file = onSuccess()
+            val hash = calculateMD5(file)
+            cachedFileHashMap[file.absolutePath] = hash
+        } finally {
+            isExporting = false
+        }
     }
 
     override suspend fun terminalAutoReloadLabel() {

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/StandaloneDialogs.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/StandaloneDialogs.kt
@@ -95,13 +95,19 @@ fun StandaloneDialogs(
                 appState.closeExportDialog()
                 if (parent != null && name != null) {
                     mainScope.launch(Dispatchers.IO) {
-                        appState.showProgress()
-                        appState.exportProjectModule(
-                            appState.requireProject(),
-                            project.currentModuleIndex,
-                            File(parent, name),
-                        )
-                        appState.hideProgress()
+                        try {
+                            appState.showProgress()
+                            appState.exportProjectModule(
+                                appState.requireProject(),
+                                project.currentModuleIndex,
+                                File(parent, name),
+                            )
+                        } catch (e: Exception) {
+                            Log.error(e)
+                            appState.showError(e)
+                        } finally {
+                            appState.hideProgress()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fix `withExporting` to reset `isExporting` flag in a `finally` block, preventing permanent breakage of file change detection after a failed export
- Remove silent `runCatching` in `exportProjectModule` so callers can handle and display errors to the user
- Add `try/catch/finally` in overwrite export and dialog export paths to show error dialogs and ensure the progress indicator is always hidden
- Keep auto-export errors silently logged to avoid blocking project save

## Test plan
- [ ] Open a project with a raw label file defined, use "Export Label File Overwriting" and verify it works
- [ ] Trigger an export failure (e.g. to a read-only path) and verify an error dialog is shown instead of silent failure
- [ ] Verify the progress indicator disappears after both successful and failed exports
- [ ] Verify auto-export on save still works and does not crash on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)