### PR TITLE
Fix crash when rendering waveform

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/repository/ChartRepository.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/repository/ChartRepository.kt
@@ -15,9 +15,9 @@ import com.sdercolin.vlabeler.util.parseJson
 import com.sdercolin.vlabeler.util.stringifyJson
 import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
-import org.jetbrains.skiko.toBufferedImage
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image as SkiaImage
 import java.io.File
-import javax.imageio.ImageIO
 
 /**
  * Repository for charts.
@@ -158,10 +158,11 @@ object ChartRepository {
         if (file.parentFile.exists().not()) {
             file.parentFile.mkdirs()
         }
-        val outputStream = file.outputStream()
-        ImageIO.write(image.asSkiaBitmap().toBufferedImage(), "png", outputStream)
-        outputStream.flush()
-        outputStream.close()
+        val bitmap = image.asSkiaBitmap()
+        if (bitmap.peekPixels() == null) return
+        val skiaImage = SkiaImage.makeFromBitmap(bitmap)
+        val pngBytes = skiaImage.encodeToData(EncodedImageFormat.PNG)?.bytes ?: return
+        file.writeBytes(pngBytes)
         cacheMap[cacheKey] = file.relativeTo(cacheDirectory).path.replace(File.separatorChar, '/')
         cacheDirectory.mkdirs()
         cacheMapFile.writeText(cacheMap.stringifyJson())


### PR DESCRIPTION
Replace AWT-based image saving with Skia's native PNG encoder to fix a crash caused by a signed/unsigned byte overflow in Skiko's `toBufferedImage()`.

## Root cause

The crash originates in Skiko's internal `DirectDataBuffer` class (`Convertors.jvm.kt`), used by `Bitmap.toBufferedImage()`:

```kotlin
private class DirectDataBuffer(val backing: ByteBuffer) : DataBuffer(TYPE_BYTE, backing.limit()) {
    override fun getElem(bank: Int, index: Int): Int {
        return backing[index].toInt()   // BUG: sign-extends unsigned pixel data
    }
}
```

Skia stores pixel channel values as unsigned bytes (0-255), but Java's `ByteBuffer.get()` returns a signed `Byte` (-128 to 127). When a pixel channel value is >= 128 (e.g. `0xFF` for full alpha or bright white), it wraps to a negative number. The `.toInt()` call then sign-extends it (e.g. byte `-1` becomes `Int` `-1` / `0xFFFFFFFF` instead of `255` / `0x000000FF`).

AWT's `ComponentColorModel` expects `getElem()` to return values in the range 0-255. When it receives negative values, it causes `ArrayIndexOutOfBoundsException` in internal lookup tables or corrupts the PNG encoder's buffers, crashing the application.

This crash is triggered whenever any rendered chart pixel has a channel value >= 128, which is extremely common (any color brighter than 50% gray, or any fully opaque pixel with alpha = 255).

The correct fix within Skiko would be:

```kotlin
return backing[index].toInt() and 0xFF  // mask to unsigned
```

## Fix

Since the bug is in Skiko itself, this commit sidesteps it by replacing the AWT pipeline (`Bitmap.toBufferedImage()` + `ImageIO.write()`) with Skia's native PNG encoder (`Image.encodeToData(EncodedImageFormat.PNG)`). The pixel data is encoded entirely in native C++ code where bytes are unsigned, so the signed/unsigned mismatch never occurs.

Additionally, a `bitmap.peekPixels() == null` guard is added to handle the case where a bitmap has no valid pixel data (e.g. if it has been disposed or not yet rendered), which would have caused a `NullPointerException` via `peekPixels()!!.addr` in the old code.
