### PR TITLE
Phase 4: UI tests — state holders and Compose UI tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Full guide: `docs/testing.md`. Keep both that file and this section updated when
 
 - Tests use kotlin.test on JUnit Platform, under `src/jvmTest/kotlin`, in short packages mirroring the production area (`io`, `model`, `util`, `plugins`, ...). Coverage via Kover (`./gradlew koverHtmlReport`).
 - All bundled labelers and plugins have integration tests (`fixtures/`, `plugins/`) that execute their real JS scripts — when changing a bundled labeler/plugin, update its test in the same PR.
+- Compose UI tests use `runComposeUiTest` (headless via Skiko, works on CI); state holders like `ProjectStore` are tested without rendering. See the "Compose UI tests" section of `docs/testing.md` for desktop-specific gotchas.
 - Shared helpers in `src/jvmTest/kotlin/testutil/`: `TestLabelers` (loads real bundled labelers — the test task points `compose.application.resources.dir` at `resources/common`), `TestFixtures.deploy(...)` (copies a fixture project from `src/jvmTest/resources/fixtures/` and generates wav files at runtime — no binaries in git), `createTestProject(...)` (runs the real `projectOf` flow incl. JS scripts), `TestEnv.ensureLogDirectory()` (required before code that constructs `util.JavaScript()` with defaults; the log dir only exists where the app has run — missing on CI).
 - Set `Log.muted = true`/`false` in setup/teardown when tested code logs.
 - If a test reveals a suspected production bug, pin the current behavior with a comment and raise the bug for discussion instead of silently changing behavior.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.0")
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
             }
         }
     }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,7 @@ mirroring the production area rather than full package paths:
 | `io/` | Label parsing/writing, reloading, project files/lifecycle, wave loading, DSP (power/spectrogram/fundamental) |
 | `model/` | Domain model: `Module`, `ProjectHistory`, `LabelerConf`, `Entry`, serialization |
 | `plugins/` | Integration tests executing all bundled template and macro plugins through the real plugin runner |
+| `ui/` | State-holder tests (`ProjectStore`, app states) and Compose UI tests (`*UiTest`) for common components |
 | `util/` | Pure helper functions |
 | `env/`, `strings/` | Environment and localization helpers |
 | `fixtures/` | Smoke tests creating projects from the fixture data with the bundled labelers |
@@ -79,6 +80,25 @@ Plugin tests load the bundled plugins through the real `loadPlugins(type, langua
 project and captures plugin reports via `MacroPluginExecutionListener`). Tests assert exact output entries; when
 adding or changing a bundled plugin, add or update its test accordingly.
 
+### Compose UI tests
+
+UI tests use the JUnit-independent `runComposeUiTest` (`androidx.compose.ui.test`, opt-in `ExperimentalTestApi`) from
+the `compose.uiTest` dependency. It renders offscreen through Skiko, so it works on the JUnit 5 platform and on
+headless CI machines without a display. See `ui/ComposeUiTestSmokeTest.kt` for the base pattern
+(`runComposeUiTest { setContent { AppTheme { ... } } }`) and the `ui/*UiTest.kt` classes for component examples.
+Notes:
+
+- A `Modifier.testTag` on a component wrapper usually lands on a `Box`, not the interactive descendant — find
+  interactive nodes with matchers such as `hasSetTextAction()` or `hasClickAction()`.
+- On desktop, a disabled `BasicTextField` still exposes `SetText` semantics (unlike Android) — assert with
+  `isNotEnabled()` instead of action absence.
+- `string(Strings.X)` resolves without extra setup (`LocalLanguage` defaults to English).
+- "Cannot find font family Default" log lines in headless runs are benign.
+
+State-holder classes (`ui/ProjectStore.kt`, `AppErrorState`, dialog states, ...) are plain classes over Compose
+`mutableStateOf` and are tested without rendering — see `ui/ProjectStoreTest.kt`, which drives the real
+implementations against fixture projects.
+
 ### Environment gotchas
 
 - **Logging**: set `Log.muted = true` in `@BeforeTest` and back to `false` in `@AfterTest` when the tested code logs.
@@ -106,7 +126,9 @@ The test effort is tracked on the `feature/automated-tests` branch (sub-parts ar
 2. ✅ **Phase 2 — unit tests**: `io` (raw labels round-trips, reload, backups, wave/DSP), `model`, `util`
 3. ✅ **Phase 3 — integration tests**: all bundled template/macro plugins, full project lifecycle
    (create → save → load → edit → export → reload)
-4. **Phase 4 — UI tests**: state holders (`ProjectStore`, dialog states) and Compose UI tests (`runComposeUiTest`)
+4. ✅ **Phase 4 — UI tests**: state holders (`ProjectStore`, app states) and Compose UI tests for common
+   components and a standalone dialog. Not covered yet: the editor canvas/marker UI, dialogs requiring a full
+   `AppState`, and full-application flows.
 5. **Phase 5 — CI polish**: split unit/integration steps, coverage thresholds
 
 When adding tests in a new phase, keep this document and the Testing section of `CLAUDE.md` up to date.

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/SavedMutableState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/util/SavedMutableState.kt
@@ -20,8 +20,8 @@ class SavedMutableState<T>(initial: T, private val save: (T) -> Unit) : MutableS
             save(value)
         }
 
-    override fun component1() = state.component1()
-    override fun component2() = state.component2()
+    override fun component1(): T = value
+    override fun component2(): (T) -> Unit = { value = it }
 }
 
 /**

--- a/src/jvmTest/kotlin/ui/AppErrorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/AppErrorStateTest.kt
@@ -1,0 +1,70 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.ui.AppErrorState
+import com.sdercolin.vlabeler.ui.AppErrorStateImpl
+import testutil.TestEnv
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class AppErrorStateTest {
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    @Test
+    fun `initial state has no error`() {
+        val state = AppErrorStateImpl()
+        assertNull(state.error)
+        assertNull(state.errorPendingAction)
+    }
+
+    @Test
+    fun `showError sets the error without pending action`() {
+        val state = AppErrorStateImpl()
+        val error = IllegalStateException("test")
+        state.showError(error)
+        assertSame(error, state.error)
+        assertNull(state.errorPendingAction)
+    }
+
+    @Test
+    fun `showError sets the error with pending action`() {
+        val state = AppErrorStateImpl()
+        val error = IllegalStateException("test")
+        state.showError(error, AppErrorState.ErrorPendingAction.Exit)
+        assertSame(error, state.error)
+        assertEquals(AppErrorState.ErrorPendingAction.Exit, state.errorPendingAction)
+    }
+
+    @Test
+    fun `showError overwrites the previous error`() {
+        val state = AppErrorStateImpl()
+        state.showError(IllegalStateException("first"), AppErrorState.ErrorPendingAction.Exit)
+        val second = IllegalArgumentException("second")
+        state.showError(second)
+        assertSame(second, state.error)
+        assertNull(state.errorPendingAction)
+    }
+
+    @Test
+    fun `clearError resets the state`() {
+        val state = AppErrorStateImpl()
+        state.showError(IllegalStateException("test"), AppErrorState.ErrorPendingAction.ExitProject)
+        state.clearError()
+        assertNull(state.error)
+        assertNull(state.errorPendingAction)
+    }
+}

--- a/src/jvmTest/kotlin/ui/AppProgressStateTest.kt
+++ b/src/jvmTest/kotlin/ui/AppProgressStateTest.kt
@@ -1,0 +1,37 @@
+package ui
+
+import com.sdercolin.vlabeler.ui.AppProgressStateImpl
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppProgressStateTest {
+
+    @Test
+    fun `initial state is not busy`() {
+        val state = AppProgressStateImpl()
+        assertFalse(state.isBusy)
+    }
+
+    @Test
+    fun `showProgress sets busy`() {
+        val state = AppProgressStateImpl()
+        state.showProgress()
+        assertTrue(state.isBusy)
+    }
+
+    @Test
+    fun `hideProgress resets busy`() {
+        val state = AppProgressStateImpl()
+        state.showProgress()
+        state.hideProgress()
+        assertFalse(state.isBusy)
+    }
+
+    @Test
+    fun `hideProgress without showProgress keeps not busy`() {
+        val state = AppProgressStateImpl()
+        state.hideProgress()
+        assertFalse(state.isBusy)
+    }
+}

--- a/src/jvmTest/kotlin/ui/AppSnackbarStateTest.kt
+++ b/src/jvmTest/kotlin/ui/AppSnackbarStateTest.kt
@@ -1,0 +1,84 @@
+package ui
+
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.SnackbarHostState
+import com.sdercolin.vlabeler.ui.AppSnackbarStateImpl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppSnackbarStateTest {
+
+    @Test
+    fun `showSnackbar exposes the message via the host state`() = runTest {
+        val hostState = SnackbarHostState()
+        val state = AppSnackbarStateImpl(hostState)
+
+        var finished = false
+        val job = launch {
+            state.showSnackbar("hello", actionLabel = "OK", duration = SnackbarDuration.Short)
+            finished = true
+        }
+        advanceUntilIdle()
+
+        val data = assertNotNull(hostState.currentSnackbarData)
+        assertEquals("hello", data.message)
+        assertEquals("OK", data.actionLabel)
+        assertEquals(SnackbarDuration.Short, data.duration)
+        assertFalse(finished)
+
+        data.dismiss()
+        advanceUntilIdle()
+        assertTrue(finished)
+        assertNull(hostState.currentSnackbarData)
+        job.join()
+    }
+
+    @Test
+    fun `showSnackbar completes when the action is performed`() = runTest {
+        val hostState = SnackbarHostState()
+        val state = AppSnackbarStateImpl(hostState)
+
+        var finished = false
+        val job = launch {
+            state.showSnackbar("message", actionLabel = "Retry")
+            finished = true
+        }
+        advanceUntilIdle()
+
+        assertNotNull(hostState.currentSnackbarData).performAction()
+        advanceUntilIdle()
+        assertTrue(finished)
+        assertNull(hostState.currentSnackbarData)
+        job.join()
+    }
+
+    @Test
+    fun `showSnackbar queues messages until the current one is dismissed`() = runTest {
+        val hostState = SnackbarHostState()
+        val state = AppSnackbarStateImpl(hostState)
+
+        val first = launch { state.showSnackbar("first") }
+        val second = launch { state.showSnackbar("second") }
+        advanceUntilIdle()
+
+        assertEquals("first", assertNotNull(hostState.currentSnackbarData).message)
+        assertNotNull(hostState.currentSnackbarData).dismiss()
+        advanceUntilIdle()
+
+        assertEquals("second", assertNotNull(hostState.currentSnackbarData).message)
+        assertNotNull(hostState.currentSnackbarData).dismiss()
+        advanceUntilIdle()
+        assertNull(hostState.currentSnackbarData)
+        first.join()
+        second.join()
+    }
+}

--- a/src/jvmTest/kotlin/ui/AppUnsavedChangesStateTest.kt
+++ b/src/jvmTest/kotlin/ui/AppUnsavedChangesStateTest.kt
@@ -1,0 +1,74 @@
+package ui
+
+import com.sdercolin.vlabeler.ui.AppUnsavedChangesStateImpl
+import com.sdercolin.vlabeler.ui.ProjectWriteStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppUnsavedChangesStateTest {
+
+    @Test
+    fun `initial state is updated without unsaved changes`() {
+        val state = AppUnsavedChangesStateImpl()
+        assertEquals(ProjectWriteStatus.Updated, state.projectWriteStatus)
+        assertFalse(state.hasUnsavedChanges)
+        assertFalse(state.hasLoadedAutoSavedProject)
+    }
+
+    @Test
+    fun `projectContentChanged marks unsaved changes`() {
+        val state = AppUnsavedChangesStateImpl()
+        state.projectContentChanged()
+        assertEquals(ProjectWriteStatus.Changed, state.projectWriteStatus)
+        assertTrue(state.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `requestProjectSave sets update requested`() {
+        val state = AppUnsavedChangesStateImpl()
+        state.projectContentChanged()
+        state.requestProjectSave()
+        assertEquals(ProjectWriteStatus.UpdateRequested, state.projectWriteStatus)
+        // only `Changed` counts as unsaved changes
+        assertFalse(state.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `projectSaved resets the status and the auto-saved flag`() {
+        val state = AppUnsavedChangesStateImpl()
+        state.hasLoadedAutoSavedProject = true
+        state.projectContentChanged()
+        state.projectSaved()
+        assertEquals(ProjectWriteStatus.Updated, state.projectWriteStatus)
+        assertFalse(state.hasUnsavedChanges)
+        assertFalse(state.hasLoadedAutoSavedProject)
+    }
+
+    @Test
+    fun `projectPathChanged keeps updated status for a normal project`() {
+        val state = AppUnsavedChangesStateImpl()
+        state.projectPathChanged()
+        assertEquals(ProjectWriteStatus.Updated, state.projectWriteStatus)
+        assertFalse(state.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `projectPathChanged marks changed for a loaded auto-saved project`() {
+        val state = AppUnsavedChangesStateImpl()
+        state.hasLoadedAutoSavedProject = true
+        state.projectPathChanged()
+        assertEquals(ProjectWriteStatus.Changed, state.projectWriteStatus)
+        assertTrue(state.hasUnsavedChanges)
+    }
+
+    @Test
+    fun `projectClosed resets the status`() {
+        val state = AppUnsavedChangesStateImpl()
+        state.projectContentChanged()
+        state.projectClosed()
+        assertEquals(ProjectWriteStatus.Updated, state.projectWriteStatus)
+        assertFalse(state.hasUnsavedChanges)
+    }
+}

--- a/src/jvmTest/kotlin/ui/CancelButtonUiTest.kt
+++ b/src/jvmTest/kotlin/ui/CancelButtonUiTest.kt
@@ -1,0 +1,26 @@
+package ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.CancelButton
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class CancelButtonUiTest {
+
+    @Test
+    fun testLabelAndClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                CancelButton(onClick = { clicks++ })
+            }
+        }
+        onNodeWithText("Cancel").performClick()
+        assertEquals(1, clicks)
+    }
+}

--- a/src/jvmTest/kotlin/ui/CircularProgressUiTest.kt
+++ b/src/jvmTest/kotlin/ui/CircularProgressUiTest.kt
@@ -1,0 +1,60 @@
+package ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.CircularProgress
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class CircularProgressUiTest {
+
+    @Test
+    fun testBlockingOverlayConsumesClicks() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                Box(Modifier.fillMaxSize()) {
+                    Button(
+                        onClick = { clicks++ },
+                        modifier = Modifier.testTag("under").fillMaxSize(),
+                    ) {
+                        Text("Under")
+                    }
+                    CircularProgress(blocking = true)
+                }
+            }
+        }
+        onNodeWithTag("under").performClick()
+        assertEquals(0, clicks)
+    }
+
+    @Test
+    fun testNonBlockingOverlayLetsClicksThrough() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                Box(Modifier.fillMaxSize()) {
+                    Button(
+                        onClick = { clicks++ },
+                        modifier = Modifier.testTag("under").fillMaxSize(),
+                    ) {
+                        Text("Under")
+                    }
+                    CircularProgress(blocking = false)
+                }
+            }
+        }
+        onNodeWithTag("under").performClick()
+        assertEquals(1, clicks)
+    }
+}

--- a/src/jvmTest/kotlin/ui/ClickableTextUiTest.kt
+++ b/src/jvmTest/kotlin/ui/ClickableTextUiTest.kt
@@ -1,0 +1,61 @@
+package ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.PartialClickableText
+import com.sdercolin.vlabeler.ui.common.SingleClickableText
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ClickableTextUiTest {
+
+    @Test
+    fun testSingleClickableTextInvokesOnClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                SingleClickableText(
+                    text = "Click me",
+                    onClick = { clicks++ },
+                )
+            }
+        }
+        onNodeWithText("Click me").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun testDisabledSingleClickableTextIgnoresClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                SingleClickableText(
+                    text = "Click me",
+                    onClick = { clicks++ },
+                    enabled = false,
+                )
+            }
+        }
+        onNodeWithText("Click me").performClick()
+        assertEquals(0, clicks)
+    }
+
+    @Test
+    fun testPartialClickableTextInvokesAnnotatedCallback() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                PartialClickableText(
+                    text = "open settings",
+                    clickables = listOf("open settings" to { clicks++ }),
+                )
+            }
+        }
+        onNodeWithText("open settings").performClick()
+        assertEquals(1, clicks)
+    }
+}

--- a/src/jvmTest/kotlin/ui/ColorHexInputBoxUiTest.kt
+++ b/src/jvmTest/kotlin/ui/ColorHexInputBoxUiTest.kt
@@ -1,0 +1,86 @@
+package ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.ColorHexInputBox
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ColorHexInputBoxUiTest {
+
+    @Test
+    fun testSanitizesInputAndCommitsRgbValue() = runComposeUiTest {
+        val committed = mutableListOf<String>()
+        setContent {
+            AppTheme {
+                ColorHexInputBox(
+                    value = "#123456",
+                    defaultValue = "#000000",
+                    onValidValue = { committed += it },
+                    useAlpha = false,
+                )
+            }
+        }
+        // non-hex chars are dropped and the value is truncated to #RRGGBB
+        onNode(hasSetTextAction()).performTextReplacement("12345678zz")
+        onNode(hasSetTextAction()).assertTextContains("#123456")
+        assertEquals("#123456", committed.last())
+    }
+
+    @Test
+    fun testPrependsHashAndNormalizesCase() = runComposeUiTest {
+        val committed = mutableListOf<String>()
+        setContent {
+            AppTheme {
+                ColorHexInputBox(
+                    value = "#000000",
+                    defaultValue = "#000000",
+                    onValidValue = { committed += it },
+                    useAlpha = false,
+                )
+            }
+        }
+        onNode(hasSetTextAction()).performTextReplacement("abcdef")
+        onNode(hasSetTextAction()).assertTextContains("#abcdef")
+        // the committed value is the normalized upper-case hex string
+        assertEquals("#ABCDEF", committed.last())
+    }
+
+    @Test
+    fun testAlphaModeKeepsNineChars() = runComposeUiTest {
+        val committed = mutableListOf<String>()
+        setContent {
+            AppTheme {
+                ColorHexInputBox(
+                    value = "#FF000000",
+                    defaultValue = "#FF000000",
+                    onValidValue = { committed += it },
+                    useAlpha = true,
+                )
+            }
+        }
+        onNode(hasSetTextAction()).performTextReplacement("80ABCDEF1234")
+        onNode(hasSetTextAction()).assertTextContains("#80ABCDEF")
+        assertEquals("#80ABCDEF", committed.last())
+    }
+
+    @Test
+    fun testInvalidInitialValueFallsBackToDefault() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                ColorHexInputBox(
+                    value = "not a color",
+                    defaultValue = "#FF0000",
+                    onValidValue = {},
+                    useAlpha = false,
+                )
+            }
+        }
+        onNode(hasSetTextAction()).assertTextContains("#FF0000")
+    }
+}

--- a/src/jvmTest/kotlin/ui/CommonConfirmationDialogUiTest.kt
+++ b/src/jvmTest/kotlin/ui/CommonConfirmationDialogUiTest.kt
@@ -1,0 +1,70 @@
+package ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.dialog.CommonConfirmationDialog
+import com.sdercolin.vlabeler.ui.dialog.CommonConfirmationDialogAction
+import com.sdercolin.vlabeler.ui.dialog.CommonConfirmationDialogResult
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class CommonConfirmationDialogUiTest {
+
+    @Test
+    fun testShowsLocalizedDescription() = runComposeUiTest {
+        val action = CommonConfirmationDialogAction.RemoveEntries(listOf(0, 1, 2))
+        setContent {
+            AppTheme {
+                CommonConfirmationDialog(action = action, finish = {})
+            }
+        }
+        onNodeWithText("Removing 3 entries...").assertExists()
+        onNodeWithText("OK").assertExists()
+        onNodeWithText("Cancel").assertExists()
+    }
+
+    @Test
+    fun testCancelFinishesWithNull() = runComposeUiTest {
+        val action = CommonConfirmationDialogAction.RemoveEntries(listOf(0))
+        var finished = false
+        var result: CommonConfirmationDialogResult? = null
+        setContent {
+            AppTheme {
+                CommonConfirmationDialog(
+                    action = action,
+                    finish = {
+                        finished = true
+                        result = it
+                    },
+                )
+            }
+        }
+        onNodeWithText("Cancel").performClick()
+        assertTrue(finished)
+        assertNull(result)
+    }
+
+    @Test
+    fun testConfirmFinishesWithAction() = runComposeUiTest {
+        val action = CommonConfirmationDialogAction.RemoveEntries(listOf(0))
+        var result: CommonConfirmationDialogResult? = null
+        setContent {
+            AppTheme {
+                CommonConfirmationDialog(
+                    action = action,
+                    finish = { result = it },
+                )
+            }
+        }
+        onNodeWithText("OK").performClick()
+        assertEquals(true, result != null)
+        assertSame(action, result?.action)
+    }
+}

--- a/src/jvmTest/kotlin/ui/ComposeUiTestSmokeTest.kt
+++ b/src/jvmTest/kotlin/ui/ComposeUiTestSmokeTest.kt
@@ -1,7 +1,6 @@
 package ui
 
 import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/src/jvmTest/kotlin/ui/ComposeUiTestSmokeTest.kt
+++ b/src/jvmTest/kotlin/ui/ComposeUiTestSmokeTest.kt
@@ -1,0 +1,63 @@
+package ui
+
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.InputBox
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+
+/**
+ * Smoke tests proving that the Compose UI test harness ([runComposeUiTest]) works in this environment, including on
+ * headless CI machines. Component-specific UI tests live in their own classes.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ComposeUiTestSmokeTest {
+
+    @Test
+    fun testStateDrivenRecomposition() = runComposeUiTest {
+        setContent {
+            var count by remember { mutableStateOf(0) }
+            Button(
+                onClick = { count++ },
+                modifier = Modifier.testTag("button"),
+            ) {
+                Text("count: $count")
+            }
+        }
+        onNodeWithText("count: 0").assertExists()
+        onNodeWithTag("button").performClick()
+        onNodeWithText("count: 1").assertExists()
+    }
+
+    @Test
+    fun testAppThemedComponentWithTextInput() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                var value by remember { mutableStateOf("") }
+                InputBox(
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.testTag("input"),
+                )
+            }
+        }
+        // the tag is on InputBox's wrapper; the editable text field is the descendant with a SetText action
+        onNode(hasSetTextAction()).performTextInput("hello")
+        onNode(hasSetTextAction()).assertTextContains("hello", substring = true)
+    }
+}

--- a/src/jvmTest/kotlin/ui/ConfirmButtonUiTest.kt
+++ b/src/jvmTest/kotlin/ui/ConfirmButtonUiTest.kt
@@ -1,0 +1,49 @@
+package ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.ConfirmButton
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ConfirmButtonUiTest {
+
+    @Test
+    fun testDefaultLabelAndClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                ConfirmButton(onClick = { clicks++ })
+            }
+        }
+        onNodeWithText("OK").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun testCustomText() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                ConfirmButton(onClick = {}, text = "Apply")
+            }
+        }
+        onNodeWithText("Apply").assertExists()
+        onNodeWithText("OK").assertDoesNotExist()
+    }
+
+    @Test
+    fun testDisabledButtonDoesNotInvoke() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                ConfirmButton(onClick = { clicks++ }, enabled = false)
+            }
+        }
+        onNodeWithText("OK").performClick()
+        assertEquals(0, clicks)
+    }
+}

--- a/src/jvmTest/kotlin/ui/InputBoxUiTest.kt
+++ b/src/jvmTest/kotlin/ui/InputBoxUiTest.kt
@@ -1,0 +1,87 @@
+package ui
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.isNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.InputBox
+import com.sdercolin.vlabeler.ui.common.IntegerInputBox
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class InputBoxUiTest {
+
+    @Test
+    fun testErrorPromptAppearsAndDisappears() = runComposeUiTest {
+        val value = mutableStateOf("")
+        setContent {
+            AppTheme {
+                InputBox(
+                    value = value.value,
+                    onValueChange = { value.value = it },
+                    errorPrompt = { if (it.isBlank()) "Required" else null },
+                )
+            }
+        }
+        onNodeWithText("Required").assertExists()
+        onNode(hasSetTextAction()).performTextInput("abc")
+        assertEquals("abc", value.value)
+        onNodeWithText("Required").assertDoesNotExist()
+    }
+
+    @Test
+    fun testDisabledInputBoxRejectsInput() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                InputBox(
+                    value = "locked",
+                    onValueChange = {},
+                    enabled = false,
+                )
+            }
+        }
+        // the text field is marked disabled, so it cannot receive input
+        onNode(hasSetTextAction()).assert(isNotEnabled())
+        onNodeWithText("locked").assertExists()
+    }
+
+    @Test
+    fun testIntegerInputBoxValidation() = runComposeUiTest {
+        val intValue = mutableStateOf(5)
+        setContent {
+            AppTheme {
+                IntegerInputBox(
+                    enabled = true,
+                    intValue = intValue.value,
+                    onValueChange = { intValue.value = it },
+                    min = 1,
+                    max = 10,
+                    getInvalidPrompt = { null },
+                )
+            }
+        }
+        // non-integer input shows the integer prompt and does not commit
+        onNode(hasSetTextAction()).performTextClearance()
+        onNodeWithText("Please enter an integer number.").assertExists()
+        assertEquals(5, intValue.value)
+
+        // out-of-range input shows the range prompt and does not commit
+        onNode(hasSetTextAction()).performTextInput("50")
+        onNodeWithText("Please enter a number between 1 and 10.").assertExists()
+        assertEquals(5, intValue.value)
+
+        // valid input commits and clears the error
+        onNode(hasSetTextAction()).performTextClearance()
+        onNode(hasSetTextAction()).performTextInput("7")
+        assertEquals(7, intValue.value)
+        onNodeWithText("Please enter a number between 1 and 10.").assertDoesNotExist()
+        onNodeWithText("Please enter an integer number.").assertDoesNotExist()
+    }
+}

--- a/src/jvmTest/kotlin/ui/PlainClickableUiTest.kt
+++ b/src/jvmTest/kotlin/ui/PlainClickableUiTest.kt
@@ -1,0 +1,36 @@
+package ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.sdercolin.vlabeler.ui.common.plainClickable
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class PlainClickableUiTest {
+
+    @Test
+    fun testPlainClickableInvokesOnClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            AppTheme {
+                Box(
+                    Modifier
+                        .testTag("target")
+                        .size(50.dp)
+                        .plainClickable { clicks++ },
+                )
+            }
+        }
+        onNodeWithTag("target").performClick()
+        assertEquals(1, clicks)
+    }
+}

--- a/src/jvmTest/kotlin/ui/ProjectStoreTest.kt
+++ b/src/jvmTest/kotlin/ui/ProjectStoreTest.kt
@@ -1,0 +1,912 @@
+package ui
+
+import androidx.compose.runtime.mutableStateOf
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.exception.InvalidEditedProjectException
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.SampleInfo
+import com.sdercolin.vlabeler.model.filter.EntryFilter
+import com.sdercolin.vlabeler.ui.AppErrorStateImpl
+import com.sdercolin.vlabeler.ui.AppProgressStateImpl
+import com.sdercolin.vlabeler.ui.AppScreenStateImpl
+import com.sdercolin.vlabeler.ui.AppUnsavedChangesStateImpl
+import com.sdercolin.vlabeler.ui.ProjectStoreImpl
+import com.sdercolin.vlabeler.ui.editor.Edition
+import com.sdercolin.vlabeler.ui.editor.ScrollFitViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ProjectStoreTest {
+
+    private lateinit var storeScope: CoroutineScope
+    private lateinit var screenState: AppScreenStateImpl
+    private lateinit var errorState: AppErrorStateImpl
+    private lateinit var progressState: AppProgressStateImpl
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        storeScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @AfterTest
+    fun teardown() {
+        storeScope.cancel()
+        Log.muted = false
+    }
+
+    private fun createStore(appConf: AppConf = AppConf()): ProjectStoreImpl {
+        screenState = AppScreenStateImpl()
+        errorState = AppErrorStateImpl()
+        progressState = AppProgressStateImpl()
+        return ProjectStoreImpl(
+            scope = storeScope,
+            appConf = mutableStateOf(appConf),
+            screenState = screenState,
+            scrollFitViewModel = ScrollFitViewModel(storeScope),
+            errorState = errorState,
+            progressState = progressState,
+        )
+    }
+
+    /**
+     * Creates a store with the shared base project loaded, normalized to module "C4" at entry 0.
+     */
+    private fun createStoreWithProject(appConf: AppConf = AppConf()): ProjectStoreImpl =
+        createStore(appConf).apply {
+            newProject(baseProject)
+            jumpToModuleByNameAndEntry("C4", 0)
+        }
+
+    /**
+     * Waits for all coroutines launched by the store on [storeScope] to finish.
+     */
+    private fun awaitStoreJobs() {
+        runBlocking {
+            storeScope.coroutineContext.job.children.toList().joinAll()
+        }
+    }
+
+    /* region project lifecycle */
+
+    @Test
+    fun `initial state has no project`() {
+        val store = createStore()
+        assertNull(store.project)
+        assertFalse(store.hasProject)
+        assertFailsWith<IllegalArgumentException> { store.requireProject() }
+    }
+
+    @Test
+    fun `newProject sets the project and initializes history`() {
+        val store = createStore()
+        store.newProject(baseProject)
+        assertTrue(store.hasProject)
+        assertEquals(baseProject, store.requireProject())
+        assertEquals(store.requireProject(), store.history.current)
+        assertFalse(store.canUndo)
+        assertFalse(store.canRedo)
+    }
+
+    @Test
+    fun `newProject replaces an existing project and resets history`() {
+        val store = createStoreWithProject()
+        store.editCurrentEntryTag("edited")
+        assertTrue(store.canUndo)
+        store.newProject(baseProject)
+        assertEquals(baseProject, store.requireProject())
+        assertFalse(store.canUndo)
+        assertFalse(store.canRedo)
+    }
+
+    @Test
+    fun `clearProject resets the store`() {
+        val store = createStoreWithProject()
+        store.clearProject()
+        assertNull(store.project)
+        assertFalse(store.hasProject)
+        assertFalse(store.canUndo)
+        assertFalse(store.canRedo)
+    }
+
+    /* endregion */
+
+    /* region editProject and updateProject */
+
+    @Test
+    fun `editProject applies a valid edit and pushes history`() {
+        val store = createStoreWithProject()
+        store.editProject { updateCurrentModule { editEntryTag(0, "hello") } }
+        assertEquals("hello", store.requireProject().currentModule.entries[0].notes.tag)
+        assertTrue(store.canUndo)
+        assertNull(errorState.error)
+    }
+
+    @Test
+    fun `editProject reports invalid edits and keeps the project`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        store.editProject { copy(currentModuleIndex = 99) }
+        assertIs<InvalidEditedProjectException>(errorState.error)
+        assertSame(before, store.requireProject())
+        assertFalse(store.canUndo)
+    }
+
+    @Test
+    fun `updateProject pushes a changed project`() {
+        val store = createStoreWithProject()
+        val updated = store.requireProject().updateCurrentModule { editEntryTag(0, "updated") }
+        store.updateProject(updated)
+        assertEquals("updated", store.requireProject().currentModule.entries[0].notes.tag)
+        assertTrue(store.canUndo)
+    }
+
+    @Test
+    fun `updateProject ignores an equal project`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        store.updateProject(before.copy())
+        assertFalse(store.canUndo)
+        assertEquals(before, store.requireProject())
+    }
+
+    /* endregion */
+
+    /* region undo and redo */
+
+    @Test
+    fun `undo and redo restore project states`() {
+        val store = createStoreWithProject()
+        store.editCurrentEntryTag("first")
+        store.editCurrentEntryTag("second")
+
+        assertTrue(store.canUndo)
+        store.undo()
+        assertEquals("first", store.requireProject().currentModule.entries[0].notes.tag)
+        assertTrue(store.canRedo)
+
+        store.undo()
+        assertEquals("", store.requireProject().currentModule.entries[0].notes.tag)
+        assertFalse(store.canUndo)
+
+        store.redo()
+        assertEquals("first", store.requireProject().currentModule.entries[0].notes.tag)
+        store.redo()
+        assertEquals("second", store.requireProject().currentModule.entries[0].notes.tag)
+        assertFalse(store.canRedo)
+    }
+
+    @Test
+    fun `undo keeps the current indexes when index changes are squashed`() {
+        val store = createStoreWithProject()
+        store.editEntryTag(0, "edited")
+        // an index-only change is squashed by the history with the default configuration
+        store.jumpToEntry(1)
+        assertEquals(1, store.requireProject().currentModule.currentIndex)
+
+        store.undo()
+        val project = store.requireProject()
+        assertEquals("", project.currentModule.entries[0].notes.tag)
+        // the cursor does not move on undo
+        assertEquals(1, project.currentModule.currentIndex)
+        assertFalse(store.canUndo)
+    }
+
+    @Test
+    fun `undo restores the indexes when squashing is disabled`() {
+        val conf = AppConf(history = AppConf.History(squashIndex = false))
+        val store = createStore(conf)
+        store.newProject(baseProject)
+        val initialIndex = store.requireProject().currentModule.currentIndex
+        store.jumpToEntry(1)
+        assertTrue(store.canUndo)
+
+        store.undo()
+        assertEquals(initialIndex, store.requireProject().currentModule.currentIndex)
+        assertTrue(store.canRedo)
+        store.redo()
+        assertEquals(1, store.requireProject().currentModule.currentIndex)
+    }
+
+    /* endregion */
+
+    /* region entry navigation */
+
+    @Test
+    fun `entry navigation moves within the module`() {
+        val store = createStoreWithProject()
+        assertFalse(store.canGoPreviousEntryOrSample)
+        assertTrue(store.canGoNextEntryOrSample)
+
+        store.nextEntry()
+        assertEquals(1, store.requireProject().currentModule.currentIndex)
+        assertTrue(store.canGoPreviousEntryOrSample)
+
+        store.previousEntry()
+        assertEquals(0, store.requireProject().currentModule.currentIndex)
+
+        // no-op at the first entry
+        store.previousEntry()
+        assertEquals(0, store.requireProject().currentModule.currentIndex)
+
+        store.jumpToEntry(3)
+        assertFalse(store.canGoNextEntryOrSample)
+        // no-op at the last entry
+        store.nextEntry()
+        assertEquals(3, store.requireProject().currentModule.currentIndex)
+    }
+
+    @Test
+    fun `navigation flags are false without a project`() {
+        val store = createStore()
+        assertFalse(store.canGoNextEntryOrSample)
+        assertFalse(store.canGoPreviousEntryOrSample)
+        assertFalse(store.canGoNextModule)
+        assertFalse(store.canGoPreviousModule)
+    }
+
+    @Test
+    fun `nextSample and previousSample switch between sample groups`() {
+        val store = createStoreWithProject()
+        // module "C4": entries 0..1 belong to sample "_a_ka.wav", entries 2..3 to "_i_ki.wav"
+        store.nextSample()
+        assertEquals(2, store.requireProject().currentModule.currentIndex)
+
+        // at the last sample: move to the last entry of the current group
+        store.nextSample()
+        assertEquals(3, store.requireProject().currentModule.currentIndex)
+
+        store.previousSample()
+        assertEquals(1, store.requireProject().currentModule.currentIndex)
+
+        // at the first sample: move to the first entry of the current group
+        store.previousSample()
+        assertEquals(0, store.requireProject().currentModule.currentIndex)
+    }
+
+    @Test
+    fun `jumpToEntry with module name targets another module without switching`() {
+        val store = createStoreWithProject()
+        store.jumpToEntry("A3", 1)
+        val project = store.requireProject()
+        assertEquals("C4", project.currentModule.name)
+        assertEquals(1, project.modules.first { it.name == "A3" }.currentIndex)
+    }
+
+    @Test
+    fun `jumpToModuleAndEntry switches module and entry`() {
+        val store = createStoreWithProject()
+        val a3Index = store.requireProject().modules.indexOfFirst { it.name == "A3" }
+        store.jumpToModuleAndEntry(a3Index, 1)
+        val project = store.requireProject()
+        assertEquals("A3", project.currentModule.name)
+        assertEquals(1, project.currentModule.currentIndex)
+    }
+
+    @Test
+    fun `jumpToModuleByNameAndEntry with an unknown module is a no-op`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        store.jumpToModuleByNameAndEntry("unknown", 0)
+        assertSame(before, store.requireProject())
+    }
+
+    @Test
+    fun `jumpToModuleByNameAndEntryName finds the entry by name`() {
+        val store = createStoreWithProject()
+        store.jumpToModuleByNameAndEntryName("C4", "i ki")
+        val project = store.requireProject()
+        assertEquals("C4", project.currentModule.name)
+        assertEquals(3, project.currentModule.currentIndex)
+    }
+
+    @Test
+    fun `jumpToModuleByNameAndEntryName with an unknown entry is a no-op`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        store.jumpToModuleByNameAndEntryName("C4", "unknown entry")
+        assertSame(before, store.requireProject())
+    }
+
+    /* endregion */
+
+    /* region module navigation */
+
+    @Test
+    fun `module navigation moves between modules`() {
+        val store = createStoreWithProject()
+        assertTrue(store.shouldShowModuleNavigation())
+        store.jumpToModule(0)
+        assertFalse(store.canGoPreviousModule)
+        assertTrue(store.canGoNextModule)
+
+        store.nextModule()
+        assertEquals(1, store.requireProject().currentModuleIndex)
+        assertFalse(store.canGoNextModule)
+        assertTrue(store.canGoPreviousModule)
+
+        // no-op at the last module
+        store.nextModule()
+        assertEquals(1, store.requireProject().currentModuleIndex)
+
+        store.previousModule()
+        assertEquals(0, store.requireProject().currentModuleIndex)
+    }
+
+    @Test
+    fun `jumpToModule with a target entry index sets the entry`() {
+        val store = createStoreWithProject()
+        val a3Index = store.requireProject().modules.indexOfFirst { it.name == "A3" }
+        store.jumpToModule(a3Index, targetEntryIndex = 1)
+        val project = store.requireProject()
+        assertEquals("A3", project.currentModule.name)
+        assertEquals(1, project.currentModule.currentIndex)
+    }
+
+    @Test
+    fun `jumpToModule to the current position is a no-op`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        store.jumpToModule(before.currentModuleIndex)
+        assertSame(before, store.requireProject())
+        store.jumpToModule(before.currentModuleIndex, targetEntryIndex = before.currentModule.currentIndex)
+        assertSame(before, store.requireProject())
+    }
+
+    /* endregion */
+
+    /* region entry edits */
+
+    @Test
+    fun `renameEntry renames the entry`() {
+        val store = createStoreWithProject()
+        store.renameEntry(0, "renamed")
+        assertEquals("renamed", store.requireProject().currentModule.entries[0].name)
+        assertTrue(store.canUndo)
+    }
+
+    @Test
+    fun `duplicateEntry inserts a copy after the entry and selects it`() {
+        val store = createStoreWithProject()
+        store.duplicateEntry(0, "dup")
+        val module = store.requireProject().currentModule
+        assertEquals(5, module.entries.size)
+        assertEquals("dup", module.entries[1].name)
+        assertEquals(module.entries[0].copy(name = "dup"), module.entries[1])
+        assertEquals(1, module.currentIndex)
+    }
+
+    @Test
+    fun `removeEntry removes the entry and moves the cursor backwards`() {
+        val store = createStoreWithProject()
+        store.jumpToEntry(1)
+        store.removeEntry(1)
+        val module = store.requireProject().currentModule
+        assertEquals(listOf("- a", "- i", "i ki"), module.entries.map { it.name })
+        assertEquals(0, module.currentIndex)
+    }
+
+    @Test
+    fun `removeEntries removes multiple entries`() {
+        val store = createStoreWithProject()
+        store.removeEntries(listOf(1, 3))
+        val module = store.requireProject().currentModule
+        assertEquals(listOf("- a", "- i"), module.entries.map { it.name })
+        assertEquals(0, module.currentIndex)
+    }
+
+    @Test
+    fun `moveEntry moves the entry and follows the cursor`() {
+        val store = createStoreWithProject()
+        assertTrue(store.canMoveEntry)
+        store.moveEntry(0, 1)
+        val module = store.requireProject().currentModule
+        assertEquals(listOf("a ka", "- a", "- i", "i ki"), module.entries.map { it.name })
+        assertEquals(1, module.currentIndex)
+    }
+
+    @Test
+    fun `isOnlyEntry is false when the sample has multiple entries`() {
+        val store = createStoreWithProject()
+        assertFalse(store.isOnlyEntry())
+    }
+
+    @Test
+    fun `toggleMultipleEditMode on a non-continuous labeler reports an error`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        store.toggleMultipleEditMode(true)
+        assertIs<InvalidEditedProjectException>(errorState.error)
+        assertSame(before, store.requireProject())
+    }
+
+    @Test
+    fun `toggle done and star of entries`() {
+        val store = createStoreWithProject()
+        store.toggleEntryDone(1)
+        assertTrue(store.requireProject().currentModule.entries[1].notes.done)
+        store.toggleEntryDone(1)
+        assertFalse(store.requireProject().currentModule.entries[1].notes.done)
+
+        store.toggleCurrentEntryDone()
+        assertTrue(store.requireProject().currentModule.entries[0].notes.done)
+
+        store.toggleEntryStar(1)
+        assertTrue(store.requireProject().currentModule.entries[1].notes.star)
+        store.toggleCurrentEntryStar()
+        assertTrue(store.requireProject().currentModule.entries[0].notes.star)
+    }
+
+    @Test
+    fun `edit entry tags`() {
+        val store = createStoreWithProject()
+        store.editEntryTag(1, "tag1")
+        assertEquals("tag1", store.requireProject().currentModule.entries[1].notes.tag)
+
+        store.editCurrentEntryTag("tag0")
+        assertEquals("tag0", store.requireProject().currentModule.entries[0].notes.tag)
+
+        store.editEntriesTag(listOf(2, 3), "bulk")
+        val module = store.requireProject().currentModule
+        assertEquals("bulk", module.entries[2].notes.tag)
+        assertEquals("bulk", module.entries[3].notes.tag)
+    }
+
+    @Test
+    fun `set done and star of multiple entries`() {
+        val store = createStoreWithProject()
+        store.setEntriesDone(listOf(0, 2), true)
+        var module = store.requireProject().currentModule
+        assertEquals(listOf(true, false, true, false), module.entries.map { it.notes.done })
+
+        store.setEntriesDone(listOf(0), false)
+        assertFalse(store.requireProject().currentModule.entries[0].notes.done)
+
+        store.setEntriesStar(listOf(1, 3), true)
+        module = store.requireProject().currentModule
+        assertEquals(listOf(false, true, false, true), module.entries.map { it.notes.star })
+    }
+
+    @Test
+    fun `createDefaultEntries appends entries with default values`() {
+        val store = createStoreWithProject()
+        store.createDefaultEntry("C4", "_a_ka.wav")
+        val module = store.requireProject().currentModule
+        assertEquals(5, module.entries.size)
+        val created = module.entries.last()
+        assertEquals("_a_ka.wav", created.sample)
+        assertEquals(baseProject.labelerConf.defaultValues.first(), created.start)
+        assertEquals(baseProject.labelerConf.defaultValues.last(), created.end)
+    }
+
+    @Test
+    fun `updateEntryExtra updates the extra fields`() {
+        val store = createStoreWithProject()
+        store.updateEntryExtra(0, listOf("123"))
+        assertEquals(listOf("123"), store.requireProject().currentModule.entries[0].extras)
+    }
+
+    @Test
+    fun `importEntries appends entries to a module`() {
+        val store = createStoreWithProject()
+        val imported = baseProject.modules.first { it.name == "C4" }.entries[0].copy(name = "imported")
+        store.importEntries(listOf("C4" to listOf(imported)), replace = false)
+        val module = store.requireProject().currentModule
+        assertEquals(5, module.entries.size)
+        assertEquals("imported", module.entries.last().name)
+    }
+
+    @Test
+    fun `importEntries replaces entries and coerces the current index`() {
+        val store = createStoreWithProject()
+        store.jumpToEntry(3)
+        val newEntries = baseProject.modules.first { it.name == "C4" }.entries.take(2)
+        store.importEntries(listOf("C4" to newEntries), replace = true)
+        val module = store.requireProject().currentModule
+        assertEquals(2, module.entries.size)
+        assertEquals(1, module.currentIndex)
+    }
+
+    /* endregion */
+
+    /* region editions */
+
+    @Test
+    fun `editEntries applies the edition and takes the post-edit done action`() {
+        val store = createStoreWithProject()
+        val entry = store.requireProject().currentModule.entries[0]
+        val edited = entry.copy(end = entry.end + 5f)
+        store.editEntries(listOf(Edition(0, edited, listOf("end"), Edition.Method.Dragging)))
+        val result = store.requireProject().currentModule.entries[0]
+        assertEquals(entry.end + 5f, result.end)
+        // the default post-edit action marks the edited entry as done
+        assertTrue(result.notes.done)
+        assertTrue(store.canUndo)
+    }
+
+    @Test
+    fun `editEntriesWithCascade applies editions to other modules`() {
+        val store = createStoreWithProject()
+        val currentEntry = store.requireProject().currentModule.entries[0]
+        val a3Entry = store.requireProject().modules.first { it.name == "A3" }.entries[0]
+        store.editEntriesWithCascade(
+            currentModuleEditions = listOf(
+                Edition(0, currentEntry.copy(end = currentEntry.end + 5f), listOf("end"), Edition.Method.Dragging),
+            ),
+            cascadeEditions = mapOf(
+                "A3" to listOf(
+                    Edition(0, a3Entry.copy(end = a3Entry.end + 7f), listOf("end"), Edition.Method.Dragging),
+                ),
+            ),
+        )
+        val project = store.requireProject()
+        assertEquals(currentEntry.end + 5f, project.currentModule.entries[0].end)
+        assertEquals(a3Entry.end + 7f, project.modules.first { it.name == "A3" }.entries[0].end)
+    }
+
+    @Test
+    fun `cutEntry splits an entry at the position`() {
+        val store = createStoreWithProject()
+        val original = store.requireProject().currentModule.entries[0]
+        store.cutEntry(0, position = 200f, rename = null, newName = "cut", targetEntryIndex = null)
+        val module = store.requireProject().currentModule
+        assertEquals(5, module.entries.size)
+        assertEquals(original.name, module.entries[0].name)
+        assertEquals(200f, module.entries[0].end)
+        assertTrue(module.entries[0].notes.done)
+        assertEquals("cut", module.entries[1].name)
+        assertEquals(200f, module.entries[1].start)
+        assertEquals(original.end, module.entries[1].end)
+        assertEquals(0, module.currentIndex)
+    }
+
+    @Test
+    fun `cutEntryOnScreen with former target renames the former part`() {
+        val store = createStoreWithProject()
+        val originalName = store.requireProject().currentModule.entries[0].name
+        store.cutEntryOnScreen(
+            index = 0,
+            position = 200f,
+            name = "former",
+            target = AppConf.ScissorsActions.Target.Former,
+            targetEntryIndex = 1,
+        )
+        val module = store.requireProject().currentModule
+        assertEquals("former", module.entries[0].name)
+        assertEquals(originalName, module.entries[1].name)
+        assertEquals(1, module.currentIndex)
+    }
+
+    /* endregion */
+
+    /* region entry filter */
+
+    @Test
+    fun `updateEntryFilter filters entries and adjusts the current index`() {
+        val store = createStoreWithProject()
+        store.updateEntryFilter { copy(searchText = "ki") }
+        val project = store.requireProject()
+        assertEquals("ki", project.entryFilter?.searchText)
+        assertEquals(listOf(2, 3), project.currentModule.filteredEntryIndexes)
+        assertEquals(2, project.currentModule.currentIndex)
+    }
+
+    @Test
+    fun `updateEntryFilter with a null updater keeps the project`() {
+        val store = createStoreWithProject()
+        store.updateEntryFilter { copy(searchText = "ki") }
+        val before = store.requireProject()
+        store.updateEntryFilter { null }
+        assertEquals(before, store.requireProject())
+    }
+
+    @Test
+    fun `updateEntryFilter with an empty filter includes all entries`() {
+        val store = createStoreWithProject()
+        store.updateEntryFilter { copy(searchText = "ki") }
+        store.updateEntryFilter { EntryFilter() }
+        assertEquals(listOf(0, 1, 2, 3), store.requireProject().currentModule.filteredEntryIndexes)
+    }
+
+    /* endregion */
+
+    /* region flags */
+
+    @Test
+    fun `raw label file related flags for a multi-module project`() {
+        val store = createStoreWithProject()
+        assertTrue(store.hasRawLabelFileForCurrentModule())
+        assertTrue(store.shouldShowOverwriteExportAllModules())
+        assertTrue(store.canOverwriteExportAllModules())
+        assertTrue(store.canReloadAllLabelFiles())
+    }
+
+    @Test
+    fun `flags are false without a project`() {
+        val store = createStore()
+        assertFalse(store.hasRawLabelFileForCurrentModule())
+        assertFalse(store.shouldShowOverwriteExportAllModules())
+        assertFalse(store.canOverwriteExportAllModules())
+        assertFalse(store.canReloadAllLabelFiles())
+        assertFalse(store.shouldShowModuleNavigation())
+        assertFalse(store.canEditCurrentEntryExtra)
+        assertFalse(store.canEditCurrentModuleExtra)
+    }
+
+    @Test
+    fun `extra edit flags depend on the visible extra fields of the labeler`() {
+        val store = createStoreWithProject()
+        // the utau-singer labeler has one invisible entry extra field and no module extra fields
+        assertFalse(store.canEditCurrentEntryExtra)
+        assertFalse(store.canEditCurrentModuleExtra)
+    }
+
+    @Test
+    fun `single-module project hides multi-module features`() {
+        val store = createStore()
+        store.newProject(singleModuleProject)
+        assertFalse(store.shouldShowModuleNavigation())
+        assertFalse(store.shouldShowOverwriteExportAllModules())
+        assertFalse(store.canReloadAllLabelFiles())
+        assertFalse(store.canGoNextModule)
+        assertFalse(store.canGoPreviousModule)
+    }
+
+    /* endregion */
+
+    /* region sample directory */
+
+    @Test
+    fun `changeSampleDirectory updates the module path in a multi-module project`() {
+        val store = createStoreWithProject()
+        val root = store.requireProject().rootSampleDirectory
+        store.changeSampleDirectory("C4", root)
+        val project = store.requireProject()
+        val module = project.modules.first { it.name == "C4" }
+        assertEquals("", module.sampleDirectoryPath)
+        assertEquals(root.absolutePath, module.getSampleDirectory(project).absolutePath)
+    }
+
+    @Test
+    fun `changeSampleDirectory changes the root for a single-module root project`() {
+        val store = createStore()
+        store.newProject(singleModuleProject)
+        val oldWorkingDirectory = store.requireProject().workingDirectory.absolutePath
+        val newRoot = tempDir.resolve("oto-new-root").also { it.mkdirs() }
+        store.changeSampleDirectory(newRoot)
+        val project = store.requireProject()
+        assertEquals(newRoot.absolutePath, project.rootSampleDirectoryPath)
+        assertEquals("", project.modules.first().sampleDirectoryPath)
+        // the working directory keeps pointing to the previous location
+        assertEquals(oldWorkingDirectory, project.workingDirectory.absolutePath)
+    }
+
+    /* endregion */
+
+    /* region sample sync */
+
+    @Test
+    fun `updateProjectOnLoadedSample syncs negative entry ends and replaces the history top`() {
+        val store = createStoreWithProject()
+        val originalEnd = store.requireProject().currentModule.entries[0].end
+        store.editProject {
+            updateCurrentModule {
+                copy(entries = entries.toMutableList().also { it[0] = it[0].copy(end = -100f) })
+            }
+        }
+        val sampleName = store.requireProject().currentModule.entries[0].sample
+
+        store.updateProjectOnLoadedSample(sampleInfo(sampleName, "C4", lengthMillis = 1000f), "C4")
+        assertEquals(900f, store.requireProject().currentModule.entries[0].end)
+        assertNull(errorState.error)
+
+        // the sync replaced the top of the history instead of pushing a new state
+        store.undo()
+        assertEquals(originalEnd, store.requireProject().currentModule.entries[0].end)
+        assertFalse(store.canUndo)
+    }
+
+    /* endregion */
+
+    /* region property setter */
+
+    @Test
+    fun `setCurrentEntryProperty applies the labeler value setter`() {
+        val store = createStoreWithProject()
+        // property 0 of the utau-singer labeler is "left": sets points[3] and start if the value is smaller
+        runBlocking { store.setCurrentEntryProperty(0, 5f) }
+        assertNull(errorState.error)
+        val entry = store.requireProject().currentModule.entries[0]
+        assertEquals(5f, entry.points[3])
+        assertEquals(5f, entry.start)
+    }
+
+    @Test
+    fun `setCurrentEntryProperty with an invalid index reports an error`() {
+        val store = createStoreWithProject()
+        val before = store.requireProject()
+        runBlocking { store.setCurrentEntryProperty(99, 1f) }
+        assertNotNull(errorState.error)
+        assertSame(before, store.requireProject())
+    }
+
+    /* endregion */
+
+    /* region label file reload and export */
+
+    @Test
+    fun `reloadLabelFile with an explicit file replaces the current module entries`() {
+        val store = createStoreWithProject()
+        val labelFile = baseProject.rootSampleDirectory.resolve("A3/oto.ini")
+        store.reloadLabelFile(labelFile, skipConfirmation = true)
+        awaitStoreJobs()
+        assertNull(errorState.error)
+        assertFalse(progressState.isBusy)
+        val module = store.requireProject().currentModule
+        assertEquals("C4", module.name)
+        assertEquals(listOf("- aA3", "a kaA3"), module.entries.map { it.name })
+        assertEquals(0, module.currentIndex)
+    }
+
+    @Test
+    fun `reloadAllLabelFiles restores the entries from the raw label files`() {
+        val store = createStoreWithProject()
+        store.renameEntry(0, "renamed")
+        store.reloadAllLabelFiles(skipConfirmation = true)
+        awaitStoreJobs()
+        assertNull(errorState.error)
+        assertFalse(progressState.isBusy)
+        val project = store.requireProject()
+        assertEquals(
+            listOf("- a", "a ka", "- i", "i ki"),
+            project.modules.first { it.name == "C4" }.entries.map { it.name },
+        )
+        assertEquals(
+            listOf("- aA3", "a kaA3"),
+            project.modules.first { it.name == "A3" }.entries.map { it.name },
+        )
+    }
+
+    @Test
+    fun `overwriteExportCurrentModule writes the raw label file`() {
+        val sampleDir = TestFixtures.deploy(
+            "utau-singer",
+            tempDir.resolve("export-current"),
+            wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+        )
+        val project = createTestProject(labeler = TestLabelers.utauSinger, sampleDirectory = sampleDir)
+        val store = createStore()
+        store.newProject(project)
+        store.jumpToModuleByNameAndEntry("C4", 0)
+        store.renameEntry(0, "reexported")
+
+        store.overwriteExportCurrentModule()
+        awaitStoreJobs()
+        assertNull(errorState.error)
+        assertFalse(progressState.isBusy)
+        val text = sampleDir.resolve("C4/oto.ini").readText()
+        assertTrue(text.contains("reexported"))
+    }
+
+    @Test
+    fun `withExporting runs the block and rethrows failures`() {
+        val store = createStoreWithProject()
+        val file = tempDir.resolve("export-marker.txt").also { it.writeText("content") }
+        runBlocking { store.withExporting { file } }
+        assertFailsWith<IllegalStateException> {
+            runBlocking { store.withExporting { error("boom") } }
+        }
+    }
+
+    /* endregion */
+
+    /* region auto save */
+
+    @Test
+    fun `enableAutoSaveProject with none target does not launch a job`() {
+        val store = createStoreWithProject()
+        store.enableAutoSaveProject(
+            AppConf.AutoSave(target = AppConf.AutoSave.Target.None),
+            AppUnsavedChangesStateImpl(),
+        )
+        assertEquals(0, storeScope.coroutineContext.job.children.count())
+        runBlocking { store.terminateAutoSaveProject() }
+    }
+
+    @Test
+    fun `enableAutoSaveProject launches a job that terminate cancels`() {
+        val store = createStoreWithProject()
+        store.enableAutoSaveProject(
+            AppConf.AutoSave(target = AppConf.AutoSave.Target.Record, intervalSec = 10000),
+            AppUnsavedChangesStateImpl(),
+        )
+        assertEquals(1, storeScope.coroutineContext.job.children.count())
+        runBlocking { store.terminateAutoSaveProject() }
+        assertEquals(0, storeScope.coroutineContext.job.children.count())
+    }
+
+    /* endregion */
+
+    private fun sampleInfo(name: String, moduleName: String, lengthMillis: Float) = SampleInfo(
+        name = name,
+        file = baseProject.rootSampleDirectory.resolve("$moduleName/$name").absolutePath,
+        moduleName = moduleName,
+        sampleRate = 44100f,
+        maxSampleRate = 44100,
+        normalize = false,
+        normalizeRatio = null,
+        channels = 1,
+        length = 44100,
+        lengthMillis = lengthMillis,
+        chunkSize = 44100,
+        chunkCount = 1,
+        hasSpectrogram = false,
+        hasPower = false,
+        powerChannels = 0,
+        hasFundamental = false,
+        lastModified = 0L,
+        algorithmVersion = 0,
+    )
+
+    companion object {
+
+        private val tempDir: File by lazy {
+            createTempDirectory("vlabeler-test").toFile().also { dir ->
+                Runtime.getRuntime().addShutdownHook(Thread { dir.deleteRecursively() })
+            }
+        }
+
+        /**
+         * A real project created once and shared by all tests, since [Project] is immutable. It contains two modules
+         * "A3" (entries "- aA3", "a kaA3") and "C4" (entries "- a", "a ka", "- i", "i ki").
+         */
+        private val baseProject: Project by lazy {
+            val sampleDir = TestFixtures.deploy(
+                "utau-singer",
+                tempDir.resolve("utau-singer"),
+                wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+            )
+            createTestProject(labeler = TestLabelers.utauSinger, sampleDirectory = sampleDir)
+        }
+
+        /**
+         * A single-module project (oto fixture, 2 entries) whose module directory is the root sample directory.
+         */
+        private val singleModuleProject: Project by lazy {
+            val sampleDir = TestFixtures.deploy(
+                "oto",
+                tempDir.resolve("oto"),
+                wavFiles = listOf("_a_ka.wav"),
+            )
+            createTestProject(
+                labeler = TestLabelers.utauOto,
+                sampleDirectory = sampleDir,
+                inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+            )
+        }
+    }
+}

--- a/src/jvmTest/kotlin/ui/ScrollFitViewModelTest.kt
+++ b/src/jvmTest/kotlin/ui/ScrollFitViewModelTest.kt
@@ -1,0 +1,90 @@
+package ui
+
+import com.sdercolin.vlabeler.ui.editor.ScrollFitViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScrollFitViewModelTest {
+
+    @Test
+    fun `emit delivers the pending value with the current mode`() = runTest {
+        val viewModel = ScrollFitViewModel(this)
+        val events = mutableListOf<ScrollFitViewModel.Event>()
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.eventFlow.collect { events.add(it) }
+        }
+
+        viewModel.setMode(ScrollFitViewModel.Mode.FORWARD)
+        viewModel.emit()
+        advanceUntilIdle()
+        assertEquals(listOf(ScrollFitViewModel.Event(0, ScrollFitViewModel.Mode.FORWARD)), events)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun `emit resets the mode to normal`() = runTest {
+        val viewModel = ScrollFitViewModel(this)
+        val events = mutableListOf<ScrollFitViewModel.Event>()
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.eventFlow.collect { events.add(it) }
+        }
+
+        viewModel.setMode(ScrollFitViewModel.Mode.FORWARD)
+        viewModel.emit()
+        viewModel.emit()
+        advanceUntilIdle()
+        assertEquals(
+            listOf(
+                ScrollFitViewModel.Event(0, ScrollFitViewModel.Mode.FORWARD),
+                ScrollFitViewModel.Event(0, ScrollFitViewModel.Mode.NORMAL),
+            ),
+            events,
+        )
+
+        collector.cancel()
+    }
+
+    @Test
+    fun `emitNext alone does not emit an event`() = runTest {
+        val viewModel = ScrollFitViewModel(this)
+        val events = mutableListOf<ScrollFitViewModel.Event>()
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.eventFlow.collect { events.add(it) }
+        }
+
+        viewModel.emitNext()
+        advanceUntilIdle()
+        assertEquals(emptyList(), events)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun `update without a matching entry does not emit even when waiting`() = runTest {
+        val viewModel = ScrollFitViewModel(this)
+        val events = mutableListOf<ScrollFitViewModel.Event>()
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.eventFlow.collect { events.add(it) }
+        }
+
+        viewModel.emitNext()
+        viewModel.update(
+            showLeftSide = true,
+            horizontalScrollState = androidx.compose.foundation.ScrollState(0),
+            canvasLength = 1000f,
+            entriesInPixel = emptyList(),
+            currentIndex = 0,
+        )
+        advanceUntilIdle()
+        assertEquals(emptyList(), events)
+
+        collector.cancel()
+    }
+}

--- a/src/jvmTest/kotlin/ui/SearchBarUiTest.kt
+++ b/src/jvmTest/kotlin/ui/SearchBarUiTest.kt
@@ -1,0 +1,87 @@
+package ui
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.isNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.SearchBar
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SearchBarUiTest {
+
+    @Test
+    fun testTypingUpdatesText() = runComposeUiTest {
+        val text = mutableStateOf("")
+        setContent {
+            AppTheme {
+                SearchBar(
+                    text = text.value,
+                    onTextChange = { text.value = it },
+                )
+            }
+        }
+        onNode(hasSetTextAction()).performTextInput("query")
+        assertEquals("query", text.value)
+        onNode(hasSetTextAction()).assertTextContains("query")
+    }
+
+    @Test
+    fun testSubmitViaImeAction() = runComposeUiTest {
+        val text = mutableStateOf("")
+        var submitted = 0
+        setContent {
+            AppTheme {
+                SearchBar(
+                    text = text.value,
+                    onTextChange = { text.value = it },
+                    onSubmit = { submitted++ },
+                )
+            }
+        }
+        onNode(hasSetTextAction()).performTextInput("abc")
+        onNode(hasSetTextAction()).performImeAction()
+        assertEquals(1, submitted)
+    }
+
+    @Test
+    fun testDisabledContentBlocksInputAndIsShown() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                SearchBar(
+                    text = "",
+                    onTextChange = {},
+                    disabledContent = { Text("Disabled hint") },
+                )
+            }
+        }
+        // providing disabledContent disables the text field
+        onNode(hasSetTextAction()).assert(isNotEnabled())
+        onNodeWithText("Disabled hint").assertExists()
+    }
+
+    @Test
+    fun testTrailingContentRendered() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                SearchBar(
+                    text = "",
+                    onTextChange = {},
+                    trailingContent = { Text("Trailing") },
+                )
+            }
+        }
+        onNodeWithText("Trailing").assertExists()
+        // the text field itself stays editable
+        onNode(hasSetTextAction()).assertExists()
+    }
+}

--- a/src/jvmTest/kotlin/ui/SelectionBoxUiTest.kt
+++ b/src/jvmTest/kotlin/ui/SelectionBoxUiTest.kt
@@ -1,0 +1,58 @@
+package ui
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.SelectionBox
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SelectionBoxUiTest {
+
+    @Test
+    fun testOpenDropdownAndSelectOption() = runComposeUiTest {
+        val value = mutableStateOf("One")
+        setContent {
+            AppTheme {
+                SelectionBox(
+                    value = value.value,
+                    onSelect = { value.value = it },
+                    options = listOf("One", "Two", "Three"),
+                )
+            }
+        }
+        // dropdown is closed initially
+        onNodeWithText("Two").assertDoesNotExist()
+
+        // clicking the box opens the dropdown
+        onNodeWithText("One").performClick()
+        onNodeWithText("Two").assertExists()
+        onNodeWithText("Three").assertExists()
+
+        // selecting an option commits it and closes the dropdown
+        onNodeWithText("Two").performClick()
+        assertEquals("Two", value.value)
+        onNodeWithText("Three").assertDoesNotExist()
+        onNodeWithText("Two").assertExists()
+    }
+
+    @Test
+    fun testDisabledSelectionBoxDoesNotOpen() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                SelectionBox(
+                    value = "One",
+                    onSelect = {},
+                    options = listOf("One", "Two"),
+                    enabled = false,
+                )
+            }
+        }
+        onNodeWithText("One").performClick()
+        onNodeWithText("Two").assertDoesNotExist()
+    }
+}

--- a/src/jvmTest/kotlin/ui/ToggleButtonGroupUiTest.kt
+++ b/src/jvmTest/kotlin/ui/ToggleButtonGroupUiTest.kt
@@ -1,0 +1,52 @@
+package ui
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.ToggleButtonGroup
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ToggleButtonGroupUiTest {
+
+    @Test
+    fun testClickChangesSelection() = runComposeUiTest {
+        val selected = mutableStateOf("A")
+        setContent {
+            AppTheme {
+                ToggleButtonGroup(
+                    selected = selected.value,
+                    options = listOf("A", "B", "C"),
+                    onSelectedChange = { selected.value = it },
+                    buttonContent = { Text(it) },
+                )
+            }
+        }
+        onNodeWithText("B").performClick()
+        assertEquals("B", selected.value)
+        onNodeWithText("C").performClick()
+        assertEquals("C", selected.value)
+    }
+
+    @Test
+    fun testClickingSelectedOptionStillInvokesCallback() = runComposeUiTest {
+        var calls = 0
+        setContent {
+            AppTheme {
+                ToggleButtonGroup(
+                    selected = "A",
+                    options = listOf("A", "B"),
+                    onSelectedChange = { calls++ },
+                    buttonContent = { Text(it) },
+                )
+            }
+        }
+        onNodeWithText("A").performClick()
+        assertEquals(1, calls)
+    }
+}

--- a/src/jvmTest/kotlin/ui/WarningTextUiTest.kt
+++ b/src/jvmTest/kotlin/ui/WarningTextUiTest.kt
@@ -1,0 +1,37 @@
+package ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import com.sdercolin.vlabeler.ui.common.WarningText
+import com.sdercolin.vlabeler.ui.common.WarningTextStyle
+import com.sdercolin.vlabeler.ui.theme.AppTheme
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class WarningTextUiTest {
+
+    @Test
+    fun testWarningStyleShowsWarningTitle() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                WarningText(text = "Something risky happened.", style = WarningTextStyle.Warning)
+            }
+        }
+        onNodeWithText("Warning").assertExists()
+        onNodeWithText("Something risky happened.").assertExists()
+        onNodeWithText("Error").assertDoesNotExist()
+    }
+
+    @Test
+    fun testErrorStyleShowsErrorTitle() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                WarningText(text = "Something failed.", style = WarningTextStyle.Error)
+            }
+        }
+        onNodeWithText("Error").assertExists()
+        onNodeWithText("Something failed.").assertExists()
+        onNodeWithText("Warning").assertDoesNotExist()
+    }
+}

--- a/src/jvmTest/kotlin/util/SavedMutableStateTest.kt
+++ b/src/jvmTest/kotlin/util/SavedMutableStateTest.kt
@@ -42,7 +42,6 @@ class SavedMutableStateTest {
         assertEquals(1, value)
         setValue(5)
         assertEquals(5, state.value)
-        // note: the destructured setter delegates to the wrapped state directly, so `save` is not called
-        assertEquals(emptyList(), saved)
+        assertEquals(listOf(5), saved)
     }
 }

--- a/src/jvmTest/kotlin/util/SavedMutableStateTest.kt
+++ b/src/jvmTest/kotlin/util/SavedMutableStateTest.kt
@@ -1,0 +1,48 @@
+package util
+
+import com.sdercolin.vlabeler.util.savedMutableStateOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SavedMutableStateTest {
+
+    @Test
+    fun `initial value does not trigger save`() {
+        val saved = mutableListOf<Int>()
+        val state = savedMutableStateOf(1) { saved.add(it) }
+        assertEquals(1, state.value)
+        assertEquals(emptyList(), saved)
+    }
+
+    @Test
+    fun `setting a value saves it`() {
+        val saved = mutableListOf<Int>()
+        val state = savedMutableStateOf(1) { saved.add(it) }
+        state.value = 2
+        assertEquals(2, state.value)
+        assertEquals(listOf(2), saved)
+    }
+
+    @Test
+    fun `every set is saved including repeated values`() {
+        val saved = mutableListOf<String>()
+        val state = savedMutableStateOf("a") { saved.add(it) }
+        state.value = "b"
+        state.value = "b"
+        state.value = "c"
+        assertEquals("c", state.value)
+        assertEquals(listOf("b", "b", "c"), saved)
+    }
+
+    @Test
+    fun `destructuring exposes the getter and setter`() {
+        val saved = mutableListOf<Int>()
+        val state = savedMutableStateOf(1) { saved.add(it) }
+        val (value, setValue) = state
+        assertEquals(1, value)
+        setValue(5)
+        assertEquals(5, state.value)
+        // note: the destructured setter delegates to the wrapped state directly, so `save` is not called
+        assertEquals(emptyList(), saved)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of the automated-tests effort: 117 new tests (492 total, all passing) for the UI layer.

### Compose UI test harness
- `compose.uiTest` dependency; tests use the JUnit-independent `runComposeUiTest` (`ExperimentalTestApi`), rendering offscreen through Skiko — **verified to run headless on the CI runner** with no xvfb or display setup
- Smoke tests + desktop-specific gotchas documented in `docs/testing.md` (wrapper `testTag` semantics, disabled-`BasicTextField` `SetText` quirk vs Android)

### State holders (85 tests, no rendering)
- **`ProjectStoreImpl` (58 tests)** driving the real implementation with real collaborators against fixture projects: project new/clear/edit transitions, undo/redo incl. index-squash, entry rename/duplicate/remove/move/cut, done/star/tag bulk edits, entry import/filters, sample directory changes, `updateProjectOnLoadedSample`, property setting via the real JS value setter, label reload from raw files, module export, auto-save modes
- `AppUnsavedChangesState`, `AppErrorState`, `AppProgressState`, `AppSnackbarState`, `ScrollFitViewModel`, `SavedMutableState`

### Component UI tests (30 tests)
12 `ui/common` components + `CommonConfirmationDialog`, behavior-focused via semantics: error prompts and commit/reject flows (`InputBox`/`IntegerInputBox`/`ColorHexInputBox`), IME submit (`SearchBar`), selection (`ToggleButtonGroup`, `SelectionBox`), blocking overlay click interception (`CircularProgress`), localized dialog text + callbacks

### Bug fix
- `SavedMutableState.component2()` delegated to the inner state's setter, so writes through a destructured setter bypassed the `save` callback and never persisted. Fixed by routing the destructured setter through the saving `value` property; all current call sites use property delegation and were unaffected (latent trap only)

### Testability refactor candidates (described only, for later discussion)
1. `AppRecordStore`: inject the record file path (currently writes unconditionally to `~/vLabeler`, so it is untested)
2. `ProjectStore`: depend on a narrow dialog interface instead of the whole `AppState` (would unlock reload-confirmation flow tests)
3. `ScrollFitViewModel.update`: accept a plain `scrollMax: Int` (would unlock fit-math tests)

### Not covered (future work)
Editor canvas/marker UI, dialogs requiring a full `AppState`, full-application flows.

## Test plan

- [x] `./gradlew jvmTest` — 492 tests, 0 failures
- [x] `./gradlew ktlintCheck`
- [x] Headless CI validated on the first commit of this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

