### PR TITLE
Phase 2: unit tests for io, model and util packages

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: pull-request-builder
 
 on:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, feature/automated-tests ]
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Full guide: `docs/testing.md`. Keep both that file and this section updated when
 - Tests use kotlin.test on JUnit Platform, under `src/jvmTest/kotlin`, in short packages mirroring the production area (`io`, `model`, `util`, ...). Coverage via Kover (`./gradlew koverHtmlReport`).
 - Shared helpers in `src/jvmTest/kotlin/testutil/`: `TestLabelers` (loads real bundled labelers — the test task points `compose.application.resources.dir` at `resources/common`), `TestFixtures.deploy(...)` (copies a fixture project from `src/jvmTest/resources/fixtures/` and generates wav files at runtime — no binaries in git), `createTestProject(...)` (runs the real `projectOf` flow incl. JS scripts), `TestEnv.ensureLogDirectory()` (required before code that constructs `util.JavaScript()` with defaults; the log dir only exists where the app has run — missing on CI).
 - Set `Log.muted = true`/`false` in setup/teardown when tested code logs.
-- Some tests intentionally document suspected bugs (listed in `docs/testing.md`) — don't "fix" those tests without fixing the bug.
+- If a test reveals a suspected production bug, pin the current behavior with a comment and raise the bug for discussion instead of silently changing behavior.
 
 ## Git conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,17 @@ Requires **JDK 17+** to build.
 
 Notes:
 - The `test` task depends on `checkLicenseReportUpdate` — if you add/change dependencies in `build.gradle.kts`, run `./gradlew updateLicenseReport` or tests will fail.
-- Tests use kotlin.test on JUnit Platform, under `src/jvmTest/kotlin`.
 - App version lives in `gradle.properties` (`app.version`).
 - Dev feature flags: add `flag.xxx=true` to `local.properties` (read by `flag/FeatureFlags.kt` via system properties).
+
+## Testing
+
+Full guide: `docs/testing.md`. Keep both that file and this section updated when extending the test suite.
+
+- Tests use kotlin.test on JUnit Platform, under `src/jvmTest/kotlin`, in short packages mirroring the production area (`io`, `model`, `util`, ...). Coverage via Kover (`./gradlew koverHtmlReport`).
+- Shared helpers in `src/jvmTest/kotlin/testutil/`: `TestLabelers` (loads real bundled labelers — the test task points `compose.application.resources.dir` at `resources/common`), `TestFixtures.deploy(...)` (copies a fixture project from `src/jvmTest/resources/fixtures/` and generates wav files at runtime — no binaries in git), `createTestProject(...)` (runs the real `projectOf` flow incl. JS scripts), `TestEnv.ensureLogDirectory()` (required before code that constructs `util.JavaScript()` with defaults; the log dir only exists where the app has run — missing on CI).
+- Set `Log.muted = true`/`false` in setup/teardown when tested code logs.
+- Some tests intentionally document suspected bugs (listed in `docs/testing.md`) — don't "fix" those tests without fixing the bug.
 
 ## Git conventions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,110 @@
+# Testing
+
+This is the documentation of the automated test suite of `vLabeler`: how to run it, how it is structured, and the
+conventions to follow when adding tests.
+
+## Running tests
+
+```bash
+./gradlew jvmTest                                  # run all tests
+./gradlew jvmTest --tests "io.RawLabelsTest"       # run a single test class
+./gradlew build test                               # what PR CI runs (includes ktlint and license report check)
+./gradlew koverHtmlReport                          # coverage report at build/reports/kover/html
+```
+
+CI (`.github/workflows/pull-request.yml`) runs the full build and tests for PRs targeting `main`, `dev` and
+`feature/automated-tests`, and uploads test and coverage reports as workflow artifacts (also on failure).
+
+## Test source layout
+
+All tests live in `src/jvmTest/kotlin`, written with `kotlin.test` on the JUnit 5 platform. Packages are short names
+mirroring the production area rather than full package paths:
+
+| Location | Contents |
+|---|---|
+| `io/` | Label parsing/writing, reloading, project files, wave loading, DSP (power/spectrogram/fundamental) |
+| `model/` | Domain model: `Module`, `ProjectHistory`, `LabelerConf`, `Entry`, serialization |
+| `util/` | Pure helper functions |
+| `env/`, `strings/` | Environment and localization helpers |
+| `fixtures/` | Smoke tests creating projects from the fixture data with the bundled labelers |
+| `testutil/` | Shared test helpers (see below) |
+| (root) | Older tests for single utilities |
+
+## Test infrastructure
+
+### Bundled labelers and plugins are available in tests
+
+The `jvmTest` task sets the `compose.application.resources.dir` system property to `resources/common` (see
+`build.gradle.kts`), so production code that reads `DefaultLabelerDir` / `DefaultPluginDir` works in tests exactly as
+in a packaged app. Use `testutil.TestLabelers` to load a bundled labeler (`utauSinger`, `utauOto`, `nnsvsSinger`,
+`audacity`, `sinsy`) through the real loading path (`asLabelerConf`).
+
+### Fixtures
+
+`src/jvmTest/resources/fixtures/` contains text label files for small sample projects:
+
+- `utau-singer/` — a voicebank with two pitch folders (`C4`, `A3`) with `oto.ini` files
+- `nnsvs-singer/` — `lab/` folder with HTS-style `.lab` files (100 ns units)
+- `oto/` — a flat single-`oto.ini` voicebank
+
+Wav files are **not committed**; they are generated at test runtime. Deploy a fixture to a temp directory with:
+
+```kotlin
+val sampleDir = TestFixtures.deploy(
+    "utau-singer",
+    tempDir.resolve("utau-singer"),
+    wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+)
+```
+
+`testutil.TestWav.write(file, durationMs, sampleRate, frequency)` writes real 16-bit mono PCM sine wavs;
+`testutil.TestWaves` builds in-memory `Wave.Channel` objects for DSP tests.
+
+Note: the fixture root is located on the classpath via the `fixtures/root.marker` file, because a plain directory
+lookup can be shadowed by a package of the same name.
+
+### Creating projects
+
+`testutil.createTestProject(labeler, sampleDirectory, ...)` runs the real project creation flow (`projectOf`),
+including the labeler's project constructor and parser scripts in the GraalVM JS engine. See
+`fixtures/UtauSingerProjectFixtureTest.kt` for a complete example including temp directory setup/teardown.
+
+### Environment gotchas
+
+- **Logging**: set `Log.muted = true` in `@BeforeTest` and back to `false` in `@AfterTest` when the tested code logs.
+- **Log directory**: constructing `util.JavaScript()` with default arguments opens the info log file directly, which
+  fails on machines where the app has never run (e.g. CI). Call `testutil.TestEnv.ensureLogDirectory()` first
+  (`createTestProject` already does).
+- **License report**: the `test` Gradle task depends on `checkLicenseReportUpdate`; run
+  `./gradlew updateLicenseReport` after changing dependencies.
+
+## Conventions
+
+- Deterministic, exact assertions; no sleeps (except where file timestamp resolution requires it), no randomness, no
+  network, no native dependencies (FFmpeg, VLC, LWJGL) in tests.
+- DSP assertions verify meaningful properties (shapes, ranges, energy at the expected frequency bin) instead of exact
+  floating point equality.
+- ktlint applies to test sources: run `./gradlew ktlintFormat` before committing.
+- Tests must not change production behavior. If a test reveals a suspected bug, write the test against the **current**
+  behavior with a comment, and raise the bug separately (see below).
+
+## Tests documenting suspected bugs
+
+The following tests intentionally pin current, possibly-buggy behavior; fixing the bug should flip the test:
+
+- `util/DateTimeTest.testParseIsoTimeIgnoresOffset` — `parseIsoTime` ignores the timezone offset in the input.
+- `util/CollectionsTest.testGetNextOrNullNotFound` — `getNextOrNull` returns the first element when nothing matches.
+- `util/MathTest` — `Double.roundToDecimalDigit` loses precision by converting through `Float`.
+
+## Roadmap
+
+The test effort is tracked on the `feature/automated-tests` branch (sub-parts are merged into it via PRs):
+
+1. ✅ **Phase 1 — foundations**: Kover coverage, fixtures, `testutil` helpers, labeler smoke tests, CI reports
+2. ✅ **Phase 2 — unit tests**: `io` (raw labels round-trips, reload, backups, wave/DSP), `model`, `util`
+3. **Phase 3 — integration tests**: bundled template/macro plugin execution, full project lifecycle
+   (create → save → load → edit → export)
+4. **Phase 4 — UI tests**: state holders (`ProjectStore`, dialog states) and Compose UI tests (`runComposeUiTest`)
+5. **Phase 5 — CI polish**: split unit/integration steps, coverage thresholds
+
+When adding tests in a new phase, keep this document and the Testing section of `CLAUDE.md` up to date.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,15 +86,7 @@ including the labeler's project constructor and parser scripts in the GraalVM JS
   floating point equality.
 - ktlint applies to test sources: run `./gradlew ktlintFormat` before committing.
 - Tests must not change production behavior. If a test reveals a suspected bug, write the test against the **current**
-  behavior with a comment, and raise the bug separately (see below).
-
-## Tests documenting suspected bugs
-
-The following tests intentionally pin current, possibly-buggy behavior; fixing the bug should flip the test:
-
-- `util/DateTimeTest.testParseIsoTimeIgnoresOffset` — `parseIsoTime` ignores the timezone offset in the input.
-- `util/CollectionsTest.testGetNextOrNullNotFound` — `getNextOrNull` returns the first element when nothing matches.
-- `util/MathTest` — `Double.roundToDecimalDigit` loses precision by converting through `Float`.
+  behavior with a comment, and raise the bug separately for discussion before fixing it.
 
 ## Roadmap
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/Collections.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/Collections.kt
@@ -7,6 +7,7 @@ fun <T> List<T>.getPreviousOrNull(predict: (T) -> Boolean): T? {
 
 fun <T> List<T>.getNextOrNull(predict: (T) -> Boolean): T? {
     val index = indexOfFirst { predict(it) }
+    if (index < 0) return null
     return getOrNull(index + 1)
 }
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/DateTime.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/DateTime.kt
@@ -2,12 +2,11 @@ package com.sdercolin.vlabeler.util
 
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 fun parseIsoTime(time: String): Long {
     val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
-    return LocalDateTime.parse(time, formatter).toInstant(ZoneOffset.UTC).toEpochMilli()
+    return OffsetDateTime.parse(time, formatter).toInstant().toEpochMilli()
 }
 
 fun getLocalDate(time: Long): String {

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/Math.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/Math.kt
@@ -8,5 +8,5 @@ fun Float.roundToDecimalDigit(n: Int?): Float = if (n == null) this else {
 }
 
 fun Double.roundToDecimalDigit(n: Int?): Double = if (n == null) this else {
-    10.0.pow(n).let { times(it).roundToLong().toFloat().div(it) }
+    10.0.pow(n).let { times(it).roundToLong().toDouble().div(it) }
 }

--- a/src/jvmTest/kotlin/io/AudioFormatTest.kt
+++ b/src/jvmTest/kotlin/io/AudioFormatTest.kt
@@ -1,0 +1,55 @@
+package io
+
+import com.sdercolin.vlabeler.io.NORMALIZED_SAMPLE_SIZE_IN_BITS
+import com.sdercolin.vlabeler.io.normalize
+import javax.sound.sampled.AudioFormat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [normalize].
+ */
+class AudioFormatTest {
+
+    private fun format(
+        sampleRate: Float,
+        sampleSizeInBits: Int = 24,
+        channels: Int = 1,
+        isBigEndian: Boolean = false,
+    ) = AudioFormat(sampleRate, sampleSizeInBits, channels, true, isBigEndian)
+
+    @Test
+    fun testZeroMaxSampleRateKeepsOriginalRate() {
+        val normalized = format(96000f).normalize(0)
+        assertEquals(96000f, normalized.sampleRate)
+    }
+
+    @Test
+    fun testHigherRateIsResampledDownToMax() {
+        val normalized = format(96000f).normalize(44100)
+        assertEquals(44100f, normalized.sampleRate)
+    }
+
+    @Test
+    fun testLowerRateIsKept() {
+        val normalized = format(22050f).normalize(44100)
+        assertEquals(22050f, normalized.sampleRate)
+    }
+
+    @Test
+    fun testSampleSizeIsNormalized() {
+        listOf(8, 16, 24, 32).forEach { bits ->
+            val normalized = format(44100f, sampleSizeInBits = bits).normalize(44100)
+            assertEquals(NORMALIZED_SAMPLE_SIZE_IN_BITS, normalized.sampleSizeInBits)
+        }
+    }
+
+    @Test
+    fun testChannelsAndEndiannessArePreserved() {
+        val normalized = format(48000f, channels = 2, isBigEndian = true).normalize(44100)
+        assertEquals(2, normalized.channels)
+        assertTrue(normalized.isBigEndian)
+        assertEquals(AudioFormat.Encoding.PCM_SIGNED, normalized.encoding)
+    }
+}

--- a/src/jvmTest/kotlin/io/FundamentalTest.kt
+++ b/src/jvmTest/kotlin/io/FundamentalTest.kt
@@ -1,0 +1,85 @@
+package io
+
+import com.sdercolin.vlabeler.io.Semitone
+import com.sdercolin.vlabeler.io.Wave
+import com.sdercolin.vlabeler.io.toFundamental
+import com.sdercolin.vlabeler.io.toFundamentalSwipePrime
+import com.sdercolin.vlabeler.model.AppConf
+import testutil.TestWaves
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [Semitone], [toFundamental] and [toFundamentalSwipePrime].
+ */
+class FundamentalTest {
+
+    private val conf = AppConf.Fundamental()
+    private val sampleRate = 44100f
+
+    @Test
+    fun testSemitoneFromFrequency() {
+        assertEquals(69f, Semitone.fromFrequency(440f), 1e-4f)
+        assertEquals(81f, Semitone.fromFrequency(880f), 1e-4f)
+        assertEquals(57f, Semitone.fromFrequency(220f), 1e-4f)
+    }
+
+    @Test
+    fun testSemitoneToFrequency() {
+        assertEquals(440f, Semitone.toFrequency(69f), 1e-2f)
+        assertEquals(880f, Semitone.toFrequency(81f), 1e-2f)
+    }
+
+    @Test
+    fun testSemitoneRoundTrip() {
+        listOf(130.81f, 261.63f, 440f, 880f).forEach { frequency ->
+            assertEquals(frequency, Semitone.toFrequency(Semitone.fromFrequency(frequency)), 1e-2f)
+        }
+    }
+
+    @Test
+    fun testSineFundamentalIsDetected() {
+        val frequency = 220.0
+        val wave = Wave(listOf(TestWaves.sineChannel(22050, frequency = frequency, amplitude = 16000f)))
+
+        val fundamental = wave.toFundamental(conf, sampleRate)
+
+        assertTrue(fundamental.freq.isNotEmpty())
+        assertEquals(fundamental.freq.size, fundamental.corr.size)
+        // all candidates are within the configured fundamental range (snapped to the semitone grid)
+        fundamental.freq.forEach { assertTrue(it in 120f..900f) }
+        // where the correlation is the highest, the detected frequency should be close to the sine frequency
+        val bestIndex = fundamental.corr.indices.maxByOrNull { fundamental.corr[it] }!!
+        val detected = fundamental.freq[bestIndex]
+        assertTrue(
+            detected in 200f..240f,
+            "Expected the best candidate near $frequency Hz but got $detected Hz",
+        )
+    }
+
+    @Test
+    fun testHigherPitchIsDetectedHigher() {
+        val wave = Wave(listOf(TestWaves.sineChannel(22050, frequency = 440.0, amplitude = 16000f)))
+
+        val fundamental = wave.toFundamental(conf, sampleRate)
+
+        val bestIndex = fundamental.corr.indices.maxByOrNull { fundamental.corr[it] }!!
+        val detected = fundamental.freq[bestIndex]
+        assertTrue(
+            detected in 410f..470f,
+            "Expected the best candidate near 440 Hz but got $detected Hz",
+        )
+    }
+
+    @Test
+    fun testInvalidConfReturnsFallback() {
+        val invalidConf = conf.copy(minFundamental = 880f, maxFundamental = 130f)
+        val wave = Wave(listOf(TestWaves.sineChannel(4410)))
+
+        val fundamental = wave.toFundamentalSwipePrime(invalidConf, sampleRate)
+
+        assertEquals(listOf(invalidConf.minFundamental), fundamental.freq)
+        assertEquals(listOf(0f), fundamental.corr)
+    }
+}

--- a/src/jvmTest/kotlin/io/PowerTest.kt
+++ b/src/jvmTest/kotlin/io/PowerTest.kt
@@ -1,0 +1,102 @@
+package io
+
+import com.sdercolin.vlabeler.io.Wave
+import com.sdercolin.vlabeler.io.toPower
+import com.sdercolin.vlabeler.model.AppConf
+import testutil.TestWaves
+import kotlin.math.abs
+import kotlin.math.log10
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [toPower].
+ */
+class PowerTest {
+
+    private val conf = AppConf.Power()
+
+    // the dB value produced for a silent signal: 20 * log10(1 / 2^15)
+    private val silenceDb = (20 * log10(1.0 / 32768)).toFloat()
+
+    @Test
+    fun testSilenceIsAtFloor() {
+        val wave = Wave(listOf(TestWaves.silentChannel(6000)))
+
+        val power = wave.toPower(conf)
+
+        assertEquals(1, power.data.size)
+        assertTrue(power.data[0].isNotEmpty())
+        power.data[0].forEach { assertEquals(silenceDb, it, 1e-3f) }
+    }
+
+    @Test
+    fun testOutputShape() {
+        val frameCount = 6000
+        val wave = Wave(listOf(TestWaves.sineChannel(frameCount)))
+
+        val power = wave.toPower(conf)
+
+        // The data is padded with (windowSize - unitSize) / 2 zeros, then windowed by unitSize with partial windows.
+        val paddedSize = frameCount + (conf.windowSize - conf.unitSize) / 2
+        val expectedSize = (paddedSize + conf.unitSize - 1) / conf.unitSize
+        assertEquals(expectedSize, power.data[0].size)
+    }
+
+    @Test
+    fun testLouderSignalHasHigherPower() {
+        val frameCount = 6000
+        val loud = Wave(listOf(TestWaves.sineChannel(frameCount, amplitude = 16000f)))
+        val quiet = Wave(listOf(TestWaves.sineChannel(frameCount, amplitude = 1600f)))
+
+        val loudPower = loud.toPower(conf).data[0]
+        val quietPower = quiet.toPower(conf).data[0]
+
+        assertEquals(loudPower.size, quietPower.size)
+        val middle = loudPower.size / 2
+        assertTrue(loudPower[middle] > quietPower[middle])
+        // 10x amplitude is +20 dB
+        assertEquals(20f, loudPower[middle] - quietPower[middle], 0.1f)
+    }
+
+    @Test
+    fun testFullScaleSinePowerValue() {
+        val wave = Wave(listOf(TestWaves.sineChannel(6000, amplitude = 32767f)))
+
+        val power = wave.toPower(conf).data[0]
+
+        // RMS of a full-scale sine is 1/sqrt(2), which is about -3.01 dB.
+        // Use a window in the middle: windows at the edges are affected by padding and partial window sizes.
+        assertEquals(-3.01f, power[power.size / 2], 0.3f)
+        power.forEach { assertTrue(it <= 0f && it >= silenceDb) }
+    }
+
+    @Test
+    fun testMergeChannels() {
+        val channel = TestWaves.sineChannel(6000)
+        val wave = Wave(listOf(channel, channel))
+
+        val merged = wave.toPower(conf.copy(mergeChannels = true))
+        val separate = wave.toPower(conf.copy(mergeChannels = false))
+
+        assertEquals(1, merged.data.size)
+        assertEquals(2, separate.data.size)
+        assertEquals(separate.data[0].size, separate.data[1].size)
+        // identical channels: merged result equals each separate channel's result
+        merged.data[0].forEachIndexed { i, value ->
+            assertTrue(abs(value - separate.data[0][i]) < 1e-3f)
+        }
+    }
+
+    @Test
+    fun testOppositeChannelsCancelWhenMerged() {
+        val channel = TestWaves.sineChannel(6000, amplitude = 16000f)
+        val wave = Wave(listOf(channel, TestWaves.invertedChannel(channel)))
+
+        val power = wave.toPower(conf.copy(mergeChannels = true))
+
+        assertEquals(1, power.data.size)
+        power.data[0].forEach { assertEquals(silenceDb, it, 1e-3f) }
+    }
+}

--- a/src/jvmTest/kotlin/io/ProjectBackupTest.kt
+++ b/src/jvmTest/kotlin/io/ProjectBackupTest.kt
@@ -1,0 +1,90 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.saveBackupProjectFile
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.util.stringifyJson
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Tests for [saveBackupProjectFile].
+ */
+class ProjectBackupTest {
+
+    private lateinit var tempDir: File
+    private lateinit var project: Project
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        project = createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        )
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+        tempDir.deleteRecursively()
+    }
+
+    private val backupDir get() = project.workingDirectory.resolve("backups")
+
+    private fun listBackups() = backupDir.listFiles().orEmpty().sortedBy { it.lastModified() }
+
+    @Test
+    fun testCreatesBackupFile() {
+        runBlocking { saveBackupProjectFile(project, maxFileCount = 5) }
+        val backups = listBackups()
+        assertEquals(1, backups.size)
+        assertEquals(project.stringifyJson(), backups.single().readText())
+    }
+
+    @Test
+    fun testSkipsBackupWhenContentUnchanged() {
+        runBlocking {
+            saveBackupProjectFile(project, maxFileCount = 5)
+            saveBackupProjectFile(project, maxFileCount = 5)
+        }
+        assertEquals(1, listBackups().size)
+    }
+
+    @Test
+    fun testRotationKeepsMaxFileCount() {
+        runBlocking {
+            repeat(3) { index ->
+                val modified = project.copy(currentModuleIndex = 0, autoExport = index % 2 == 0)
+                saveBackupProjectFile(modified.copy(projectName = project.projectName), maxFileCount = 2)
+                // the backup file name has millisecond resolution; avoid name collisions between iterations
+                Thread.sleep(5)
+            }
+        }
+        assertEquals(2, listBackups().size)
+    }
+
+    @Test
+    fun testDisabledWhenMaxFileCountIsZero() {
+        runBlocking { saveBackupProjectFile(project, maxFileCount = 0) }
+        assertFalse(backupDir.exists())
+    }
+}

--- a/src/jvmTest/kotlin/io/RawLabelsTest.kt
+++ b/src/jvmTest/kotlin/io/RawLabelsTest.kt
@@ -1,0 +1,140 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.moduleFromRawLabels
+import com.sdercolin.vlabeler.io.singleModuleToRawLabels
+import com.sdercolin.vlabeler.model.Entry
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [moduleFromRawLabels] and [singleModuleToRawLabels] using the bundled labelers.
+ */
+class RawLabelsTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+        tempDir.deleteRecursively()
+    }
+
+    private fun parseUtau(vararg lines: String): List<Entry> = moduleFromRawLabels(
+        sources = lines.toList(),
+        inputFile = null,
+        labelerConf = TestLabelers.utauSinger,
+        labelerParams = TestLabelers.utauSinger.getDefaultParams(),
+        sampleFiles = listOf(File("_a_ka.wav"), File("_i_ki.wav")),
+        encoding = "UTF-8",
+    )
+
+    @Test
+    fun testParseUtauOtoLine() {
+        val entries = parseUtau("_a_ka.wav=- a,10.0,100.0,-400.0,80.0,30.0")
+        val entry = entries.single()
+        assertEquals("_a_ka.wav", entry.sample)
+        assertEquals("- a", entry.name)
+        assertEquals(10f, entry.start)
+        assertEquals(410f, entry.end)
+        // points: [fixed, preutterance, overlap, offset] as absolute positions
+        assertEquals(listOf(110f, 90f, 40f, 10f), entry.points)
+        assertFalse(entry.needSync)
+        // the raw cutoff value is kept as an extra to allow restoring the original value
+        assertEquals(-400f, entry.extras.single()?.toFloat())
+    }
+
+    @Test
+    fun testParseSkipsBlankLines() {
+        val entries = parseUtau(
+            "",
+            "_a_ka.wav=- a,10.0,100.0,-400.0,80.0,30.0",
+            "   ",
+            "_i_ki.wav=- i,10.0,100.0,-400.0,80.0,30.0",
+            "",
+        )
+        assertEquals(listOf("- a", "- i"), entries.map { it.name })
+    }
+
+    @Test
+    fun testParseSkipsInvalidLines() {
+        val entries = parseUtau(
+            "this is not an oto line",
+            "_a_ka.wav=- a,10.0,100.0,-400.0,80.0,30.0",
+        )
+        assertEquals(listOf("- a"), entries.map { it.name })
+    }
+
+    @Test
+    fun testParseEmptyNameFallsBackToSampleName() {
+        val entries = parseUtau("_a_ka.wav=,10.0,100.0,-400.0,80.0,30.0")
+        assertEquals("_a_ka", entries.single().name)
+    }
+
+    @Test
+    fun testParseEmptyFieldsDefaultToZero() {
+        val entries = parseUtau("_a_ka.wav=empty,,,,,")
+        val entry = entries.single()
+        assertEquals(0f, entry.start)
+        assertEquals(0f, entry.end, absoluteTolerance = 0f)
+        assertEquals(listOf(0f, 0f, 0f, 0f), entry.points)
+        // a non-negative raw cutoff value is relative to the sample end, which requires syncing with the sample
+        assertTrue(entry.needSync)
+    }
+
+    @Test
+    fun testUtauSingerWriteRoundTrip() {
+        val sampleDir = TestFixtures.deploy(
+            "utau-singer",
+            tempDir.resolve("utau-singer"),
+            wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+        )
+        val project = createTestProject(
+            labeler = TestLabelers.utauSinger,
+            sampleDirectory = sampleDir,
+        )
+        for (moduleName in listOf("C4", "A3")) {
+            val moduleIndex = project.modules.indexOfFirst { it.name == moduleName }
+            val output = project.singleModuleToRawLabels(moduleIndex)
+            val original = sampleDir.resolve(moduleName).resolve("oto.ini").readText().trimEnd()
+            assertEquals(original, output.trimEnd(), "Round trip failed for module $moduleName")
+        }
+    }
+
+    @Test
+    fun testNnsvsWriteRoundTrip() {
+        val sampleDir = TestFixtures.deploy(
+            "nnsvs-singer",
+            tempDir.resolve("nnsvs-singer"),
+            wavFiles = listOf("wav/doremi.wav", "wav/legato.wav"),
+            wavDurationMs = 1500,
+        )
+        val project = createTestProject(
+            labeler = TestLabelers.nnsvsSinger,
+            sampleDirectory = sampleDir,
+        )
+        for (moduleName in listOf("doremi", "legato")) {
+            val moduleIndex = project.modules.indexOfFirst { it.name == moduleName }
+            val output = project.singleModuleToRawLabels(moduleIndex)
+            val original = sampleDir.resolve("lab").resolve("$moduleName.lab").readText().trimEnd()
+            assertEquals(original, output.trimEnd(), "Round trip failed for module $moduleName")
+        }
+    }
+}

--- a/src/jvmTest/kotlin/io/ReloadLabelTest.kt
+++ b/src/jvmTest/kotlin/io/ReloadLabelTest.kt
@@ -1,0 +1,166 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.mergeEntryLists
+import com.sdercolin.vlabeler.io.reloadEntriesFromLabelFile
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.EntryListDiffItem.Add
+import com.sdercolin.vlabeler.model.EntryListDiffItem.Edit
+import com.sdercolin.vlabeler.model.EntryListDiffItem.Remove
+import com.sdercolin.vlabeler.model.EntryListDiffItem.Unchanged
+import com.sdercolin.vlabeler.model.EntryNotes
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.computeEntryListDiff
+import com.sdercolin.vlabeler.ui.dialog.ReloadLabelConfigs
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [reloadEntriesFromLabelFile] and [mergeEntryLists].
+ */
+class ReloadLabelTest {
+
+    private lateinit var tempDir: File
+    private lateinit var sampleDir: File
+    private lateinit var project: Project
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+        sampleDir = TestFixtures.deploy(
+            "utau-singer",
+            tempDir.resolve("utau-singer"),
+            wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+        )
+        project = createTestProject(
+            labeler = TestLabelers.utauSinger,
+            sampleDirectory = sampleDir,
+        )
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+        tempDir.deleteRecursively()
+    }
+
+    private val module get() = project.modules.first { it.name == "C4" }
+    private val otoFile get() = sampleDir.resolve("C4").resolve("oto.ini")
+
+    private fun reload(): Pair<List<Entry>, com.sdercolin.vlabeler.model.EntryListDiff> =
+        reloadEntriesFromLabelFile(project, module, otoFile).getOrThrow()
+
+    @Test
+    fun testReloadUnchangedFile() {
+        val (entries, diff) = reload()
+        assertEquals(module.entries, entries)
+        assertEquals(4, diff.items.filterIsInstance<Unchanged>().size)
+        assertEquals(4, diff.items.size)
+    }
+
+    @Test
+    fun testReloadEditedValue() {
+        // change preutterance of entry "- a" from 80.0 to 90.0
+        otoFile.writeText(
+            otoFile.readText().replace(
+                "_a_ka.wav=- a,10.0,100.0,-400.0,80.0,30.0",
+                "_a_ka.wav=- a,10.0,100.0,-400.0,90.0,30.0",
+            ),
+        )
+        val (entries, diff) = reload()
+        assertEquals(100f, entries.first { it.name == "- a" }.points[1])
+        val edits = diff.items.filterIsInstance<Edit>()
+        assertEquals(1, edits.size)
+        assertEquals("- a", edits.single().old.name)
+        assertEquals(90f, edits.single().new.points[1] - edits.single().new.points[3])
+        assertEquals(3, diff.items.filterIsInstance<Unchanged>().size)
+    }
+
+    @Test
+    fun testReloadAddedEntry() {
+        otoFile.appendText("\n_i_ki.wav=u ki,450.0,120.0,-350.0,100.0,40.0\n")
+        val (entries, diff) = reload()
+        assertEquals(5, entries.size)
+        val adds = diff.items.filterIsInstance<Add>()
+        assertEquals(1, adds.size)
+        assertEquals("u ki", adds.single().new.name)
+        assertEquals(4, diff.items.filterIsInstance<Unchanged>().size)
+    }
+
+    @Test
+    fun testReloadRemovedEntry() {
+        otoFile.writeText(
+            otoFile.readLines().filterNot { it.contains("=i ki,") }.joinToString("\n"),
+        )
+        val (entries, diff) = reload()
+        assertEquals(3, entries.size)
+        val removes = diff.items.filterIsInstance<Remove>()
+        assertEquals(1, removes.size)
+        assertEquals("i ki", removes.single().old.name)
+        assertEquals(3, diff.items.filterIsInstance<Unchanged>().size)
+    }
+
+    private fun entry(name: String, start: Float) = Entry(
+        sample = "a.wav",
+        name = name,
+        start = start,
+        end = start + 100f,
+        points = listOf(),
+        extras = listOf(),
+    )
+
+    @Test
+    fun testMergeInheritsNotesOnEditedAndUnchangedEntries() {
+        val notes = EntryNotes(done = true, star = true, tag = "keep")
+        val old = listOf(
+            entry("a", 0f).copy(notes = notes),
+            entry("b", 100f).copy(notes = EntryNotes(tag = "other")),
+        )
+        val new = listOf(
+            entry("a", 10f), // edited
+            entry("b", 100f), // unchanged
+        )
+        val diff = computeEntryListDiff(old, new)
+        val merged = mergeEntryLists(new, old, diff, ReloadLabelConfigs())
+        assertEquals(notes, merged[0].notes)
+        assertEquals("other", merged[1].notes.tag)
+        // positions come from the new list
+        assertEquals(10f, merged[0].start)
+    }
+
+    @Test
+    fun testMergeWithoutInheritanceReturnsNewList() {
+        val old = listOf(entry("a", 0f).copy(notes = EntryNotes(tag = "keep")))
+        val new = listOf(entry("a", 10f))
+        val diff = computeEntryListDiff(old, new)
+        val configs = ReloadLabelConfigs(inheritStar = false, inheritDone = false, inheritTag = false)
+        val merged = mergeEntryLists(new, old, diff, configs)
+        assertSame(new, merged)
+    }
+
+    @Test
+    fun testMergeSelectiveInheritance() {
+        val old = listOf(entry("a", 0f).copy(notes = EntryNotes(done = true, star = true, tag = "keep")))
+        val new = listOf(entry("a", 10f))
+        val diff = computeEntryListDiff(old, new)
+        val configs = ReloadLabelConfigs(inheritStar = false, inheritDone = false, inheritTag = true)
+        val merged = mergeEntryLists(new, old, diff, configs)
+        assertEquals("keep", merged.single().notes.tag)
+        assertFalse(merged.single().notes.done)
+        assertFalse(merged.single().notes.star)
+        assertTrue(old.single().notes.done)
+    }
+}

--- a/src/jvmTest/kotlin/io/SampleListTest.kt
+++ b/src/jvmTest/kotlin/io/SampleListTest.kt
@@ -1,0 +1,56 @@
+package io
+
+import com.sdercolin.vlabeler.io.Sample
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [Sample.listSampleFiles].
+ */
+class SampleListTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setup() {
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun testAcceptedExtensionsAreListed() {
+        val accepted = listOf("a.wav", "b.mp3", "c.flac", "d.ogg", "e.m4a")
+        accepted.forEach { tempDir.resolve(it).writeText("dummy") }
+
+        val actual = Sample.listSampleFiles(tempDir).map { it.name }.sorted()
+
+        assertEquals(accepted, actual)
+    }
+
+    @Test
+    fun testOtherFilesAreExcluded() {
+        tempDir.resolve("a.wav").writeText("dummy")
+        tempDir.resolve("readme.txt").writeText("dummy")
+        tempDir.resolve("noextension").writeText("dummy")
+        tempDir.resolve("project.lbp").writeText("dummy")
+
+        val actual = Sample.listSampleFiles(tempDir).map { it.name }
+
+        assertEquals(listOf("a.wav"), actual)
+    }
+
+    @Test
+    fun testNonExistentDirectoryReturnsEmptyList() {
+        val actual = Sample.listSampleFiles(tempDir.resolve("not-existing"))
+
+        assertEquals(emptyList(), actual)
+    }
+}

--- a/src/jvmTest/kotlin/io/SpectrogramTest.kt
+++ b/src/jvmTest/kotlin/io/SpectrogramTest.kt
@@ -1,0 +1,121 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.MelScale
+import com.sdercolin.vlabeler.io.Wave
+import com.sdercolin.vlabeler.io.toSpectrogram
+import com.sdercolin.vlabeler.model.AppConf
+import testutil.TestWaves
+import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [toSpectrogram] and [MelScale].
+ */
+class SpectrogramTest {
+
+    private val conf = AppConf.Spectrogram()
+    private val sampleRate = 44100f
+
+    // matches the window size calculation in toSpectrogram for 44100 Hz
+    private val windowSize = (conf.standardWindowSize * 2.0.pow((sampleRate / 44100f).toDouble())).toInt()
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    @Test
+    fun testShapeAndValueRange() {
+        val wave = Wave(listOf(TestWaves.sineChannel(22050, frequency = 1000.0, amplitude = 1000f)))
+
+        val spectrogram = wave.toSpectrogram(conf, sampleRate)
+
+        assertEquals(conf.standardHopSize, spectrogram.hopSize)
+        assertTrue(spectrogram.data.isNotEmpty())
+        val frequencySize = spectrogram.data.first().size
+        assertTrue(frequencySize > 0)
+        spectrogram.data.forEach { frame ->
+            assertEquals(frequencySize, frame.size)
+            frame.forEach { value -> assertTrue(value in 0.0..1.0) }
+        }
+    }
+
+    @Test
+    fun testHopSizeScalesWithSampleRate() {
+        val lowSampleRate = 22050f
+        val wave = Wave(listOf(TestWaves.sineChannel(11025, sampleRate = lowSampleRate, amplitude = 1000f)))
+
+        val spectrogram = wave.toSpectrogram(conf, lowSampleRate)
+
+        assertEquals((conf.standardHopSize * lowSampleRate / 44100).roundToInt(), spectrogram.hopSize)
+    }
+
+    @Test
+    fun testEnergyPeaksAtSineFrequency() {
+        val frequency = 1000.0
+        val wave = Wave(listOf(TestWaves.sineChannel(22050, frequency = frequency, amplitude = 1000f)))
+
+        val spectrogram = wave.toSpectrogram(conf, sampleRate)
+
+        // pick a frame in the middle where the window fully covers the sine wave
+        val frame = spectrogram.data[spectrogram.data.size / 2]
+        val peakBin = frame.indices.maxByOrNull { frame[it] }!!
+        val binFrequency = peakBin * sampleRate / windowSize
+        assertTrue(
+            abs(binFrequency - frequency) < 100.0,
+            "Expected peak near $frequency Hz but found it at $binFrequency Hz",
+        )
+        assertTrue(frame[peakBin] > 0.5)
+        // a far away bin should carry almost no energy
+        val farBin = (5000 * windowSize / sampleRate).toInt()
+        assertTrue(frame[farBin] < 0.1)
+    }
+
+    @Test
+    fun testOppositeChannelsCancelWhenMerged() {
+        val channel = TestWaves.sineChannel(22050, frequency = 1000.0, amplitude = 1000f)
+        val wave = Wave(listOf(channel, TestWaves.invertedChannel(channel)))
+
+        val spectrogram = wave.toSpectrogram(conf, sampleRate)
+
+        assertTrue(spectrogram.data.isNotEmpty())
+        spectrogram.data.forEach { frame ->
+            frame.forEach { value -> assertEquals(0.0, value, 1e-9) }
+        }
+    }
+
+    @Test
+    fun testInvalidIntensityRangeReturnsEmptyData() {
+        val wave = Wave(listOf(TestWaves.sineChannel(22050, amplitude = 1000f)))
+
+        val spectrogram = wave.toSpectrogram(conf.copy(minIntensity = 55, maxIntensity = 55), sampleRate)
+
+        assertTrue(spectrogram.data.isEmpty())
+    }
+
+    @Test
+    fun testMelScaleRoundTrip() {
+        assertEquals(0.0, MelScale.toMel(0.0), 1e-9)
+        listOf(100.0, 440.0, 1000.0, 8000.0).forEach { frequency ->
+            assertEquals(frequency, MelScale.toFreq(MelScale.toMel(frequency)), 1e-6)
+        }
+    }
+
+    @Test
+    fun testMelScaleIsMonotonic() {
+        val mels = listOf(100.0, 440.0, 1000.0, 8000.0).map { MelScale.toMel(it) }
+        assertEquals(mels, mels.sorted())
+    }
+}

--- a/src/jvmTest/kotlin/io/WaveLoadingTest.kt
+++ b/src/jvmTest/kotlin/io/WaveLoadingTest.kt
@@ -1,0 +1,235 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.WAVE_LOADING_ALGORITHM_VERSION
+import com.sdercolin.vlabeler.io.getSampleValueFromFrame
+import com.sdercolin.vlabeler.io.loadSampleChunk
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.SampleInfo
+import kotlinx.coroutines.runBlocking
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.TestWav
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [SampleInfo.load] and [loadSampleChunk] driven by real generated wav files.
+ */
+class WaveLoadingTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+        tempDir.deleteRecursively()
+    }
+
+    private fun createProject(): Project {
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        return createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        )
+    }
+
+    private fun loadSampleInfo(project: Project, file: File, appConf: AppConf): SampleInfo = runBlocking {
+        SampleInfo.load(project, moduleName = "", file = file, appConf = appConf).getOrThrow()
+    }
+
+    @Test
+    fun testGetSampleValueFromFrameMonoLittleEndian() {
+        val frame = byteArrayOf(0x34, 0x12)
+        val value = getSampleValueFromFrame(frame, 2, 0, 1, isBigEndian = false)
+        assertEquals(0x1234.toFloat(), value)
+    }
+
+    @Test
+    fun testGetSampleValueFromFrameNegativeValues() {
+        val minusOne = byteArrayOf(0xFF.toByte(), 0xFF.toByte())
+        assertEquals(-1f, getSampleValueFromFrame(minusOne, 2, 0, 1, isBigEndian = false))
+        val minValue = byteArrayOf(0x00, 0x80.toByte())
+        assertEquals(-32768f, getSampleValueFromFrame(minValue, 2, 0, 1, isBigEndian = false))
+    }
+
+    @Test
+    fun testGetSampleValueFromFrameBigEndian() {
+        val frame = byteArrayOf(0x12, 0x34)
+        val value = getSampleValueFromFrame(frame, 2, 0, 1, isBigEndian = true)
+        assertEquals(0x1234.toFloat(), value)
+    }
+
+    @Test
+    fun testGetSampleValueFromFrameStereo() {
+        val frame = byteArrayOf(0x01, 0x00, 0x00, 0x80.toByte())
+        assertEquals(1f, getSampleValueFromFrame(frame, 4, 0, 2, isBigEndian = false))
+        assertEquals(-32768f, getSampleValueFromFrame(frame, 4, 1, 2, isBigEndian = false))
+    }
+
+    @Test
+    fun testLoadSampleInfo() {
+        val project = createProject()
+        val file = project.rootSampleDirectory.resolve("_a_ka.wav")
+        val appConf = AppConf()
+
+        val sampleInfo = loadSampleInfo(project, file, appConf)
+
+        assertEquals("_a_ka.wav", sampleInfo.name)
+        assertEquals("_a_ka.wav", sampleInfo.file)
+        assertNull(sampleInfo.convertedFile)
+        assertEquals(44100f, sampleInfo.sampleRate)
+        assertEquals(1, sampleInfo.channels)
+        assertEquals(44100, sampleInfo.length)
+        assertEquals(1000f, sampleInfo.lengthMillis, 1f)
+        assertEquals(1, sampleInfo.chunkCount)
+        assertEquals(44100, sampleInfo.chunkSize)
+        assertNull(sampleInfo.normalizeRatio)
+        assertEquals(appConf.painter.spectrogram.enabled, sampleInfo.hasSpectrogram)
+        assertEquals(appConf.painter.power.enabled, sampleInfo.hasPower)
+        assertEquals(appConf.painter.fundamental.enabled, sampleInfo.hasFundamental)
+        assertEquals(WAVE_LOADING_ALGORITHM_VERSION, sampleInfo.algorithmVersion)
+    }
+
+    @Test
+    fun testLoadSampleInfoWithNormalize() {
+        val project = createProject()
+        val file = project.rootSampleDirectory.resolve("_a_ka.wav")
+        val appConf = AppConf().run {
+            copy(painter = painter.copy(amplitude = painter.amplitude.copy(normalize = true)))
+        }
+
+        val sampleInfo = loadSampleInfo(project, file, appConf)
+
+        // the test wav has a peak of about half the full scale, so the ratio should be about 2
+        val ratio = assertNotNull(sampleInfo.normalizeRatio)
+        assertEquals(2f, ratio, 0.05f)
+    }
+
+    @Test
+    fun testLoadSampleInfoWithResampling() {
+        val project = createProject()
+        val file = project.rootSampleDirectory.resolve("high-rate.wav")
+        TestWav.write(file, durationMs = 1000, sampleRate = 88200)
+        val appConf = AppConf()
+
+        val sampleInfo = loadSampleInfo(project, file, appConf)
+
+        assertEquals(44100, appConf.painter.amplitude.resampleDownToHz)
+        assertEquals(44100f, sampleInfo.sampleRate)
+        assertEquals(44100, sampleInfo.length)
+        assertEquals(1000f, sampleInfo.lengthMillis, 1f)
+    }
+
+    @Test
+    fun testLoadSampleChunk() {
+        val project = createProject()
+        val file = project.rootSampleDirectory.resolve("sine.wav")
+        TestWav.write(file, durationMs = 1000, sampleRate = 44100, frequency = 440.0)
+        val appConf = AppConf().run {
+            copy(
+                painter = painter.copy(
+                    power = painter.power.copy(enabled = true),
+                    fundamental = painter.fundamental.copy(enabled = true),
+                ),
+            )
+        }
+        val sampleInfo = loadSampleInfo(project, file, appConf)
+
+        val chunk = runBlocking {
+            loadSampleChunk(project, sampleInfo, appConf, chunkIndex = 0, chunkSize = sampleInfo.chunkSize)
+        }.getOrThrow()
+
+        assertEquals(0, chunk.index)
+        assertEquals(sampleInfo, chunk.info)
+        assertEquals(1, chunk.wave.channels.size)
+        assertEquals(sampleInfo.length, chunk.wave.length)
+        // the generated sine wave has an amplitude of about half the full 16-bit scale
+        val data = chunk.wave.channels[0].data
+        val max = data.max()
+        val min = data.min()
+        assertTrue(max in 16000f..16384f, "Unexpected max amplitude: $max")
+        assertTrue(min in -16384f..-16000f, "Unexpected min amplitude: $min")
+        assertNotNull(chunk.spectrogram)
+        assertNotNull(chunk.power)
+        assertNotNull(chunk.fundamental)
+    }
+
+    @Test
+    fun testLoadSampleChunkDisabledFeatures() {
+        val project = createProject()
+        val file = project.rootSampleDirectory.resolve("_a_ka.wav")
+        val appConf = AppConf().run {
+            copy(
+                painter = painter.copy(
+                    spectrogram = painter.spectrogram.copy(enabled = false),
+                ),
+            )
+        }
+        val sampleInfo = loadSampleInfo(project, file, appConf)
+
+        val chunk = runBlocking {
+            loadSampleChunk(project, sampleInfo, appConf, chunkIndex = 0, chunkSize = sampleInfo.chunkSize)
+        }.getOrThrow()
+
+        assertNull(chunk.spectrogram)
+        assertNull(chunk.power)
+        assertNull(chunk.fundamental)
+    }
+
+    @Test
+    fun testChunkedLoadingMatchesSingleChunk() {
+        val project = createProject()
+        val file = project.rootSampleDirectory.resolve("chunked.wav")
+        TestWav.write(file, durationMs = 3000, sampleRate = 8000)
+
+        // a small max chunk size forces the file to be split into multiple chunks
+        val chunkedConf = AppConf().run { copy(painter = painter.copy(maxDataChunkSize = 8000)) }
+        val chunkedInfo = loadSampleInfo(project, file, chunkedConf)
+        assertEquals(3, chunkedInfo.chunkCount)
+        assertEquals(8000, chunkedInfo.chunkSize)
+
+        val singleConf = AppConf()
+        val singleInfo = loadSampleInfo(project, file, singleConf)
+        assertEquals(1, singleInfo.chunkCount)
+        val fullWave = runBlocking {
+            loadSampleChunk(project, singleInfo, singleConf, chunkIndex = 0, chunkSize = singleInfo.chunkSize)
+        }.getOrThrow().wave
+
+        val chunkWaves = (0 until chunkedInfo.chunkCount).map { index ->
+            runBlocking {
+                loadSampleChunk(
+                    project = project,
+                    sampleInfo = chunkedInfo,
+                    appConf = chunkedConf,
+                    chunkIndex = index,
+                    chunkSize = chunkedInfo.chunkSize,
+                )
+            }.getOrThrow().wave
+        }
+
+        assertEquals(fullWave.length, chunkWaves.sumOf { it.length })
+        val concatenated = chunkWaves.flatMap { it.channels[0].data.toList() }.toFloatArray()
+        assertTrue(fullWave.channels[0].data.contentEquals(concatenated))
+    }
+}

--- a/src/jvmTest/kotlin/model/EntryTest.kt
+++ b/src/jvmTest/kotlin/model/EntryTest.kt
@@ -1,0 +1,75 @@
+package model
+
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Entry
+import testutil.TestLabelers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EntryTest {
+
+    @Test
+    fun `fromDefaultValues uses the labeler's default values`() {
+        // oto-labeler: defaultValues = [100, 400, 300, 200, 100, 500], one extra field with default "500"
+        val entry = Entry.fromDefaultValues("_a_ka.wav", TestLabelers.utauOto)
+        assertEquals("_a_ka.wav", entry.sample)
+        // no defaultEntryName: the sample name without extension is used
+        assertEquals("_a_ka", entry.name)
+        assertEquals(100f, entry.start)
+        assertEquals(500f, entry.end)
+        assertEquals(listOf(400f, 300f, 200f, 100f), entry.points)
+        assertEquals(listOf<String?>("500"), entry.extras)
+        assertTrue(entry.needSync)
+    }
+
+    @Test
+    fun `fromDefaultValues uses the labeler's defaultEntryName when given`() {
+        // nnsvs-singer-labeler: defaultValues = [0, 0], defaultEntryName = "pau", no fields or extras
+        val entry = Entry.fromDefaultValues("doremi.wav", TestLabelers.nnsvsSinger)
+        assertEquals("pau", entry.name)
+        assertEquals(0f, entry.start)
+        assertEquals(0f, entry.end)
+        assertEquals(emptyList(), entry.points)
+        assertEquals(emptyList(), entry.extras)
+        assertTrue(entry.needSync)
+    }
+
+    @Test
+    fun `sample name extension can be hidden by the view configuration`() {
+        val entry = Entry.fromDefaultValues("_a_ka.wav", TestLabelers.utauOto)
+        assertEquals("_a_ka", entry.sampleNameWithoutExtension)
+        assertEquals("_a_ka", entry.getDisplayedSampleName(AppConf.View(hideSampleExtension = true)))
+        assertEquals("_a_ka.wav", entry.getDisplayedSampleName(AppConf.View(hideSampleExtension = false)))
+    }
+
+    @Test
+    fun `note editing helpers only change the corresponding note`() {
+        val entry = Entry.fromDefaultValues("_a_ka.wav", TestLabelers.utauOto)
+
+        val starred = entry.starToggled()
+        assertTrue(starred.notes.star)
+        assertFalse(starred.starToggled().notes.star)
+
+        val done = entry.doneToggled()
+        assertTrue(done.notes.done)
+        assertFalse(done.doneToggled().notes.done)
+        assertTrue(entry.done().notes.done)
+        assertTrue(done.done().notes.done)
+
+        val tagged = entry.tagEdited("tag")
+        assertEquals("tag", tagged.notes.tag)
+        assertEquals(entry, tagged.tagEdited(""))
+    }
+
+    @Test
+    fun `needSyncCompatibly covers entries created by older labelers`() {
+        val entry = Entry.fromDefaultValues("_a_ka.wav", TestLabelers.utauOto)
+        assertTrue(entry.copy(end = 0f, needSync = true).needSyncCompatibly)
+        // negative end is always relative to the sample end, even without the flag
+        assertTrue(entry.copy(end = -100f, needSync = false).needSyncCompatibly)
+        assertFalse(entry.copy(end = 0f, needSync = false).needSyncCompatibly)
+        assertFalse(entry.copy(end = 100f, needSync = true).needSyncCompatibly)
+    }
+}

--- a/src/jvmTest/kotlin/model/LabelerConfTest.kt
+++ b/src/jvmTest/kotlin/model/LabelerConfTest.kt
@@ -1,0 +1,150 @@
+package model
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.LabelerConf
+import com.sdercolin.vlabeler.model.Parameter
+import com.sdercolin.vlabeler.ui.string.toLocalized
+import testutil.TestLabelers
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class LabelerConfTest {
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private val labeler get() = TestLabelers.utauOto
+
+    @Test
+    fun `migrate from serialVersion 0 creates extraFields from the deprecated properties`() {
+        val old = labeler.copy(
+            serialVersion = 0,
+            extraFields = emptyList(),
+            extraFieldNames = listOf("f1", "f2"),
+            defaultExtras = listOf("a", "b"),
+        )
+        val migrated = old.migrate()
+        assertEquals(
+            listOf(
+                LabelerConf.ExtraField(name = "f1", default = "a"),
+                LabelerConf.ExtraField(name = "f2", default = "b"),
+            ),
+            migrated.extraFields,
+        )
+        // the deprecated fields themselves are kept as-is
+        assertEquals(old.extraFieldNames, migrated.extraFieldNames)
+        assertEquals(old.defaultExtras, migrated.defaultExtras)
+    }
+
+    @Test
+    fun `migrate from serialVersion 0 is skipped when the deprecated properties are missing`() {
+        val old = labeler.copy(
+            serialVersion = 0,
+            extraFields = emptyList(),
+            extraFieldNames = listOf("f1"),
+            defaultExtras = null,
+        )
+        assertSame(old, old.migrate())
+    }
+
+    @Test
+    fun `migrate is a no-op for the current serialVersion`() {
+        assertSame(labeler, labeler.migrate())
+    }
+
+    @Test
+    fun `validate passes for a bundled labeler`() {
+        assertSame(labeler, labeler.validate())
+    }
+
+    @Test
+    fun `validate rejects implicit start or end for continuous labelers`() {
+        // the "left" field of the oto-labeler uses replaceStart
+        assertFailsWith<IllegalArgumentException> {
+            labeler.copy(continuous = true).validate()
+        }
+    }
+
+    @Test
+    fun `validate rejects a file reference as string parameter default value`() {
+        val holder = LabelerConf.ParameterHolder(
+            parameter = Parameter.StringParam(
+                name = "param",
+                label = "param".toLocalized(),
+                defaultValue = "file::foo.txt",
+            ),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            labeler.copy(parameters = labeler.parameters + holder).validate()
+        }
+        // a plain default value is accepted
+        val plainHolder = LabelerConf.ParameterHolder(
+            parameter = Parameter.StringParam(
+                name = "param",
+                label = "param".toLocalized(),
+                defaultValue = "foo.txt",
+            ),
+        )
+        labeler.copy(parameters = labeler.parameters + plainHolder).validate()
+    }
+
+    @Test
+    fun `validate rejects quick project builders without an input source`() {
+        // the oto-labeler defines quick project builders and defaultInputFilePath, but no projectConstructor
+        assertFailsWith<IllegalArgumentException> {
+            labeler.copy(defaultInputFilePath = null).validate()
+        }
+    }
+
+    @Test
+    fun `connectedConstraints are built from the field constraints`() {
+        // fixed: min=3; preu: min=3, max=0; ovl: max=0; left: none
+        assertEquals(
+            listOf(3 to 0, 3 to 1, 1 to 0, 2 to 0),
+            labeler.connectedConstraints,
+        )
+    }
+
+    @Test
+    fun `post edit trigger field names are built from the trigger settings`() {
+        // oto-labeler: postEditDoneTrigger uses start, end and the fields with triggerPostEditDone == true;
+        // postEditNextTrigger is not set anywhere
+        assertEquals(listOf("start", "end", "fixed", "preu", "ovl"), labeler.postEditDoneTriggerFieldNames)
+        assertEquals(emptyList(), labeler.postEditNextTriggerFieldNames)
+    }
+
+    @Test
+    fun `implicit start replaces the entry start`() {
+        // the "left" field (index 3) of the oto-labeler uses replaceStart
+        assertTrue(labeler.useImplicitStart)
+        assertFalse(labeler.useImplicitEnd)
+        val entry = Entry(
+            sample = "a.wav",
+            name = "a",
+            start = 100f,
+            end = 500f,
+            points = listOf(400f, 300f, 200f, 150f),
+            extras = listOf("500"),
+        )
+        assertEquals(150f, labeler.getActualStart(entry))
+        assertEquals(500f, labeler.getActualEnd(entry))
+
+        // without replacing fields, start and end are used directly
+        assertEquals(100f, TestLabelers.nnsvsSinger.getActualStart(entry))
+        assertEquals(500f, TestLabelers.nnsvsSinger.getActualEnd(entry))
+    }
+}

--- a/src/jvmTest/kotlin/model/ModuleTest.kt
+++ b/src/jvmTest/kotlin/model/ModuleTest.kt
@@ -1,0 +1,495 @@
+package model
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.LabelerConf
+import com.sdercolin.vlabeler.model.Module
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.SampleInfo
+import com.sdercolin.vlabeler.model.postApplyLabelerConf
+import com.sdercolin.vlabeler.ui.editor.IndexedEntry
+import testutil.TestLabelers
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ModuleTest {
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private val nonContinuousLabeler get() = TestLabelers.utauOto
+    private val continuousLabeler get() = TestLabelers.nnsvsSinger
+
+    private fun entry(
+        sample: String,
+        name: String,
+        start: Float = 0f,
+        end: Float = 100f,
+        points: List<Float> = emptyList(),
+        extras: List<String?> = emptyList(),
+    ) = Entry(sample = sample, name = name, start = start, end = end, points = points, extras = extras)
+
+    private fun module(
+        entries: List<Entry>,
+        currentIndex: Int = 0,
+        name: String = "",
+        rawFilePath: String? = null,
+    ) = Module(
+        name = name,
+        sampleDirectoryPath = "",
+        entries = entries,
+        currentIndex = currentIndex,
+        rawFilePath = rawFilePath,
+    )
+
+    /**
+     * 5 entries in 3 samples: a.wav -> [0, 1], b.wav -> [2, 3], c.wav -> [4].
+     */
+    private val navModule = module(
+        listOf(
+            entry("a.wav", "e0"),
+            entry("a.wav", "e1"),
+            entry("b.wav", "e2"),
+            entry("b.wav", "e3"),
+            entry("c.wav", "e4"),
+        ),
+    )
+
+    /**
+     * 3 continuous entries in a single sample.
+     */
+    private val continuousModule = module(
+        listOf(
+            entry("d.wav", "a", 0f, 100f),
+            entry("d.wav", "b", 100f, 200f),
+            entry("d.wav", "c", 200f, 300f),
+        ),
+    )
+
+    @Test
+    fun `nextEntry and previousEntry move by one and clamp at borders`() {
+        assertEquals(1, navModule.nextEntry().currentIndex)
+        assertEquals(0, navModule.previousEntry().currentIndex)
+        assertEquals(4, navModule.copy(currentIndex = 4).nextEntry().currentIndex)
+        assertEquals(3, navModule.copy(currentIndex = 4).previousEntry().currentIndex)
+    }
+
+    @Test
+    fun `entry navigation skips filtered-out entries`() {
+        val filtered = navModule.copy(filteredEntryIndexes = listOf(0, 2, 4))
+        assertEquals(2, filtered.nextEntry().currentIndex)
+        assertEquals(2, filtered.copy(currentIndex = 4).previousEntry().currentIndex)
+        assertEquals(0, filtered.previousEntry().currentIndex)
+    }
+
+    @Test
+    fun `nextSample moves to the first entry of the next sample`() {
+        assertEquals(2, navModule.nextSample().currentIndex)
+        assertEquals(4, navModule.copy(currentIndex = 2).nextSample().currentIndex)
+        // in the last sample: move to the last entry of the same sample
+        assertEquals(4, navModule.copy(currentIndex = 4).nextSample().currentIndex)
+    }
+
+    @Test
+    fun `previousSample moves to the last entry of the previous sample`() {
+        assertEquals(1, navModule.copy(currentIndex = 3).previousSample().currentIndex)
+        // in the first sample: move to the first entry of the same sample
+        assertEquals(0, navModule.copy(currentIndex = 1).previousSample().currentIndex)
+    }
+
+    @Test
+    fun `updateEntries replaces entries without touching neighbors when not continuous`() {
+        val edited = IndexedEntry(entry("a.wav", "e1-edited", 10f, 90f), 1)
+        val result = navModule.updateEntries(listOf(edited), nonContinuousLabeler)
+        assertEquals(edited.entry, result.entries[1])
+        assertEquals(navModule.entries[0], result.entries[0])
+        assertEquals(navModule.entries[2], result.entries[2])
+    }
+
+    @Test
+    fun `updateEntries adjusts neighbor borders when continuous`() {
+        val edited = IndexedEntry(entry("d.wav", "b", 110f, 190f), 1)
+        val result = continuousModule.updateEntries(listOf(edited), continuousLabeler)
+        assertEquals(110f, result.entries[0].end)
+        assertEquals(edited.entry, result.entries[1])
+        assertEquals(190f, result.entries[2].start)
+    }
+
+    @Test
+    fun `updateCurrentEntry edits the entry at currentIndex`() {
+        val result = continuousModule.copy(currentIndex = 1)
+            .updateCurrentEntry(entry("d.wav", "b2", 120f, 180f), continuousLabeler)
+        assertEquals("b2", result.entries[1].name)
+        assertEquals(120f, result.entries[0].end)
+        assertEquals(180f, result.entries[2].start)
+    }
+
+    @Test
+    fun `renameEntry only changes the name`() {
+        val result = navModule.renameEntry(2, "renamed", nonContinuousLabeler)
+        assertEquals("renamed", result.entries[2].name)
+        assertEquals(navModule.entries[2].copy(name = "renamed"), result.entries[2])
+    }
+
+    @Test
+    fun `updateEntryExtra only changes the extras`() {
+        val original = module(listOf(entry("a.wav", "e0", extras = listOf("500"))))
+        val result = original.updateEntryExtra(0, listOf("600"), nonContinuousLabeler)
+        assertEquals(listOf<String?>("600"), result.entries[0].extras)
+    }
+
+    @Test
+    fun `duplicateEntry inserts a copy after the original`() {
+        val result = navModule.duplicateEntry(1, "e1-copy", nonContinuousLabeler)
+        assertEquals(6, result.entries.size)
+        assertEquals(navModule.entries[1], result.entries[1])
+        assertEquals(navModule.entries[1].copy(name = "e1-copy"), result.entries[2])
+        assertEquals(1, result.currentIndex)
+    }
+
+    @Test
+    fun `duplicateEntry splits the entry at the middle when continuous`() {
+        val result = continuousModule.duplicateEntry(1, "b2", continuousLabeler)
+        assertEquals(4, result.entries.size)
+        assertEquals(150f, result.entries[1].end)
+        assertEquals("b2", result.entries[2].name)
+        assertEquals(150f, result.entries[2].start)
+        assertEquals(200f, result.entries[2].end)
+    }
+
+    @Test
+    fun `removeEntry removes and moves currentIndex to the previous entry`() {
+        val result = navModule.copy(currentIndex = 2).removeEntry(2, nonContinuousLabeler)
+        assertEquals(listOf("e0", "e1", "e3", "e4"), result.entries.map { it.name })
+        assertEquals(1, result.currentIndex)
+        assertEquals(0, navModule.removeEntry(0, nonContinuousLabeler).currentIndex)
+    }
+
+    @Test
+    fun `removeEntry extends the previous entry when continuous`() {
+        val result = continuousModule.removeEntry(1, continuousLabeler)
+        assertEquals(listOf("a", "c"), result.entries.map { it.name })
+        assertEquals(200f, result.entries[0].end)
+        assertEquals(200f, result.entries[1].start)
+    }
+
+    @Test
+    fun `removeEntries removes multiple entries`() {
+        val result = navModule.removeEntries(listOf(0, 2), nonContinuousLabeler)
+        assertEquals(listOf("e1", "e3", "e4"), result.entries.map { it.name })
+    }
+
+    @Test
+    fun `cutEntry splits an entry at the given position`() {
+        val original = module(
+            listOf(entry("a.wav", "orig", 100f, 500f, points = listOf(150f, 450f, 300f, 200f))),
+        )
+        val result = original.cutEntry(0, 300f, rename = "left", newName = "right", targetEntryIndex = 1)
+        assertEquals(2, result.entries.size)
+        assertEquals(1, result.currentIndex)
+
+        val first = result.entries[0]
+        assertEquals("left", first.name)
+        assertEquals(100f, first.start)
+        assertEquals(300f, first.end)
+        assertEquals(listOf(150f, 300f, 300f, 200f), first.points)
+        assertTrue(first.notes.done)
+
+        val second = result.entries[1]
+        assertEquals("right", second.name)
+        assertEquals(300f, second.start)
+        assertEquals(500f, second.end)
+        assertEquals(listOf(300f, 450f, 300f, 300f), second.points)
+        assertTrue(second.notes.done)
+    }
+
+    @Test
+    fun `toggle and batch edit entry notes`() {
+        assertTrue(navModule.toggleEntryDone(0).entries[0].notes.done)
+        assertFalse(navModule.toggleEntryDone(0).toggleEntryDone(0).entries[0].notes.done)
+        assertTrue(navModule.toggleEntryStar(1).entries[1].notes.star)
+        assertEquals("tag", navModule.editEntryTag(2, "tag").entries[2].notes.tag)
+
+        val allDone = navModule.setEntriesDone(listOf(0, 2), done = true)
+        assertEquals(listOf(true, false, true, false, false), allDone.entries.map { it.notes.done })
+
+        val allStarred = navModule.setEntriesStar(listOf(1, 4), star = true)
+        assertEquals(listOf(false, true, false, false, true), allStarred.entries.map { it.notes.star })
+
+        val allTagged = navModule.editEntriesTag(listOf(0, 1), "v")
+        assertEquals(listOf("v", "v", "", "", ""), allTagged.entries.map { it.notes.tag })
+    }
+
+    @Test
+    fun `getEntriesForEditing returns a single entry in single edit mode`() {
+        val result = navModule.copy(currentIndex = 2).getEntriesForEditing(null, multipleEditMode = false)
+        assertEquals(listOf(IndexedEntry(navModule.entries[2], 2)), result)
+
+        val explicit = navModule.getEntriesForEditing(4, multipleEditMode = false)
+        assertEquals(listOf(IndexedEntry(navModule.entries[4], 4)), explicit)
+    }
+
+    @Test
+    fun `getEntriesForEditing returns the whole sample group in multiple edit mode`() {
+        val result = navModule.getEntriesForEditing(2, multipleEditMode = true)
+        assertEquals(
+            listOf(
+                IndexedEntry(navModule.entries[2], 2),
+                IndexedEntry(navModule.entries[3], 3),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `sample and raw file paths are resolved against the root sample directory`() {
+        val root = File("/root/samples")
+        val module = module(
+            listOf(entry("a.wav", "e0")),
+            name = "C4",
+            rawFilePath = File("C4", "oto.ini").path,
+        ).copy(sampleDirectoryPath = "C4")
+        val project = Project(
+            rootSampleDirectoryPath = root.path,
+            workingDirectoryPath = ".",
+            projectName = "test",
+            cacheDirectoryPath = "cache",
+            originalLabelerConf = nonContinuousLabeler,
+            modules = listOf(module),
+            currentModuleIndex = 0,
+            autoExport = false,
+        )
+        val sampleDirectory = root.resolve("C4")
+        assertEquals(sampleDirectory, module.getSampleDirectory(project))
+        assertEquals(sampleDirectory.resolve("a.wav"), module.getSampleFile(project, "a.wav"))
+        assertEquals(sampleDirectory.resolve("a.wav"), module.getCurrentSampleFile(project))
+        assertEquals(sampleDirectory.resolve("oto.ini"), module.getRawFile(project))
+        assertNull(module.copy(rawFilePath = null).getRawFile(project))
+    }
+
+    @Test
+    fun `secondary constructor relativizes absolute paths against the root directory`() {
+        val root = File("/root/samples")
+        val module = Module(
+            rootDirectory = root,
+            name = "C4",
+            sampleDirectory = root.resolve("C4"),
+            entries = listOf(entry("a.wav", "e0")),
+            currentIndex = 0,
+            rawFilePath = root.resolve("C4").resolve("oto.ini"),
+        )
+        assertEquals("C4", module.sampleDirectoryPath)
+        assertEquals(File("C4", "oto.ini").path, module.rawFilePath)
+
+        // relative paths are kept as-is
+        val relative = Module(
+            rootDirectory = root,
+            name = "C4",
+            sampleDirectory = File("C4"),
+            entries = listOf(entry("a.wav", "e0")),
+            currentIndex = 0,
+            rawFilePath = null,
+        )
+        assertEquals("C4", relative.sampleDirectoryPath)
+        assertNull(relative.rawFilePath)
+    }
+
+    @Test
+    fun `isParallelTo requires a shared non-null raw label file`() {
+        val first = module(listOf(entry("a.wav", "e0")), name = "a", rawFilePath = "x.lab")
+        val second = module(listOf(entry("b.wav", "e1")), name = "b", rawFilePath = "x.lab")
+        assertTrue(first.isParallelTo(second))
+        assertFalse(first.isParallelTo(first))
+        assertFalse(
+            first.copy(rawFilePath = null).isParallelTo(second.copy(rawFilePath = null)),
+        )
+    }
+
+    @Test
+    fun `updateOnLoadedSample resolves relative ends of the loaded sample`() {
+        val sampleInfo = SampleInfo(
+            name = "a.wav",
+            file = "a.wav",
+            moduleName = "",
+            sampleRate = 44100f,
+            maxSampleRate = 44100,
+            normalize = false,
+            normalizeRatio = null,
+            channels = 1,
+            length = 44100,
+            lengthMillis = 1000f,
+            chunkSize = 44100,
+            chunkCount = 1,
+            hasSpectrogram = false,
+            hasPower = false,
+            powerChannels = 0,
+            hasFundamental = false,
+            lastModified = 0L,
+            algorithmVersion = 1,
+        )
+        val original = module(
+            listOf(
+                entry("a.wav", "e0", 0f, 0f).copy(needSync = true),
+                entry("a.wav", "e1", 10f, -100f),
+                entry("a.wav", "e2", 0f, 500f),
+                entry("b.wav", "e3", 0f, 0f).copy(needSync = true),
+            ),
+        )
+        val result = original.updateOnLoadedSample(sampleInfo)
+        assertEquals(1000f, result.entries[0].end)
+        assertFalse(result.entries[0].needSync)
+        assertEquals(900f, result.entries[1].end)
+        assertEquals(original.entries[2], result.entries[2])
+        // entries of other samples are not touched
+        assertEquals(original.entries[3], result.entries[3])
+    }
+
+    @Test
+    fun `validate rejects an invalid currentIndex`() {
+        val invalid = module(listOf(entry("a.wav", "e0")), currentIndex = 5)
+        assertFailsWith<IllegalArgumentException> {
+            invalid.validate(multipleEditMode = false, labelerConf = continuousLabeler)
+        }
+    }
+
+    @Test
+    fun `validate rejects multiple edit mode for non-continuous labelers`() {
+        assertFailsWith<IllegalArgumentException> {
+            navModule.validate(multipleEditMode = true, labelerConf = nonContinuousLabeler)
+        }
+    }
+
+    @Test
+    fun `validate rejects non-continuous entries for continuous labelers`() {
+        val broken = module(
+            listOf(
+                entry("d.wav", "a", 0f, 100f),
+                entry("d.wav", "b", 150f, 200f),
+            ),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            broken.validate(multipleEditMode = true, labelerConf = continuousLabeler)
+        }
+        // the continuous case passes
+        continuousModule.validate(multipleEditMode = true, labelerConf = continuousLabeler)
+    }
+
+    @Test
+    fun `validate rejects mismatched points or extras sizes`() {
+        // the labeler requires 4 points and 1 extra
+        val noPoints = module(listOf(entry("a.wav", "e0", extras = listOf("500"))))
+        assertFailsWith<IllegalArgumentException> {
+            noPoints.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        }
+        val noExtras = module(listOf(entry("a.wav", "e0", points = listOf(1f, 2f, 3f, 4f))))
+        assertFailsWith<IllegalArgumentException> {
+            noExtras.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        }
+        val nullExtra = module(
+            listOf(entry("a.wav", "e0", points = listOf(1f, 2f, 3f, 4f), extras = listOf(null))),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            // the extra field of the labeler is not optional
+            nullExtra.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        }
+    }
+
+    @Test
+    fun `validate clamps a negative start to zero`() {
+        val original = module(
+            listOf(entry("a.wav", "e0", -50f, 500f, points = listOf(10f, 20f, 30f, 40f), extras = listOf("500"))),
+        )
+        val result = original.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        assertEquals(0f, result.entries[0].start)
+    }
+
+    @Test
+    fun `validate sets end to start when start is greater than end`() {
+        val original = module(
+            listOf(
+                entry("a.wav", "e0", 200f, 100f, points = listOf(200f, 200f, 200f, 200f), extras = listOf("500")),
+            ),
+        )
+        val result = original.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        assertEquals(200f, result.entries[0].end)
+    }
+
+    @Test
+    fun `validate handles points before start according to overflowBeforeStart`() {
+        val original = module(
+            listOf(entry("a.wav", "e0", 100f, 500f, points = listOf(90f, 400f, 300f, 200f), extras = listOf("500"))),
+        )
+        // the bundled labeler uses AdjustBorder
+        val adjustedBorder = original.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        assertEquals(90f, adjustedBorder.entries[0].start)
+
+        val adjustPointLabeler =
+            nonContinuousLabeler.copy(overflowBeforeStart = LabelerConf.PointOverflow.AdjustPoint)
+        val adjustedPoint = original.validate(multipleEditMode = false, labelerConf = adjustPointLabeler)
+        assertEquals(100f, adjustedPoint.entries[0].start)
+        assertEquals(listOf(100f, 400f, 300f, 200f), adjustedPoint.entries[0].points)
+
+        val errorLabeler = nonContinuousLabeler.copy(overflowBeforeStart = LabelerConf.PointOverflow.Error)
+        assertFailsWith<IllegalArgumentException> {
+            original.validate(multipleEditMode = false, labelerConf = errorLabeler)
+        }
+    }
+
+    @Test
+    fun `validate handles points after end according to overflowAfterEnd`() {
+        val original = module(
+            listOf(entry("a.wav", "e0", 100f, 500f, points = listOf(550f, 400f, 300f, 200f), extras = listOf("500"))),
+        )
+        // the bundled labeler uses AdjustBorder
+        val adjustedBorder = original.validate(multipleEditMode = false, labelerConf = nonContinuousLabeler)
+        assertEquals(550f, adjustedBorder.entries[0].end)
+
+        val adjustPointLabeler = nonContinuousLabeler.copy(overflowAfterEnd = LabelerConf.PointOverflow.AdjustPoint)
+        val adjustedPoint = original.validate(multipleEditMode = false, labelerConf = adjustPointLabeler)
+        assertEquals(500f, adjustedPoint.entries[0].end)
+        assertEquals(listOf(500f, 400f, 300f, 200f), adjustedPoint.entries[0].points)
+
+        val errorLabeler = nonContinuousLabeler.copy(overflowAfterEnd = LabelerConf.PointOverflow.Error)
+        assertFailsWith<IllegalArgumentException> {
+            original.validate(multipleEditMode = false, labelerConf = errorLabeler)
+        }
+    }
+
+    @Test
+    fun `postApplyLabelerConf connects entries for continuous labelers`() {
+        val entries = listOf(
+            entry("d.wav", "a", 0f, 25f),
+            entry("d.wav", "c", 70f, 100f),
+            entry("d.wav", "b", 30f, 70f),
+        )
+        val result = entries.postApplyLabelerConf(continuousLabeler)
+        assertEquals(listOf("a", "b", "c"), result.map { it.name })
+        assertEquals(listOf(30f, 70f, 100f), result.map { it.end })
+    }
+
+    @Test
+    fun `postApplyLabelerConf removes same-name entries when not allowed`() {
+        val entries = listOf(
+            entry("a.wav", "x", 0f, 10f),
+            entry("a.wav", "y", 10f, 20f),
+            entry("b.wav", "x", 0f, 10f),
+        )
+        val result = entries.postApplyLabelerConf(nonContinuousLabeler)
+        assertEquals(listOf("x", "y"), result.map { it.name })
+        assertEquals("a.wav", result[0].sample)
+    }
+}

--- a/src/jvmTest/kotlin/model/ProjectHistoryTest.kt
+++ b/src/jvmTest/kotlin/model/ProjectHistoryTest.kt
@@ -1,0 +1,214 @@
+package model
+
+import androidx.compose.runtime.mutableStateOf
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.ProjectHistory
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProjectHistoryTest {
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private fun history(conf: AppConf = AppConf()) = ProjectHistory(mutableStateOf(conf))
+
+    private fun Project.withTag(tag: String) = updateCurrentModule { editEntryTag(0, tag) }
+
+    private fun Project.withCurrentIndex(index: Int) = updateCurrentModule { copy(currentIndex = index) }
+
+    @Test
+    fun `new initializes the stack`() {
+        val history = history()
+        history.new(baseProject)
+        assertEquals(baseProject, history.current)
+        assertFalse(history.canUndo)
+        assertFalse(history.canRedo)
+    }
+
+    @Test
+    fun `push adds a new state`() {
+        val history = history()
+        history.new(baseProject)
+        val edited = baseProject.withTag("edited")
+        history.push(edited)
+        assertEquals(edited, history.current)
+        assertTrue(history.canUndo)
+        assertFalse(history.canRedo)
+    }
+
+    @Test
+    fun `push deduplicates equal content`() {
+        val history = history()
+        history.new(baseProject)
+        history.push(baseProject.copy())
+        assertEquals(baseProject, history.current)
+        assertFalse(history.canUndo)
+    }
+
+    @Test
+    fun `push squashes index-only changes by default`() {
+        val history = history()
+        history.new(baseProject)
+        history.push(baseProject.withCurrentIndex(1))
+        // with the default `squashIndex == true`, an index-only change is not pushed
+        assertEquals(baseProject, history.current)
+        assertFalse(history.canUndo)
+    }
+
+    @Test
+    fun `push keeps index-only changes when squash is disabled`() {
+        val history = history(AppConf(history = AppConf.History(squashIndex = false)))
+        history.new(baseProject)
+        val indexChanged = baseProject.withCurrentIndex(1)
+        history.push(indexChanged)
+        assertEquals(indexChanged, history.current)
+        assertTrue(history.canUndo)
+    }
+
+    @Test
+    fun `undo and redo move over pushed states`() {
+        val history = history()
+        val first = baseProject.withTag("first")
+        val second = baseProject.withTag("second")
+        history.new(baseProject)
+        history.push(first)
+        history.push(second)
+
+        history.undo()
+        assertEquals(first, history.current)
+        assertTrue(history.canUndo)
+        assertTrue(history.canRedo)
+
+        history.undo()
+        assertEquals(baseProject, history.current)
+        assertFalse(history.canUndo)
+
+        // undo without available history is a no-op
+        history.undo()
+        assertEquals(baseProject, history.current)
+
+        history.redo()
+        assertEquals(first, history.current)
+        history.redo()
+        assertEquals(second, history.current)
+        assertFalse(history.canRedo)
+
+        // redo without available history is a no-op
+        history.redo()
+        assertEquals(second, history.current)
+    }
+
+    @Test
+    fun `push after undo truncates the redo states`() {
+        val history = history()
+        val first = baseProject.withTag("first")
+        val second = baseProject.withTag("second")
+        val third = baseProject.withTag("third")
+        history.new(baseProject)
+        history.push(first)
+        history.push(second)
+        history.undo()
+        history.undo()
+
+        history.push(third)
+        assertEquals(third, history.current)
+        assertFalse(history.canRedo)
+        history.undo()
+        assertEquals(baseProject, history.current)
+        assertFalse(history.canUndo)
+    }
+
+    @Test
+    fun `push evicts the oldest state when max size is reached`() {
+        val history = history(AppConf(history = AppConf.History(maxSize = 2)))
+        val first = baseProject.withTag("first")
+        val second = baseProject.withTag("second")
+        history.new(baseProject)
+        history.push(first)
+        history.push(second)
+
+        assertEquals(second, history.current)
+        history.undo()
+        assertEquals(first, history.current)
+        // the initial state has been evicted
+        assertFalse(history.canUndo)
+    }
+
+    @Test
+    fun `replaceTop replaces the current state without adding`() {
+        val history = history()
+        val first = baseProject.withTag("first")
+        val replaced = baseProject.withTag("replaced")
+        history.new(baseProject)
+        history.push(first)
+
+        history.replaceTop(replaced)
+        assertEquals(replaced, history.current)
+        assertTrue(history.canUndo)
+
+        history.undo()
+        assertEquals(baseProject, history.current)
+        history.redo()
+        assertEquals(replaced, history.current)
+    }
+
+    @Test
+    fun `clear empties the stack`() {
+        val history = history()
+        history.new(baseProject)
+        history.push(baseProject.withTag("first"))
+
+        history.clear()
+        assertFalse(history.canUndo)
+        assertFalse(history.canRedo)
+
+        val next = baseProject.withTag("next")
+        history.new(next)
+        assertEquals(next, history.current)
+        assertFalse(history.canUndo)
+    }
+
+    companion object {
+
+        private val tempDir: File by lazy {
+            createTempDirectory("vlabeler-test").toFile().also { dir ->
+                Runtime.getRuntime().addShutdownHook(Thread { dir.deleteRecursively() })
+            }
+        }
+
+        /**
+         * A real project (oto fixture, 2 entries) created once and shared by all tests, since [Project] is immutable.
+         */
+        private val baseProject: Project by lazy {
+            val sampleDir = TestFixtures.deploy(
+                "oto",
+                tempDir.resolve("oto"),
+                wavFiles = listOf("_a_ka.wav"),
+            )
+            createTestProject(
+                labeler = TestLabelers.utauOto,
+                sampleDirectory = sampleDir,
+                inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+            )
+        }
+    }
+}

--- a/src/jvmTest/kotlin/model/ProjectSerializationTest.kt
+++ b/src/jvmTest/kotlin/model/ProjectSerializationTest.kt
@@ -1,0 +1,81 @@
+package model
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.Parameter
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import com.sdercolin.vlabeler.util.toParamMap
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProjectSerializationTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `project survives a json round trip`() {
+        val sampleDir = TestFixtures.deploy(
+            "utau-singer",
+            tempDir.resolve("utau-singer"),
+            wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+        )
+        val labeler = TestLabelers.utauSinger
+        // use a non-default labeler parameter so that `labelerParams` is stored in the project
+        val labelerParams = (labeler.getDefaultParams() + ("useNegativeOvl" to false)).toParamMap()
+        val project = createTestProject(
+            labeler = labeler,
+            sampleDirectory = sampleDir,
+            labelerParams = labelerParams,
+        )
+
+        val parsed = project.stringifyJson().parseJson<Project>()
+
+        // basic fields
+        assertEquals(project.version, parsed.version)
+        assertEquals(project.rootSampleDirectoryPath, parsed.rootSampleDirectoryPath)
+        assertEquals(project.workingDirectoryPath, parsed.workingDirectoryPath)
+        assertEquals(project.projectName, parsed.projectName)
+        assertEquals(project.cacheDirectoryPath, parsed.cacheDirectoryPath)
+        assertEquals(project.encoding, parsed.encoding)
+        assertEquals(project.multipleEditMode, parsed.multipleEditMode)
+        assertEquals(project.currentModuleIndex, parsed.currentModuleIndex)
+        assertEquals(project.autoExport, parsed.autoExport)
+
+        // modules with all entries survive
+        assertEquals(project.modules, parsed.modules)
+        assertEquals(listOf("A3", "C4"), parsed.modules.map { it.name }.sorted())
+        val entries = parsed.modules.first { it.name == "C4" }.entries
+        assertEquals(project.modules.first { it.name == "C4" }.entries, entries)
+
+        // the non-default labeler parameter survives
+        val storedParam = requireNotNull(requireNotNull(parsed.labelerParams).get("useNegativeOvl"))
+        assertEquals(Parameter.BooleanParam.Type, storedParam.type)
+        assertEquals(false, storedParam.value)
+
+        // the original labeler conf is stored; the transient injected conf falls back to it
+        assertEquals(labeler.name, parsed.originalLabelerConf.name)
+        assertEquals(labeler.version, parsed.originalLabelerConf.version)
+        assertEquals(labeler.fields.map { it.name }, parsed.originalLabelerConf.fields.map { it.name })
+        assertEquals(parsed.originalLabelerConf, parsed.labelerConf)
+    }
+}

--- a/src/jvmTest/kotlin/testutil/TestWaves.kt
+++ b/src/jvmTest/kotlin/testutil/TestWaves.kt
@@ -1,0 +1,29 @@
+package testutil
+
+import com.sdercolin.vlabeler.io.Wave
+import kotlin.math.PI
+import kotlin.math.sin
+
+/**
+ * Builds [Wave] objects in memory for DSP tests. Amplitude values use the same scale as the wave loading code, i.e.
+ * raw 16-bit sample values (up to `Short.MAX_VALUE`).
+ */
+object TestWaves {
+
+    fun sineChannel(
+        frameCount: Int,
+        sampleRate: Float = 44100f,
+        frequency: Double = 440.0,
+        amplitude: Float = Short.MAX_VALUE * 0.5f,
+    ): Wave.Channel {
+        val data = FloatArray(frameCount) { i ->
+            (sin(2 * PI * frequency * i / sampleRate) * amplitude).toFloat()
+        }
+        return Wave.Channel(data)
+    }
+
+    fun silentChannel(frameCount: Int): Wave.Channel = Wave.Channel(FloatArray(frameCount))
+
+    fun invertedChannel(channel: Wave.Channel): Wave.Channel =
+        Wave.Channel(FloatArray(channel.data.size) { i -> -channel.data[i] })
+}

--- a/src/jvmTest/kotlin/util/BigDemicalTest.kt
+++ b/src/jvmTest/kotlin/util/BigDemicalTest.kt
@@ -1,0 +1,38 @@
+package util
+
+import com.sdercolin.vlabeler.util.divideWithBigDecimal
+import com.sdercolin.vlabeler.util.multiplyWithBigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Tests for [multiplyWithBigDecimal] and [divideWithBigDecimal].
+ */
+class BigDemicalTest {
+
+    @Test
+    fun testMultiply() {
+        assertEquals(6f, 2f.multiplyWithBigDecimal(3f))
+        assertEquals(3f, 1.5f.multiplyWithBigDecimal(2f))
+        assertEquals(0f, 0f.multiplyWithBigDecimal(123.45f))
+        assertEquals(-2.5f, 1.25f.multiplyWithBigDecimal(-2f))
+    }
+
+    @Test
+    fun testDivide() {
+        assertEquals(2.5f, 5f.multiplyWithBigDecimal(0.5f))
+        assertEquals(3.5f, 7f.divideWithBigDecimal(2f))
+        assertEquals(0.25f, 1f.divideWithBigDecimal(4f))
+        assertEquals(-1.5f, 3f.divideWithBigDecimal(-2f))
+    }
+
+    @Test
+    fun testDivideWithNonTerminatingExpansionThrows() {
+        // BigDecimal.divide is called without a scale/rounding mode,
+        // so a non-terminating decimal expansion throws.
+        assertFailsWith<ArithmeticException> {
+            1f.divideWithBigDecimal(3f)
+        }
+    }
+}

--- a/src/jvmTest/kotlin/util/ChainCallTest.kt
+++ b/src/jvmTest/kotlin/util/ChainCallTest.kt
@@ -1,0 +1,46 @@
+package util
+
+import com.sdercolin.vlabeler.util.runIf
+import com.sdercolin.vlabeler.util.runIfHave
+import com.sdercolin.vlabeler.util.runIfNotNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests for [runIf], [runIfNotNull] and [runIfHave].
+ */
+class ChainCallTest {
+
+    @Test
+    fun testRunIfWithTrueCondition() {
+        assertEquals(2, 1.runIf(true) { this + 1 })
+    }
+
+    @Test
+    fun testRunIfWithFalseCondition() {
+        assertEquals(1, 1.runIf(false) { this + 1 })
+    }
+
+    @Test
+    fun testRunIfNotNullWithTrueCondition() {
+        assertEquals(2, 1.runIfNotNull(true) { this + 1 })
+        assertNull(1.runIfNotNull(true) { null })
+    }
+
+    @Test
+    fun testRunIfNotNullWithFalseCondition() {
+        assertEquals(1, 1.runIfNotNull(false) { null })
+    }
+
+    @Test
+    fun testRunIfHaveWithParameter() {
+        assertEquals("ab", "a".runIfHave("b") { this + it })
+    }
+
+    @Test
+    fun testRunIfHaveWithoutParameter() {
+        val parameter: String? = null
+        assertEquals("a", "a".runIfHave(parameter) { this + it })
+    }
+}

--- a/src/jvmTest/kotlin/util/CollectionsTest.kt
+++ b/src/jvmTest/kotlin/util/CollectionsTest.kt
@@ -1,0 +1,68 @@
+package util
+
+import com.sdercolin.vlabeler.util.getNextOrNull
+import com.sdercolin.vlabeler.util.getNullableOrElse
+import com.sdercolin.vlabeler.util.getPreviousOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests for [getPreviousOrNull], [getNextOrNull] and [getNullableOrElse].
+ */
+class CollectionsTest {
+
+    private val list = listOf("a", "b", "c")
+
+    @Test
+    fun testGetPreviousOrNullFound() {
+        assertEquals("a", list.getPreviousOrNull { it == "b" })
+        assertEquals("b", list.getPreviousOrNull { it == "c" })
+    }
+
+    @Test
+    fun testGetPreviousOrNullOnFirstItem() {
+        assertNull(list.getPreviousOrNull { it == "a" })
+    }
+
+    @Test
+    fun testGetPreviousOrNullNotFound() {
+        assertNull(list.getPreviousOrNull { it == "d" })
+    }
+
+    @Test
+    fun testGetNextOrNullFound() {
+        assertEquals("b", list.getNextOrNull { it == "a" })
+        assertEquals("c", list.getNextOrNull { it == "b" })
+    }
+
+    @Test
+    fun testGetNextOrNullOnLastItem() {
+        assertNull(list.getNextOrNull { it == "c" })
+    }
+
+    @Test
+    fun testGetNextOrNullNotFound() {
+        // When the predicate matches nothing, `indexOfFirst` returns -1,
+        // so the current implementation returns the item at index 0.
+        assertEquals("a", list.getNextOrNull { it == "d" })
+    }
+
+    @Test
+    fun testGetNullableOrElseWithExistingValue() {
+        val map = mapOf<String, Int?>("a" to 1, "b" to null)
+        assertEquals(1, map.getNullableOrElse("a") { 100 })
+    }
+
+    @Test
+    fun testGetNullableOrElseWithExistingNullValue() {
+        val map = mapOf<String, Int?>("a" to 1, "b" to null)
+        assertNull(map.getNullableOrElse("b") { 100 })
+    }
+
+    @Test
+    fun testGetNullableOrElseWithMissingKey() {
+        val map = mapOf<String, Int?>("a" to 1, "b" to null)
+        assertEquals(100, map.getNullableOrElse("c") { 100 })
+    }
+}

--- a/src/jvmTest/kotlin/util/CollectionsTest.kt
+++ b/src/jvmTest/kotlin/util/CollectionsTest.kt
@@ -43,9 +43,7 @@ class CollectionsTest {
 
     @Test
     fun testGetNextOrNullNotFound() {
-        // When the predicate matches nothing, `indexOfFirst` returns -1,
-        // so the current implementation returns the item at index 0.
-        assertEquals("a", list.getNextOrNull { it == "d" })
+        assertNull(list.getNextOrNull { it == "d" })
     }
 
     @Test

--- a/src/jvmTest/kotlin/util/DateTimeTest.kt
+++ b/src/jvmTest/kotlin/util/DateTimeTest.kt
@@ -1,0 +1,48 @@
+package util
+
+import com.sdercolin.vlabeler.util.getLocalDate
+import com.sdercolin.vlabeler.util.parseIsoTime
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [parseIsoTime] and [getLocalDate].
+ */
+class DateTimeTest {
+
+    @Test
+    fun testParseIsoTimeWithUtcOffset() {
+        // 2022-01-02T03:04:05 UTC
+        val expected = LocalDateTime.of(2022, 1, 2, 3, 4, 5).toInstant(ZoneOffset.UTC).toEpochMilli()
+        assertEquals(expected, parseIsoTime("2022-01-02T03:04:05Z"))
+    }
+
+    @Test
+    fun testParseIsoTimeIgnoresOffset() {
+        // The current implementation parses the value as a LocalDateTime and always
+        // converts it with the UTC offset, so the offset in the input is ignored.
+        assertEquals(
+            parseIsoTime("2022-01-02T03:04:05Z"),
+            parseIsoTime("2022-01-02T03:04:05+09:00"),
+        )
+    }
+
+    @Test
+    fun testGetLocalDate() {
+        val time = 1641092645000L // 2022-01-02T03:04:05Z
+        val expected = LocalDateTime
+            .ofEpochSecond(time / 1000, 0, OffsetDateTime.now().offset)
+            .format(DateTimeFormatter.ISO_LOCAL_DATE)
+        assertEquals(expected, getLocalDate(time))
+    }
+
+    @Test
+    fun testGetLocalDateFormat() {
+        val result = getLocalDate(1641092645000L)
+        assertEquals(true, Regex("""\d{4}-\d{2}-\d{2}""").matches(result))
+    }
+}

--- a/src/jvmTest/kotlin/util/DateTimeTest.kt
+++ b/src/jvmTest/kotlin/util/DateTimeTest.kt
@@ -22,13 +22,11 @@ class DateTimeTest {
     }
 
     @Test
-    fun testParseIsoTimeIgnoresOffset() {
-        // The current implementation parses the value as a LocalDateTime and always
-        // converts it with the UTC offset, so the offset in the input is ignored.
-        assertEquals(
-            parseIsoTime("2022-01-02T03:04:05Z"),
-            parseIsoTime("2022-01-02T03:04:05+09:00"),
-        )
+    fun testParseIsoTimeRespectsOffset() {
+        val expected = LocalDateTime.of(2022, 1, 2, 3, 4, 5)
+            .toInstant(ZoneOffset.ofHours(9))
+            .toEpochMilli()
+        assertEquals(expected, parseIsoTime("2022-01-02T03:04:05+09:00"))
     }
 
     @Test

--- a/src/jvmTest/kotlin/util/ElvisTest.kt
+++ b/src/jvmTest/kotlin/util/ElvisTest.kt
@@ -1,0 +1,23 @@
+package util
+
+import com.sdercolin.vlabeler.util.or
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [or].
+ */
+class ElvisTest {
+
+    @Test
+    fun testOrWithNullReceiver() {
+        val value: String? = null
+        assertEquals("default", value.or("default"))
+    }
+
+    @Test
+    fun testOrWithNonNullReceiver() {
+        val value: String? = "actual"
+        assertEquals("actual", value.or("default"))
+    }
+}

--- a/src/jvmTest/kotlin/util/EncodingTest.kt
+++ b/src/jvmTest/kotlin/util/EncodingTest.kt
@@ -1,0 +1,39 @@
+package util
+
+import com.sdercolin.vlabeler.util.AvailableEncodings
+import com.sdercolin.vlabeler.util.DefaultEncoding
+import com.sdercolin.vlabeler.util.detectEncoding
+import com.sdercolin.vlabeler.util.encodingNameEquals
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [encodingNameEquals], [DefaultEncoding] and [detectEncoding].
+ */
+class EncodingTest {
+
+    @Test
+    fun testEncodingNameEquals() {
+        assertEquals(true, encodingNameEquals("UTF-8", "UTF-8"))
+        assertEquals(true, encodingNameEquals("UTF-8", "utf-8"))
+        assertEquals(true, encodingNameEquals("UTF-8", "UTF_8"))
+        assertEquals(true, encodingNameEquals("UTF-8", "UTF 8"))
+        assertEquals(true, encodingNameEquals("Shift-JIS", "Shift_JIS"))
+        assertEquals(true, encodingNameEquals("shift jis", "Shift-JIS"))
+        assertEquals(false, encodingNameEquals("UTF-8", "UTF-16"))
+        assertEquals(false, encodingNameEquals("Shift-JIS", "EUC-JP"))
+    }
+
+    @Test
+    fun testDefaultEncoding() {
+        assertEquals("UTF-8", DefaultEncoding)
+        assertEquals(DefaultEncoding, AvailableEncodings.first())
+    }
+
+    @Test
+    fun testDetectEncodingUtf8() {
+        val text = "こんにちは、世界。これはテストです。日本語の文章を書いています。"
+        val detected = text.toByteArray(Charsets.UTF_8).detectEncoding()
+        assertEquals("UTF-8", detected)
+    }
+}

--- a/src/jvmTest/kotlin/util/FloatRangeTest.kt
+++ b/src/jvmTest/kotlin/util/FloatRangeTest.kt
@@ -1,0 +1,39 @@
+package util
+
+import com.sdercolin.vlabeler.util.contains
+import com.sdercolin.vlabeler.util.length
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the `contains` operator and [length] of `FloatRange`.
+ */
+class FloatRangeTest {
+
+    @Test
+    fun testContainsOverlappingRange() {
+        assertEquals(true, (1f..5f).contains(3f..7f))
+        assertEquals(true, (1f..5f).contains(0f..2f))
+        assertEquals(true, (1f..5f).contains(2f..3f))
+        assertEquals(true, (1f..5f).contains(0f..10f))
+    }
+
+    @Test
+    fun testContainsTouchingRange() {
+        assertEquals(true, (1f..5f).contains(5f..7f))
+        assertEquals(true, (1f..5f).contains(0f..1f))
+    }
+
+    @Test
+    fun testContainsDisjointRange() {
+        assertEquals(false, (1f..5f).contains(6f..7f))
+        assertEquals(false, (1f..5f).contains(-2f..0f))
+    }
+
+    @Test
+    fun testLength() {
+        assertEquals(4f, (1f..5f).length)
+        assertEquals(0f, (2f..2f).length)
+        assertEquals(3f, (-1.5f..1.5f).length)
+    }
+}

--- a/src/jvmTest/kotlin/util/JsonTest.kt
+++ b/src/jvmTest/kotlin/util/JsonTest.kt
@@ -1,0 +1,69 @@
+package util
+
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [parseJson] and [stringifyJson].
+ */
+class JsonTest {
+
+    @Serializable
+    private data class Item(
+        val name: String,
+        val count: Int = 0,
+        val enabled: Boolean = true,
+    )
+
+    @Test
+    fun testParseJsonPrimitiveList() {
+        assertEquals(listOf(1, 2, 3), "[1, 2, 3]".parseJson())
+    }
+
+    @Test
+    fun testParseJsonMap() {
+        assertEquals(mapOf("a" to "b", "c" to "d"), """{"a": "b", "c": "d"}""".parseJson())
+    }
+
+    @Test
+    fun testParseJsonObject() {
+        val parsed = """{"name": "entry", "count": 5, "enabled": false}""".parseJson<Item>()
+        assertEquals(Item(name = "entry", count = 5, enabled = false), parsed)
+    }
+
+    @Test
+    fun testParseJsonObjectWithDefaults() {
+        val parsed = """{"name": "entry"}""".parseJson<Item>()
+        assertEquals(Item(name = "entry", count = 0, enabled = true), parsed)
+    }
+
+    @Test
+    fun testParseJsonIsLenient() {
+        // The global instance is configured with `isLenient = true`,
+        // so unquoted strings are accepted.
+        val parsed = """{name: entry, count: 5}""".parseJson<Item>()
+        assertEquals(Item(name = "entry", count = 5), parsed)
+    }
+
+    @Test
+    fun testStringifyJsonRoundTrip() {
+        val source = Item(name = "entry", count = 42, enabled = false)
+        assertEquals(source, source.stringifyJson().parseJson())
+    }
+
+    @Test
+    fun testStringifyJsonEncodesDefaultsAndPrettyPrints() {
+        val expected =
+            """
+            {
+                "name": "entry",
+                "count": 0,
+                "enabled": true
+            }
+            """.trimIndent()
+        assertEquals(expected, Item(name = "entry").stringifyJson())
+    }
+}

--- a/src/jvmTest/kotlin/util/MD5Test.kt
+++ b/src/jvmTest/kotlin/util/MD5Test.kt
@@ -1,0 +1,41 @@
+package util
+
+import com.sdercolin.vlabeler.util.calculateMD5
+import kotlin.io.path.createTempFile
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [calculateMD5].
+ */
+class MD5Test {
+
+    @Test
+    fun testKnownContent() {
+        val file = createTempFile(prefix = "md5-test", suffix = ".txt")
+        file.writeText("hello world")
+        val result = calculateMD5(file.toFile())
+        file.toFile().delete()
+        assertEquals("5eb63bbbe01eeed093cb22bb8f5acdc3", result)
+    }
+
+    @Test
+    fun testEmptyFile() {
+        val file = createTempFile(prefix = "md5-test", suffix = ".txt")
+        val result = calculateMD5(file.toFile())
+        file.toFile().delete()
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", result)
+    }
+
+    @Test
+    fun testBinaryContentLargerThanBuffer() {
+        val file = createTempFile(prefix = "md5-test", suffix = ".bin")
+        // 8192 bytes of 0x00: needs multiple reads with the 4096-byte buffer
+        file.writeBytes(ByteArray(8192))
+        val result = calculateMD5(file.toFile())
+        file.toFile().delete()
+        assertEquals("0829f71740aab1ab98b33eae21dee122", result)
+    }
+}

--- a/src/jvmTest/kotlin/util/MathTest.kt
+++ b/src/jvmTest/kotlin/util/MathTest.kt
@@ -29,6 +29,8 @@ class MathTest {
         assertEquals(1.24, 1.236.roundToDecimalDigit(2))
         assertEquals(1.2, 1.234.roundToDecimalDigit(1))
         assertEquals(1.0, 1.234.roundToDecimalDigit(0))
+        // values whose scaled representation exceeds the Float precision (2^24) must not lose precision
+        assertEquals(200000.01, 200000.011.roundToDecimalDigit(2))
     }
 
     @Test

--- a/src/jvmTest/kotlin/util/MathTest.kt
+++ b/src/jvmTest/kotlin/util/MathTest.kt
@@ -1,0 +1,38 @@
+package util
+
+import com.sdercolin.vlabeler.util.roundToDecimalDigit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [roundToDecimalDigit].
+ */
+class MathTest {
+
+    @Test
+    fun testFloatRoundToDecimalDigit() {
+        assertEquals(1.23f, 1.234f.roundToDecimalDigit(2))
+        assertEquals(1.24f, 1.236f.roundToDecimalDigit(2))
+        assertEquals(1.2f, 1.234f.roundToDecimalDigit(1))
+        assertEquals(1f, 1.234f.roundToDecimalDigit(0))
+        assertEquals(5f, 5f.roundToDecimalDigit(3))
+    }
+
+    @Test
+    fun testFloatRoundToDecimalDigitWithNull() {
+        assertEquals(1.234f, 1.234f.roundToDecimalDigit(null))
+    }
+
+    @Test
+    fun testDoubleRoundToDecimalDigit() {
+        assertEquals(1.23, 1.234.roundToDecimalDigit(2))
+        assertEquals(1.24, 1.236.roundToDecimalDigit(2))
+        assertEquals(1.2, 1.234.roundToDecimalDigit(1))
+        assertEquals(1.0, 1.234.roundToDecimalDigit(0))
+    }
+
+    @Test
+    fun testDoubleRoundToDecimalDigitWithNull() {
+        assertEquals(1.234, 1.234.roundToDecimalDigit(null))
+    }
+}

--- a/src/jvmTest/kotlin/util/ParamTypedMapTest.kt
+++ b/src/jvmTest/kotlin/util/ParamTypedMapTest.kt
@@ -1,0 +1,134 @@
+package util
+
+import com.sdercolin.vlabeler.model.FileWithEncoding
+import com.sdercolin.vlabeler.model.Parameter
+import com.sdercolin.vlabeler.util.ParamTypedMap
+import com.sdercolin.vlabeler.util.ParamTypedMap.TypedValue
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.resolve
+import com.sdercolin.vlabeler.util.stringifyJson
+import com.sdercolin.vlabeler.util.toParamMap
+import com.sdercolin.vlabeler.util.toParamTypedMap
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import testutil.TestLabelers
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ParamTypedMapTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setup() {
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        tempDir.deleteRecursively()
+    }
+
+    private val labeler get() = TestLabelers.utauOto
+
+    @Test
+    fun `from returns null for a null or all-default param map`() {
+        assertNull(ParamTypedMap.from(null, labeler.parameterDefs))
+        assertNull(ParamTypedMap.from(labeler.getDefaultParams(), labeler.parameterDefs))
+    }
+
+    @Test
+    fun `from keeps only the values different from the defaults`() {
+        // the default value of "useNegativeOvl" is true, of "dragBase" is "Preutterance"
+        val params = (labeler.getDefaultParams() + ("useNegativeOvl" to false)).toParamMap()
+        val typed = requireNotNull(ParamTypedMap.from(params, labeler.parameterDefs))
+        val stored = requireNotNull(typed.get("useNegativeOvl"))
+        assertEquals(Parameter.BooleanParam.Type, stored.type)
+        assertEquals(false, stored.value)
+        assertNull(typed.get("dragBase"))
+    }
+
+    @Test
+    fun `resolve fills all missing parameters with default values`() {
+        val params = (labeler.getDefaultParams() + ("useNegativeOvl" to false)).toParamMap()
+        val typed = ParamTypedMap.from(params, labeler.parameterDefs)
+        val resolved = typed.resolve(labeler)
+        assertEquals(labeler.parameterDefs.size, resolved.size)
+        assertEquals(false, resolved["useNegativeOvl"])
+        assertEquals("Preutterance", resolved["dragBase"])
+    }
+
+    @Test
+    fun `resolve on null gives all default values`() {
+        assertEquals(labeler.getDefaultParams(), (null as ParamTypedMap?).resolve(labeler))
+    }
+
+    @Test
+    fun `typed values survive a json round trip`() {
+        val typed = mapOf(
+            "int" to TypedValue(Parameter.IntParam.Type, 42),
+            "float" to TypedValue(Parameter.FloatParam.Type, 1.5f),
+            "boolean" to TypedValue(Parameter.BooleanParam.Type, true),
+            "string" to TypedValue(Parameter.StringParam.Type, "hello"),
+            "enum" to TypedValue(Parameter.EnumParam.Type, "option1"),
+        ).toParamTypedMap()
+
+        val parsed = typed.stringifyJson().parseJson<ParamTypedMap>()
+
+        assertEquals(42, parsed.get("int")?.value)
+        assertEquals(1.5f, parsed.get("float")?.value)
+        assertEquals(true, parsed.get("boolean")?.value)
+        assertEquals("hello", parsed.get("string")?.value)
+        assertEquals("option1", parsed.get("enum")?.value)
+        assertEquals(Parameter.IntParam.Type, parsed.get("int")?.type)
+        assertEquals(Parameter.EnumParam.Type, parsed.get("enum")?.type)
+    }
+
+    @Test
+    fun `stripFilePaths masks file parameters only`() {
+        val typed = mapOf(
+            "file" to TypedValue(Parameter.FileParam.Type, FileWithEncoding("/some/path", "UTF-8")),
+            "rawFile" to TypedValue(Parameter.RawFileParam.Type, "/some/other/path"),
+            "string" to TypedValue(Parameter.StringParam.Type, "keep"),
+        ).toParamTypedMap()
+
+        val stripped = typed.stripFilePaths()
+        assertEquals(FileWithEncoding("*", null), stripped.get("file")?.value)
+        assertEquals("*", stripped.get("rawFile")?.value)
+        assertEquals("keep", stripped.get("string")?.value)
+    }
+
+    @Test
+    fun `ParamMap resolves primitive values to json`() {
+        val paramMap = mapOf(
+            "int" to 1,
+            "float" to 2.5f,
+            "boolean" to true,
+            "string" to "x",
+        ).toParamMap()
+
+        val resolved = paramMap.resolve(project = null, js = null)
+        assertEquals(JsonPrimitive(1), resolved["int"])
+        assertEquals(JsonPrimitive(2.5f), resolved["float"])
+        assertEquals(JsonPrimitive(true), resolved["boolean"])
+        assertEquals(JsonPrimitive("x"), resolved["string"])
+    }
+
+    @Test
+    fun `ParamMap resolves a file with encoding to its text content`() {
+        val file = tempDir.resolve("content.txt").apply { writeText("hello world") }
+        val paramMap = mapOf(
+            "existing" to FileWithEncoding(file.absolutePath, "UTF-8"),
+            "missing" to FileWithEncoding(null, null),
+        ).toParamMap()
+
+        val resolved = paramMap.resolve(project = null, js = null)
+        assertEquals(JsonPrimitive("hello world"), resolved["existing"])
+        assertEquals(JsonNull, resolved["missing"])
+    }
+}

--- a/src/jvmTest/kotlin/util/PathTest.kt
+++ b/src/jvmTest/kotlin/util/PathTest.kt
@@ -1,0 +1,94 @@
+package util
+
+import com.sdercolin.vlabeler.env.isWindows
+import com.sdercolin.vlabeler.util.HomeDir
+import com.sdercolin.vlabeler.util.asPathRelativeToHome
+import com.sdercolin.vlabeler.util.asSimplifiedPaths
+import com.sdercolin.vlabeler.util.isValidFileName
+import com.sdercolin.vlabeler.util.lastPathSection
+import com.sdercolin.vlabeler.util.pathSections
+import com.sdercolin.vlabeler.util.resolveHome
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * Tests for pure path utilities in `Path.kt`.
+ */
+class PathTest {
+
+    @Test
+    fun testPathSections() {
+        assertContentEquals(listOf("a", "b", "c"), "a/b/c".pathSections)
+        assertContentEquals(listOf("a", "b", "c"), "a\\b\\c".pathSections)
+        assertContentEquals(listOf("a", "b", "c"), "/a/b/c/".pathSections)
+        assertContentEquals(listOf("a", "b", "c.wav"), "a\\b/c.wav".pathSections)
+        assertContentEquals(listOf("a"), "a".pathSections)
+    }
+
+    @Test
+    fun testLastPathSection() {
+        assertEquals("c.wav", "a/b/c.wav".lastPathSection)
+        assertEquals("c.wav", "a\\b\\c.wav".lastPathSection)
+        assertEquals("a", "a".lastPathSection)
+    }
+
+    @Test
+    fun testIsValidFileName() {
+        assertEquals(true, "file.txt".isValidFileName())
+        assertEquals(true, "日本語 ファイル.wav".isValidFileName())
+        assertEquals(false, "".isValidFileName())
+        assertEquals(false, "   ".isValidFileName())
+        assertEquals(false, "a/b.txt".isValidFileName())
+        assertEquals(false, "a\\b.txt".isValidFileName())
+        assertEquals(false, "a:b".isValidFileName())
+        assertEquals(false, "a*b".isValidFileName())
+        assertEquals(false, "a?b".isValidFileName())
+        assertEquals(false, "a\"b".isValidFileName())
+        assertEquals(false, "a<b>".isValidFileName())
+        assertEquals(false, "a|b".isValidFileName())
+        assertEquals(false, "a\u0000b".isValidFileName())
+        assertEquals(true, "a b".isValidFileName())
+    }
+
+    @Test
+    fun testResolveHome() {
+        val home = HomeDir.absolutePath
+        assertEquals("$home/foo/bar", "~/foo/bar".resolveHome())
+        assertEquals(home, "~".resolveHome())
+        assertEquals("/foo/bar", "/foo/bar".resolveHome())
+    }
+
+    @Test
+    fun testAsPathRelativeToHome() {
+        val home = HomeDir.absolutePath
+        val input = "$home/foo/bar"
+        val expected = if (isWindows) input else "~/foo/bar"
+        assertEquals(expected, input.asPathRelativeToHome())
+        assertEquals("/nonexistent-root/foo", "/nonexistent-root/foo".asPathRelativeToHome())
+    }
+
+    @Test
+    fun testAsSimplifiedPathsAllDistinct() {
+        val paths = listOf("a/b/c.wav", "d/e/f.wav")
+        assertContentEquals(listOf("c.wav", "f.wav"), paths.asSimplifiedPaths())
+    }
+
+    @Test
+    fun testAsSimplifiedPathsWithDuplicatedFileNames() {
+        val paths = listOf("root/a/x.wav", "root/b/x.wav")
+        assertContentEquals(listOf(".../a/x.wav", ".../b/x.wav"), paths.asSimplifiedPaths())
+    }
+
+    @Test
+    fun testAsSimplifiedPathsWithDuplicatedFileNamesAtRoot() {
+        val paths = listOf("a/x.wav", "b/x.wav")
+        assertContentEquals(listOf("a/x.wav", "b/x.wav"), paths.asSimplifiedPaths())
+    }
+
+    @Test
+    fun testAsSimplifiedPathsWithTwoDuplicatedLevels() {
+        val paths = listOf("a/b/x.wav", "c/b/x.wav")
+        assertContentEquals(listOf("a/b/x.wav", "c/b/x.wav"), paths.asSimplifiedPaths())
+    }
+}

--- a/src/jvmTest/kotlin/util/ThrowableTest.kt
+++ b/src/jvmTest/kotlin/util/ThrowableTest.kt
@@ -1,0 +1,46 @@
+package util
+
+import com.sdercolin.vlabeler.exception.LocalizedException
+import com.sdercolin.vlabeler.ui.string.Language
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.ui.string.stringCertain
+import com.sdercolin.vlabeler.util.getLocalizedMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [getLocalizedMessage].
+ */
+class ThrowableTest {
+
+    private class TestLocalizedException(cause: Throwable? = null) :
+        LocalizedException(Strings.CommonOkay, cause)
+
+    @Test
+    fun testPlainThrowable() {
+        val throwable = Exception("boom")
+        assertEquals(throwable.toString(), throwable.getLocalizedMessage(Language.English))
+    }
+
+    @Test
+    fun testPlainThrowableWithPlainCause() {
+        // A non-localized cause is not appended
+        val throwable = Exception("boom", Exception("cause"))
+        assertEquals(throwable.toString(), throwable.getLocalizedMessage(Language.English))
+    }
+
+    @Test
+    fun testLocalizedException() {
+        val throwable = TestLocalizedException()
+        val expected = stringCertain(Strings.CommonOkay, Language.English)
+        assertEquals(expected, throwable.getLocalizedMessage(Language.English))
+    }
+
+    @Test
+    fun testPlainThrowableWithLocalizedCause() {
+        val cause = TestLocalizedException()
+        val throwable = Exception("boom", cause)
+        val expected = "$throwable\n\nCaused by:\n${stringCertain(Strings.CommonOkay, Language.English)}"
+        assertEquals(expected, throwable.getLocalizedMessage(Language.English))
+    }
+}

--- a/src/jvmTest/kotlin/util/TimeTest.kt
+++ b/src/jvmTest/kotlin/util/TimeTest.kt
@@ -1,0 +1,34 @@
+package util
+
+import com.sdercolin.vlabeler.util.toFrame
+import com.sdercolin.vlabeler.util.toMillisecond
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [toFrame] and [toMillisecond]. See `env.TimeTest` for `getTimeText`.
+ */
+class TimeTest {
+
+    @Test
+    fun testToFrame() {
+        assertEquals(44100f, toFrame(1000f, 44100f))
+        assertEquals(22050f, toFrame(500f, 44100f))
+        assertEquals(48f, toFrame(1f, 48000f))
+        assertEquals(0f, toFrame(0f, 44100f))
+    }
+
+    @Test
+    fun testToMillisecond() {
+        assertEquals(1000f, toMillisecond(44100f, 44100f))
+        assertEquals(500f, toMillisecond(22050f, 44100f))
+        assertEquals(1f, toMillisecond(48f, 48000f))
+        assertEquals(0f, toMillisecond(0f, 44100f))
+    }
+
+    @Test
+    fun testRoundTrip() {
+        val millis = 1234.5f
+        assertEquals(millis, toMillisecond(toFrame(millis, 44100f), 44100f))
+    }
+}

--- a/src/jvmTest/kotlin/util/UrlTest.kt
+++ b/src/jvmTest/kotlin/util/UrlTest.kt
@@ -1,0 +1,30 @@
+package util
+
+import com.sdercolin.vlabeler.util.Url
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the constants in [Url].
+ */
+class UrlTest {
+
+    @Test
+    fun testAllUrlsAreValidAbsoluteHttpsUris() {
+        val urls = listOf(
+            Url.HOME_PAGE,
+            Url.PROJECT_GIT_HUB,
+            Url.LATEST_RELEASE,
+            Url.DISCORD_INVITATION,
+            Url.GITHUB_API_ROOT,
+            Url.TRACKING_DOCUMENT,
+            Url.ENTRY_SELECTOR_SCRIPT_DOCUMENT,
+        )
+        for (url in urls) {
+            val uri = URI(url)
+            assertEquals(true, uri.isAbsolute, "Not absolute: $url")
+            assertEquals("https", uri.scheme, "Not https: $url")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the automated-tests effort (#92): 198 new unit tests (321 total, all passing), covering:

### io (my priority focus)
- `RawLabelsTest` — oto parsing edge cases (blank/invalid lines, empty name/field fallbacks) and **exact write round-trips** through the real labeler scripts for `utau-singer` and `nnsvs-singer`
- `ReloadLabelTest` — label file reloading with edit/add/remove diff classification and note-inheritance merging (`mergeEntryLists`)
- `ProjectBackupTest` — backup creation, dedup, rotation, disable
- `WaveLoadingTest`, `AudioFormatTest`, `PowerTest`, `SpectrogramTest`, `FundamentalTest`, `SampleListTest` — wave decoding/chunking and DSP numeric verification against generated sine waves (energy at expected frequency bin, SWIPE′ pitch detection of 220/440 Hz, −3 dB full-scale sine)

### model
- `ModuleTest` (32 tests) — entry editing/navigation/validation incl. continuous-labeler border syncing, `cutEntry`, `PointOverflow` modes
- `ProjectHistoryTest` — undo/redo stack semantics incl. squash-index and max-size eviction
- `LabelerConfTest` — `migrate()`/`validate()` rules; `ProjectSerializationTest` — full project JSON round trip; `EntryTest`, `ParamTypedMapTest`

### util
- 14 files covering the previously untested pure-logic helpers

### Production bug fixes

Three bugs surfaced by the new tests are fixed in this PR (usages traced to confirm safety; details in commit 8087ec3a):
1. `DateTime.parseIsoTime` ignored the timezone offset in the input string (only caller: update-dialog release dates, which GitHub serves as UTC `Z`, so no visible change)
2. `Collections.getNextOrNull` returned the first element instead of null when nothing matches (the no-match branch is unreachable from the current marker-code call sites)
3. `Math.Double.roundToDecimalDigit` lost precision via a Float round-trip for values beyond ~2.8 minutes at 2 decimal digits (label-file property writing)

The corresponding tests now assert the corrected behavior, with a new large-value regression case for the Double rounding. Also adds docs/testing.md and a Testing section in CLAUDE.md.

## Test plan

- [x] `./gradlew jvmTest --rerun-tasks` — 321 tests, 0 failures
- [x] `./gradlew ktlintCheck koverXmlReport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

