### PR TITLE
Add entry name presets applied in entry name input dialogs

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/model/AppConf.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/model/AppConf.kt
@@ -349,6 +349,7 @@ data class AppConf(
      * @param showTag When true, the tag or "New tag" button is shown in the editor and entry lists.
      * @param showExtra When true, the extra editor button/icon is shown in the editor and entry lists.
      * @param continuousLabelNames Appearance of the label names in the editor for continuous labelers.
+     * @param entryNamePresets Preset entry names that can be quickly applied in entry name input dialogs.
      */
     @Serializable
     @Immutable
@@ -379,6 +380,7 @@ data class AppConf(
             color = DEFAULT_CURSOR_POSITION_ENTRY_BORDER_HIGHLIGHT_COLOR,
             width = DEFAULT_CURSOR_POSITION_ENTRY_BORDER_HIGHLIGHT_WIDTH,
         ),
+        val entryNamePresets: List<String> = listOf(),
     ) {
 
         /**

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/AppDialogState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/AppDialogState.kt
@@ -353,6 +353,7 @@ class AppDialogStateImpl(
                 invalidOptions = invalidOptions,
                 showSnackbar = { state.mainScope.launch { snackbarState.showSnackbar(it) } },
                 purpose = purpose,
+                presets = state.appConf.editor.entryNamePresets,
             ),
         )
     }

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/AppState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/AppState.kt
@@ -281,6 +281,7 @@ class AppState(
                         invalidOptions = invalidOptions,
                         showSnackbar = showSnackbar,
                         purpose = InputEntryNameDialogPurpose.CutFormer,
+                        presets = appConf.editor.entryNamePresets,
                     ),
                 )
                 (result as InputEntryNameDialogResult?)?.name ?: return@launch
@@ -299,6 +300,7 @@ class AppState(
                         invalidOptions = invalidOptions,
                         showSnackbar = showSnackbar,
                         purpose = InputEntryNameDialogPurpose.CutLatter,
+                        presets = appConf.editor.entryNamePresets,
                     ),
                 )
                 (result as InputEntryNameDialogResult?)?.name ?: return@launch

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/EditEntryNameDialog.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/EditEntryNameDialog.kt
@@ -1,12 +1,18 @@
 package com.sdercolin.vlabeler.ui.dialog
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
@@ -21,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.TextRange
@@ -30,6 +37,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.sdercolin.vlabeler.ui.common.ConfirmButton
 import com.sdercolin.vlabeler.ui.string.*
+import com.sdercolin.vlabeler.ui.theme.White20
 import com.sdercolin.vlabeler.util.removeControlCharacters
 
 data class InputEntryNameDialogArgs(
@@ -38,6 +46,7 @@ data class InputEntryNameDialogArgs(
     val invalidOptions: List<String>,
     val showSnackbar: (String) -> Unit,
     val purpose: InputEntryNameDialogPurpose,
+    val presets: List<String> = listOf(),
 ) : EmbeddedDialogArgs
 
 enum class InputEntryNameDialogPurpose(val stringKey: Strings) {
@@ -53,6 +62,7 @@ data class InputEntryNameDialogResult(
     val purpose: InputEntryNameDialogPurpose,
 ) : EmbeddedDialogResult<InputEntryNameDialogArgs>
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun InputEntryNameDialog(
     args: InputEntryNameDialogArgs,
@@ -101,6 +111,29 @@ fun InputEntryNameDialog(
                 onDone = { trySubmit() },
             ),
         )
+        if (args.presets.isNotEmpty()) {
+            Spacer(Modifier.height(15.dp))
+            FlowRow(
+                modifier = Modifier.widthIn(max = 400.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                args.presets.forEach { preset ->
+                    Text(
+                        text = preset,
+                        modifier = Modifier
+                            .background(color = White20, shape = RoundedCornerShape(12.dp))
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable {
+                                input = TextFieldValue(preset, selection = TextRange(0, preset.length))
+                                focusRequester.requestFocus()
+                            }
+                            .padding(horizontal = 10.dp, vertical = 5.dp),
+                        style = MaterialTheme.typography.caption,
+                    )
+                }
+            }
+        }
         Spacer(Modifier.height(25.dp))
         Row(modifier = Modifier.align(Alignment.End), horizontalArrangement = Arrangement.End) {
             TextButton(

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesEditor.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesEditor.kt
@@ -36,6 +36,10 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Settings
@@ -58,6 +62,7 @@ import com.sdercolin.vlabeler.ui.AppState
 import com.sdercolin.vlabeler.ui.common.ColorHexInputBox
 import com.sdercolin.vlabeler.ui.common.ConfirmButton
 import com.sdercolin.vlabeler.ui.common.FloatInputBox
+import com.sdercolin.vlabeler.ui.common.InputBox
 import com.sdercolin.vlabeler.ui.common.IntegerInputBox
 import com.sdercolin.vlabeler.ui.common.PartialClickableText
 import com.sdercolin.vlabeler.ui.common.SearchBar
@@ -340,6 +345,7 @@ private fun Item(item: PreferencesItem, state: PreferencesEditorState) {
         is PreferencesItem.IntegerInput -> IntegerInputItem(item, state)
         is PreferencesItem.FloatInput -> FloatInputItem(item, state)
         is PreferencesItem.StringInput -> TextInputItem(item, state)
+        is PreferencesItem.StringListInput -> StringListInputItem(item, state)
         is PreferencesItem.ColorStringInput -> ColorStringInputItem(item, state)
         is PreferencesItem.Selection<*> -> SelectionItem(item, state)
         is PreferencesItem.Keymap<*> -> Keymap(item, state)
@@ -407,6 +413,74 @@ private fun TextInputItem(item: PreferencesItem.StringInput, state: PreferencesE
         onValueChange = { state.update(item, it) },
         getInvalidPrompt = { item.getInvalidPrompt(state.conf, it) },
     )
+}
+
+@Composable
+private fun StringListInputItem(item: PreferencesItem.StringListInput, state: PreferencesEditorState) {
+    val values = item.select(state.conf)
+    val enabled = item.enabled(state.conf)
+    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        values.forEachIndexed { index, value ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = value,
+                    modifier = Modifier.widthIn(min = 150.dp),
+                    style = MaterialTheme.typography.body2,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.width(10.dp))
+                IconButton(
+                    enabled = enabled && index > 0,
+                    onClick = {
+                        val list = values.toMutableList()
+                        list.add(index - 1, list.removeAt(index))
+                        state.update(item, list)
+                    },
+                    modifier = Modifier.size(30.dp),
+                ) {
+                    Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+                IconButton(
+                    enabled = enabled && index < values.lastIndex,
+                    onClick = {
+                        val list = values.toMutableList()
+                        list.add(index + 1, list.removeAt(index))
+                        state.update(item, list)
+                    },
+                    modifier = Modifier.size(30.dp),
+                ) {
+                    Icon(Icons.Default.ArrowDownward, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+                IconButton(
+                    enabled = enabled,
+                    onClick = { state.update(item, values.filterIndexed { i, _ -> i != index }) },
+                    modifier = Modifier.size(30.dp),
+                ) {
+                    Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            var newValue by remember { mutableStateOf("") }
+            InputBox(
+                value = newValue,
+                onValueChange = { newValue = it },
+                enabled = enabled,
+            )
+            Spacer(Modifier.width(10.dp))
+            IconButton(
+                enabled = enabled && newValue.isNotBlank() && newValue.trim() !in values,
+                onClick = {
+                    state.update(item, values + newValue.trim())
+                    newValue = ""
+                },
+                modifier = Modifier.size(30.dp),
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+            }
+        }
+    }
 }
 
 @Composable

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesEditor.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesEditor.kt
@@ -2,6 +2,7 @@ package com.sdercolin.vlabeler.ui.dialog.preferences
 
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,17 +20,23 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
@@ -44,6 +51,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -52,7 +60,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -62,7 +72,6 @@ import com.sdercolin.vlabeler.ui.AppState
 import com.sdercolin.vlabeler.ui.common.ColorHexInputBox
 import com.sdercolin.vlabeler.ui.common.ConfirmButton
 import com.sdercolin.vlabeler.ui.common.FloatInputBox
-import com.sdercolin.vlabeler.ui.common.InputBox
 import com.sdercolin.vlabeler.ui.common.IntegerInputBox
 import com.sdercolin.vlabeler.ui.common.PartialClickableText
 import com.sdercolin.vlabeler.ui.common.SearchBar
@@ -76,6 +85,7 @@ import com.sdercolin.vlabeler.ui.dialog.OpenFileDialog
 import com.sdercolin.vlabeler.ui.dialog.SaveFileDialog
 import com.sdercolin.vlabeler.ui.string.*
 import com.sdercolin.vlabeler.ui.theme.Black50
+import com.sdercolin.vlabeler.ui.theme.White20
 import com.sdercolin.vlabeler.ui.theme.getSwitchColors
 import com.sdercolin.vlabeler.util.argbHexString
 import com.sdercolin.vlabeler.util.rgbHexString
@@ -419,66 +429,109 @@ private fun TextInputItem(item: PreferencesItem.StringInput, state: PreferencesE
 private fun StringListInputItem(item: PreferencesItem.StringListInput, state: PreferencesEditorState) {
     val values = item.select(state.conf)
     val enabled = item.enabled(state.conf)
-    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
-        values.forEachIndexed { index, value ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = value,
-                    modifier = Modifier.widthIn(min = 150.dp),
-                    style = MaterialTheme.typography.body2,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(Modifier.width(10.dp))
-                IconButton(
-                    enabled = enabled && index > 0,
-                    onClick = {
-                        val list = values.toMutableList()
-                        list.add(index - 1, list.removeAt(index))
-                        state.update(item, list)
-                    },
-                    modifier = Modifier.size(30.dp),
+    val scrollState = rememberLazyListState()
+    Column(
+        modifier = Modifier.fillMaxWidth().background(MaterialTheme.colors.background),
+    ) {
+        Row(Modifier.height(160.dp).fillMaxWidth()) {
+            Box(Modifier.weight(1f).fillMaxHeight()) {
+                LazyColumn(
+                    state = scrollState,
+                    modifier = Modifier.padding(vertical = 5.dp, horizontal = 15.dp),
                 ) {
-                    Icon(Icons.Default.ArrowUpward, contentDescription = null, modifier = Modifier.size(16.dp))
+                    itemsIndexed(values) { index, value ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 5.dp),
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = value,
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.body2,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            val upEnabled = enabled && index > 0
+                            Icon(
+                                modifier = Modifier.size(16.dp).clickable(enabled = upEnabled) {
+                                    val list = values.toMutableList()
+                                    list.add(index - 1, list.removeAt(index))
+                                    state.update(item, list)
+                                },
+                                imageVector = Icons.Default.ArrowUpward,
+                                contentDescription = null,
+                                tint = MaterialTheme.colors.onSurface
+                                    .runIf(upEnabled.not()) { copy(alpha = 0.2f) },
+                            )
+                            val downEnabled = enabled && index < values.lastIndex
+                            Icon(
+                                modifier = Modifier.size(16.dp).clickable(enabled = downEnabled) {
+                                    val list = values.toMutableList()
+                                    list.add(index + 1, list.removeAt(index))
+                                    state.update(item, list)
+                                },
+                                imageVector = Icons.Default.ArrowDownward,
+                                contentDescription = null,
+                                tint = MaterialTheme.colors.onSurface
+                                    .runIf(downEnabled.not()) { copy(alpha = 0.2f) },
+                            )
+                            Icon(
+                                modifier = Modifier.size(16.dp).clickable(enabled = enabled) {
+                                    state.update(item, values.filterIndexed { i, _ -> i != index })
+                                },
+                                imageVector = Icons.Default.Close,
+                                contentDescription = null,
+                                tint = MaterialTheme.colors.onSurface
+                                    .runIf(enabled.not()) { copy(alpha = 0.2f) },
+                            )
+                        }
+                    }
                 }
-                IconButton(
-                    enabled = enabled && index < values.lastIndex,
-                    onClick = {
-                        val list = values.toMutableList()
-                        list.add(index + 1, list.removeAt(index))
-                        state.update(item, list)
-                    },
-                    modifier = Modifier.size(30.dp),
-                ) {
-                    Icon(Icons.Default.ArrowDownward, contentDescription = null, modifier = Modifier.size(16.dp))
-                }
-                IconButton(
-                    enabled = enabled,
-                    onClick = { state.update(item, values.filterIndexed { i, _ -> i != index }) },
-                    modifier = Modifier.size(30.dp),
-                ) {
-                    Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(16.dp))
+                if (values.isEmpty()) {
+                    CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                        Text(
+                            text = string(Strings.PreferencesStringListEmptyPlaceholder),
+                            modifier = Modifier.align(Alignment.Center),
+                            style = MaterialTheme.typography.body2,
+                        )
+                    }
                 }
             }
+            VerticalScrollbar(rememberScrollbarAdapter(scrollState))
         }
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth().background(MaterialTheme.colors.surface).padding(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             var newValue by remember { mutableStateOf("") }
-            InputBox(
-                value = newValue,
-                onValueChange = { newValue = it },
-                enabled = enabled,
-            )
-            Spacer(Modifier.width(10.dp))
-            IconButton(
-                enabled = enabled && newValue.isNotBlank() && newValue.trim() !in values,
-                onClick = {
+            val addEnabled = enabled && newValue.isNotBlank() && newValue.trim() !in values
+            val submitNewValue = {
+                if (addEnabled) {
                     state.update(item, values + newValue.trim())
                     newValue = ""
-                },
-                modifier = Modifier.size(30.dp),
-            ) {
-                Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
             }
+            BasicTextField(
+                modifier = Modifier.width(150.dp)
+                    .background(White20, MaterialTheme.shapes.small)
+                    .padding(vertical = 4.dp, horizontal = 10.dp),
+                value = newValue,
+                onValueChange = { newValue = it },
+                singleLine = true,
+                enabled = enabled,
+                textStyle = MaterialTheme.typography.caption.copy(color = MaterialTheme.colors.onSurface),
+                cursorBrush = SolidColor(MaterialTheme.colors.onSurface),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { submitNewValue() }),
+            )
+            Icon(
+                modifier = Modifier.size(18.dp).clickable(enabled = addEnabled) { submitNewValue() },
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colors.onSurface.runIf(addEnabled.not()) { copy(alpha = 0.2f) },
+            )
         }
     }
 }

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesEditor.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesEditor.kt
@@ -246,7 +246,7 @@ private fun RowScope.Page(state: PreferencesEditorState) {
         if (page.scrollable) {
             VerticalScrollbar(
                 adapter = rememberScrollbarAdapter(scrollState),
-                modifier = Modifier.align(Alignment.CenterEnd).width(30.dp),
+                modifier = Modifier.align(Alignment.CenterEnd).width(15.dp),
             )
         }
     }
@@ -431,7 +431,7 @@ private fun StringListInputItem(item: PreferencesItem.StringListInput, state: Pr
     val enabled = item.enabled(state.conf)
     val scrollState = rememberLazyListState()
     Column(
-        modifier = Modifier.fillMaxWidth().background(MaterialTheme.colors.background),
+        modifier = Modifier.widthIn(max = 400.dp).fillMaxWidth().background(MaterialTheme.colors.background),
     ) {
         Row(Modifier.height(160.dp).fillMaxWidth()) {
             Box(Modifier.weight(1f).fillMaxHeight()) {
@@ -513,19 +513,33 @@ private fun StringListInputItem(item: PreferencesItem.StringListInput, state: Pr
                     newValue = ""
                 }
             }
-            BasicTextField(
+            Box(
                 modifier = Modifier.width(150.dp)
                     .background(White20, MaterialTheme.shapes.small)
                     .padding(vertical = 4.dp, horizontal = 10.dp),
-                value = newValue,
-                onValueChange = { newValue = it },
-                singleLine = true,
-                enabled = enabled,
-                textStyle = MaterialTheme.typography.caption.copy(color = MaterialTheme.colors.onSurface),
-                cursorBrush = SolidColor(MaterialTheme.colors.onSurface),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = { submitNewValue() }),
-            )
+            ) {
+                BasicTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = newValue,
+                    onValueChange = { newValue = it },
+                    singleLine = true,
+                    enabled = enabled,
+                    textStyle = MaterialTheme.typography.caption.copy(color = MaterialTheme.colors.onSurface),
+                    cursorBrush = SolidColor(MaterialTheme.colors.onSurface),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { submitNewValue() }),
+                )
+                if (newValue.isEmpty()) {
+                    Text(
+                        text = string(Strings.PreferencesStringListNewItemPlaceholder),
+                        style = MaterialTheme.typography.caption.copy(
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.4f),
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
             Icon(
                 modifier = Modifier.size(18.dp).clickable(enabled = addEnabled) { submitNewValue() },
                 imageVector = Icons.Default.Add,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesItem.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesItem.kt
@@ -147,6 +147,27 @@ sealed class PreferencesItem(
         validationRules,
     )
 
+    class StringListInput(
+        title: Strings,
+        description: Strings?,
+        clickableTags: List<ClickableTag>,
+        columnStyle: Boolean,
+        defaultValue: List<String>,
+        select: (AppConf) -> List<String>,
+        update: AppConf.(List<String>) -> AppConf,
+        enabled: (AppConf) -> Boolean,
+    ) : Valued<List<String>>(
+        title,
+        description,
+        clickableTags,
+        columnStyle,
+        defaultValue,
+        select,
+        update,
+        enabled,
+        validationRules = listOf(),
+    )
+
     class ColorStringInput(
         title: Strings,
         description: Strings?,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesPages.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesPages.kt
@@ -742,6 +742,14 @@ object PreferencesPages {
                         select = { it.playerCursorColor },
                         update = { copy(playerCursorColor = it) },
                     )
+                    stringList(
+                        title = Strings.PreferencesEditorEntryNamePresets,
+                        description = Strings.PreferencesEditorEntryNamePresetsDescription,
+                        columnStyle = true,
+                        defaultValue = listOf(),
+                        select = { it.entryNamePresets },
+                        update = { copy(entryNamePresets = it) },
+                    )
                 }
             }
     }
@@ -1404,6 +1412,28 @@ private class PreferencesItemContext<P>(
             update = updateWithContext(update),
             enabled = selectWithContext(enabled),
             validationRules = validationRules,
+        ),
+    )
+
+    fun stringList(
+        title: Strings,
+        description: Strings? = null,
+        clickableTags: List<ClickableTag> = listOf(),
+        columnStyle: Boolean = false,
+        defaultValue: List<String>,
+        select: (P) -> List<String>,
+        update: P.(List<String>) -> P,
+        enabled: (P) -> Boolean = { true },
+    ) = builder.item(
+        PreferencesItem.StringListInput(
+            title = title,
+            description = description,
+            clickableTags = clickableTags,
+            columnStyle = columnStyle,
+            defaultValue = defaultValue,
+            select = selectWithContext(select),
+            update = updateWithContext(update),
+            enabled = selectWithContext(enabled),
         ),
     )
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
@@ -405,6 +405,8 @@ enum class Strings {
     PreferencesEditor,
     PreferencesEditorDescription,
     PreferencesEditorPlayerCursorColor,
+    PreferencesEditorEntryNamePresets,
+    PreferencesEditorEntryNamePresetsDescription,
     PreferencesEditorLockedDrag,
     PreferencesEditorLockedDragDescription,
     PreferencesEditorLockedDragUseLabeler,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
@@ -407,6 +407,7 @@ enum class Strings {
     PreferencesEditorPlayerCursorColor,
     PreferencesEditorEntryNamePresets,
     PreferencesEditorEntryNamePresetsDescription,
+    PreferencesStringListEmptyPlaceholder,
     PreferencesEditorLockedDrag,
     PreferencesEditorLockedDragDescription,
     PreferencesEditorLockedDragUseLabeler,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/Strings.kt
@@ -408,6 +408,7 @@ enum class Strings {
     PreferencesEditorEntryNamePresets,
     PreferencesEditorEntryNamePresetsDescription,
     PreferencesStringListEmptyPlaceholder,
+    PreferencesStringListNewItemPlaceholder,
     PreferencesEditorLockedDrag,
     PreferencesEditorLockedDragDescription,
     PreferencesEditorLockedDragUseLabeler,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
@@ -441,6 +441,7 @@ fun Strings.zhHans(): String? = when (this) {
     PreferencesEditorEntryNamePresets -> "条目名称预设"
     PreferencesEditorEntryNamePresetsDescription -> "预设的条目名称，可以在输入条目名称的对话框中（例如重命名或剪切条目时）快速使用。"
     PreferencesStringListEmptyPlaceholder -> "没有项目"
+    PreferencesStringListNewItemPlaceholder -> "新的项目..."
     PreferencesEditorLockedDrag -> "锁定拖动"
     PreferencesEditorLockedDragDescription ->
         "选择启用锁定拖动的条件。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
@@ -438,6 +438,8 @@ fun Strings.zhHans(): String? = when (this) {
     PreferencesEditor -> "编辑器"
     PreferencesEditorDescription -> "编辑编辑器的外观与行为。"
     PreferencesEditorPlayerCursorColor -> "音频播放光标颜色"
+    PreferencesEditorEntryNamePresets -> "条目名称预设"
+    PreferencesEditorEntryNamePresetsDescription -> "预设的条目名称，可以在输入条目名称的对话框中（例如重命名或剪切条目时）快速使用。"
     PreferencesEditorLockedDrag -> "锁定拖动"
     PreferencesEditorLockedDragDescription ->
         "选择启用锁定拖动的条件。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsChineseSimplified.kt
@@ -440,6 +440,7 @@ fun Strings.zhHans(): String? = when (this) {
     PreferencesEditorPlayerCursorColor -> "音频播放光标颜色"
     PreferencesEditorEntryNamePresets -> "条目名称预设"
     PreferencesEditorEntryNamePresetsDescription -> "预设的条目名称，可以在输入条目名称的对话框中（例如重命名或剪切条目时）快速使用。"
+    PreferencesStringListEmptyPlaceholder -> "没有项目"
     PreferencesEditorLockedDrag -> "锁定拖动"
     PreferencesEditorLockedDragDescription ->
         "选择启用锁定拖动的条件。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
@@ -495,6 +495,7 @@ fun Strings.en(): String = when (this) {
         "Preset entry names that can be quickly applied in the dialogs where you input an entry name, e.g. when " +
             "renaming or cutting an entry."
     PreferencesStringListEmptyPlaceholder -> "No items"
+    PreferencesStringListNewItemPlaceholder -> "New item..."
     PreferencesEditorLockedDrag -> "Fixed-drag"
     PreferencesEditorLockedDragDescription ->
         "Select a condition to enable fixed-drag while you move " +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
@@ -490,6 +490,10 @@ fun Strings.en(): String = when (this) {
     PreferencesEditor -> "Editor"
     PreferencesEditorDescription -> "Customize the editor's appearance and behavior."
     PreferencesEditorPlayerCursorColor -> "Player cursor color"
+    PreferencesEditorEntryNamePresets -> "Entry name presets"
+    PreferencesEditorEntryNamePresetsDescription ->
+        "Preset entry names that can be quickly applied in the dialogs where you input an entry name, e.g. when " +
+            "renaming or cutting an entry."
     PreferencesEditorLockedDrag -> "Fixed-drag"
     PreferencesEditorLockedDragDescription ->
         "Select a condition to enable fixed-drag while you move " +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsEnglish.kt
@@ -494,6 +494,7 @@ fun Strings.en(): String = when (this) {
     PreferencesEditorEntryNamePresetsDescription ->
         "Preset entry names that can be quickly applied in the dialogs where you input an entry name, e.g. when " +
             "renaming or cutting an entry."
+    PreferencesStringListEmptyPlaceholder -> "No items"
     PreferencesEditorLockedDrag -> "Fixed-drag"
     PreferencesEditorLockedDragDescription ->
         "Select a condition to enable fixed-drag while you move " +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsJapanese.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsJapanese.kt
@@ -464,6 +464,9 @@ fun Strings.ja(): String? = when (this) {
     PreferencesEditor -> "エディタ"
     PreferencesEditorDescription -> "エディタの表示と動作をカスタマイズします。"
     PreferencesEditorPlayerCursorColor -> "再生カーソルの色"
+    PreferencesEditorEntryNamePresets -> "エントリ名のプリセット"
+    PreferencesEditorEntryNamePresetsDescription ->
+        "エントリ名を入力するダイアログ（エントリの名前変更やカット時など）で、すばやく適用できるエントリ名のプリセットです。"
     PreferencesEditorLockedDrag -> "連動ドラッグ"
     PreferencesEditorLockedDragDescription ->
         "連動ドラッグを有効にする条件を選択します。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsJapanese.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsJapanese.kt
@@ -467,6 +467,7 @@ fun Strings.ja(): String? = when (this) {
     PreferencesEditorEntryNamePresets -> "エントリ名のプリセット"
     PreferencesEditorEntryNamePresetsDescription ->
         "エントリ名を入力するダイアログ（エントリの名前変更やカット時など）で、すばやく適用できるエントリ名のプリセットです。"
+    PreferencesStringListEmptyPlaceholder -> "項目がありません"
     PreferencesEditorLockedDrag -> "連動ドラッグ"
     PreferencesEditorLockedDragDescription ->
         "連動ドラッグを有効にする条件を選択します。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsJapanese.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsJapanese.kt
@@ -468,6 +468,7 @@ fun Strings.ja(): String? = when (this) {
     PreferencesEditorEntryNamePresetsDescription ->
         "エントリ名を入力するダイアログ（エントリの名前変更やカット時など）で、すばやく適用できるエントリ名のプリセットです。"
     PreferencesStringListEmptyPlaceholder -> "項目がありません"
+    PreferencesStringListNewItemPlaceholder -> "新しい項目..."
     PreferencesEditorLockedDrag -> "連動ドラッグ"
     PreferencesEditorLockedDragDescription ->
         "連動ドラッグを有効にする条件を選択します。" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
@@ -481,6 +481,9 @@ fun Strings.ko(): String? = when (this) {
     PreferencesEditor -> "에디터"
     PreferencesEditorDescription -> "에디터의 외관과 프로그램의 동작을 커스텀합니다."
     PreferencesEditorPlayerCursorColor -> "재생 커서 색상"
+    PreferencesEditorEntryNamePresets -> "엔트리 이름 프리셋"
+    PreferencesEditorEntryNamePresetsDescription ->
+        "엔트리 이름을 입력하는 대화창(엔트리 이름 변경, 자르기 등)에서 빠르게 적용할 수 있는 엔트리 이름 프리셋이에요."
     PreferencesEditorLockedDrag -> "고정 드래그"
     PreferencesEditorLockedDragDescription ->
         "주요 마커를 움직일 때, 고정 드래그의 방식을 선택합니다.\n" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
@@ -484,6 +484,7 @@ fun Strings.ko(): String? = when (this) {
     PreferencesEditorEntryNamePresets -> "엔트리 이름 프리셋"
     PreferencesEditorEntryNamePresetsDescription ->
         "엔트리 이름을 입력하는 대화창(엔트리 이름 변경, 자르기 등)에서 빠르게 적용할 수 있는 엔트리 이름 프리셋이에요."
+    PreferencesStringListEmptyPlaceholder -> "항목이 없어요"
     PreferencesEditorLockedDrag -> "고정 드래그"
     PreferencesEditorLockedDragDescription ->
         "주요 마커를 움직일 때, 고정 드래그의 방식을 선택합니다.\n" +

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/string/StringsKorean.kt
@@ -485,6 +485,7 @@ fun Strings.ko(): String? = when (this) {
     PreferencesEditorEntryNamePresetsDescription ->
         "엔트리 이름을 입력하는 대화창(엔트리 이름 변경, 자르기 등)에서 빠르게 적용할 수 있는 엔트리 이름 프리셋이에요."
     PreferencesStringListEmptyPlaceholder -> "항목이 없어요"
+    PreferencesStringListNewItemPlaceholder -> "새 항목..."
     PreferencesEditorLockedDrag -> "고정 드래그"
     PreferencesEditorLockedDragDescription ->
         "주요 마커를 움직일 때, 고정 드래그의 방식을 선택합니다.\n" +


### PR DESCRIPTION
Implements the "input preset settings" feature (Trello: https://trello.com/c/CldsHKCm).

## What it does

- **Preferences → Editor → "Entry name presets"**: a new list editor where you can add, remove, and reorder preset entry names (e.g. frequently used phonemes like `pau`, `br`).
- The presets appear as **clickable chips** below the text field in the entry name input dialog — rename, duplicate, and the cut-former/cut-latter naming flows. Clicking a chip fills the input (with the text selected, so Enter submits immediately or typing replaces it); it does not auto-submit.
- When no presets are configured, both the dialog and its layout are completely unchanged.

## UI details (iterated with maintainer review)

- The list editor follows the plugin `ParamEntrySelector` style: an always-visible fixed-height (160dp) scrollable list region with scrollbar and a "No items" placeholder, plus a surface-colored bottom bar holding a compact `BasicTextField` (with "New item..." placeholder; Enter adds) and small 16–18dp clickable icons instead of large-ripple `IconButton`s.
- List region width capped at 400dp so per-row controls stay near the text.
- The preferences page scrollbar width is unified to 15dp (was 30dp), matching other lists.

## Implementation

- New `AppConf.Editor.entryNamePresets: List<String>` (default empty — backward compatible with existing `app.conf.json`).
- New reusable preferences item type `PreferencesItem.StringListInput` + `stringList(...)` DSL builder + the list-editor UI — available for future list-valued settings.
- `InputEntryNameDialogArgs` gains a `presets` parameter (default empty), passed from the three existing call sites.
- New strings in en/zh-Hans/ja/ko.

## Testing

- `./gradlew jvmTest ktlintCheck` passes; app smoke-tested including loading a pre-existing `app.conf.json` without the new field.
- UI manually reviewed by maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)