### PR TITLE
Fix cascading entry collapse when dragging in single edit mode of continuous labelers

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/EditorState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/EditorState.kt
@@ -202,7 +202,13 @@ class EditorState(
         val editionGroups = editions.groupContinuouslyBy { index }
         editionGroups.forEach { group ->
             group.forEach { edition ->
-                editedEntries[edition.index] = edition.toIndexedEntry()
+                // Editions of entries that are not loaded for editing (e.g. a synced neighbor entry in
+                // single edit mode of a continuous labeler) should not be added to the edited entry list,
+                // otherwise the marker's entry list grows during dragging and the dragged point is
+                // reinterpreted against the wrong entry.
+                if (editedEntries.containsKey(edition.index)) {
+                    editedEntries[edition.index] = edition.toIndexedEntry()
+                }
                 this.editions[edition.index] = edition
             }
             if (project.labelerConf.continuous) {


### PR DESCRIPTION
Fixes the drag regression reported in #83 (comments): in **single edit mode** of a continuous labeler (e.g. sinsy/NNSVS lab), dragging the current entry's start/end border makes all following entries collapse onto the dragged border position (video in the issue).

## Root cause

1. In single edit mode, `EditorState.editedEntries` contains only the current entry.
2. While dragging a border, `MarkerState.editEntryIfNeeded` (Marker.kt) appends a sync-edition for the neighbor entry of a continuous labeler (added in ca8dc6f0 so post-edit actions apply to the neighbor).
3. `EditorState.updateEntries` inserted **every** edition into `editedEntries`, so the neighbor entry silently joined the marker's displayed entry list mid-drag.
4. `MarkerState` is rebuilt with 2 entries, but the persisted cursor drag state still holds `pointIndex = END_POINT_INDEX`, which now resolves to the *neighbor's* end. The next mouse-move event drags the neighbor's end to the cursor position (at the current entry's end), collapsing it to zero length; its own neighbor then gets appended in turn, cascading down the whole sample. Symmetric for the start border.

## Fix

In `EditorState.updateEntries`, only write an edition into `editedEntries` if that entry is already loaded for editing; editions of unloaded entries are still recorded in the `editions` map, so submission (`ProjectStore.editEntries` → `Module.updateEntries` neighbor sync) and post-edit actions behave exactly as before.

Multiple edit mode is unaffected (neighbors within the sample are always loaded there).

## Testing

- `./gradlew jvmTest ktlintCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)