### PR TITLE
Phase 5: coverage gate, per-level test tasks, CI action upgrades

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew build test koverXmlReport koverHtmlReport
+          ./gradlew build test koverXmlReport koverHtmlReport koverVerify
 
       - name: Upload test and coverage reports
         if: always()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew build test koverXmlReport koverHtmlReport
+          ./gradlew build test koverXmlReport koverHtmlReport koverVerify
 
       - name: Upload test and coverage reports
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ Notes:
 
 Full guide: `docs/testing.md`. Keep both that file and this section updated when extending the test suite.
 
-- Tests use kotlin.test on JUnit Platform, under `src/jvmTest/kotlin`, in short packages mirroring the production area (`io`, `model`, `util`, `plugins`, ...). Coverage via Kover (`./gradlew koverHtmlReport`).
+- Tests use kotlin.test on JUnit Platform, under `src/jvmTest/kotlin`, in short packages mirroring the production area (`io`, `model`, `util`, `plugins`, ...). Coverage via Kover (`./gradlew koverHtmlReport`); CI enforces a minimal line coverage bound (`koverVerify`).
+- Per-level local runs: `./gradlew unitTest` / `integrationTest` / `uiTest`.
 - All bundled labelers and plugins have integration tests (`fixtures/`, `plugins/`) that execute their real JS scripts — when changing a bundled labeler/plugin, update its test in the same PR.
 - Compose UI tests use `runComposeUiTest` (headless via Skiko, works on CI); state holders like `ProjectStore` are tested without rendering. See the "Compose UI tests" section of `docs/testing.md` for desktop-specific gotchas.
 - Shared helpers in `src/jvmTest/kotlin/testutil/`: `TestLabelers` (loads real bundled labelers — the test task points `compose.application.resources.dir` at `resources/common`), `TestFixtures.deploy(...)` (copies a fixture project from `src/jvmTest/resources/fixtures/` and generates wav files at runtime — no binaries in git), `createTestProject(...)` (runs the real `projectOf` flow incl. JS scripts), `TestEnv.ensureLogDirectory()` (required before code that constructs `util.JavaScript()` with defaults; the log dir only exists where the app has run — missing on CI).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,51 @@ kotlin {
     }
 }
 
+// Test subsets by package, as a local development convenience to run one level in isolation.
+// They reuse the classes and classpath of the full `jvmTest` task. Note: these tasks are not instrumented by Kover
+// (it only instruments `jvmTest` in this setup), so coverage reports require a `jvmTest` run.
+fun registerTestSubset(name: String, subsetDescription: String, packages: List<String>) =
+    tasks.register(name, org.gradle.api.tasks.testing.Test::class) {
+        group = "verification"
+        description = subsetDescription
+        val jvmTest = tasks.getByName("jvmTest") as org.gradle.api.tasks.testing.Test
+        testClassesDirs = jvmTest.testClassesDirs
+        classpath = jvmTest.classpath
+        useJUnitPlatform()
+        systemProperty(
+            "compose.application.resources.dir",
+            project.layout.projectDirectory.dir("resources").dir("common").asFile.absolutePath,
+        )
+        filter { packages.forEach { includeTestsMatching("$it.*") } }
+    }
+
+registerTestSubset(
+    "unitTest",
+    "Run unit tests (util, model, env, strings, testutil)",
+    listOf("util", "model", "env", "strings", "testutil"),
+)
+registerTestSubset(
+    "integrationTest",
+    "Run integration tests (io, fixtures, plugins)",
+    listOf("io", "fixtures", "plugins"),
+)
+registerTestSubset(
+    "uiTest",
+    "Run UI tests (ui, com.sdercolin.vlabeler.ui)",
+    listOf("ui", "com.sdercolin.vlabeler.ui"),
+)
+
+koverReport {
+    defaults {
+        verify {
+            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 32% on 2026-07-07).
+            rule("Minimal line coverage") {
+                minBound(30)
+            }
+        }
+    }
+}
+
 compose.desktop {
     application {
         mainClass = "com.sdercolin.vlabeler.MainKt"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,12 +8,17 @@ conventions to follow when adding tests.
 ```bash
 ./gradlew jvmTest                                  # run all tests
 ./gradlew jvmTest --tests "io.RawLabelsTest"       # run a single test class
-./gradlew build test                               # what PR CI runs (includes ktlint and license report check)
+./gradlew unitTest                                 # only unit tests (util, model, env, strings, testutil)
+./gradlew integrationTest                          # only integration tests (io, fixtures, plugins)
+./gradlew uiTest                                   # only UI tests (ui)
+./gradlew build test koverVerify                   # what PR CI runs (includes ktlint and license report check)
 ./gradlew koverHtmlReport                          # coverage report at build/reports/kover/html
 ```
 
-CI (`.github/workflows/pull-request.yml`) runs the full build and tests for PRs targeting `main`, `dev` and
-`feature/automated-tests`, and uploads test and coverage reports as workflow artifacts (also on failure).
+CI (`.github/workflows/pull-request.yml`) runs the full build and tests for PRs targeting `main` and `dev`, uploads
+test and coverage reports as workflow artifacts (also on failure), and enforces a minimal line coverage bound via
+`koverVerify` (see `koverReport` in `build.gradle.kts`; raise the bound as coverage grows). Coverage data is only
+collected from the full `jvmTest` task — the subset tasks are a local convenience and are not instrumented.
 
 ## Test source layout
 
@@ -30,7 +35,10 @@ mirroring the production area rather than full package paths:
 | `env/`, `strings/` | Environment and localization helpers |
 | `fixtures/` | Smoke tests creating projects from the fixture data with the bundled labelers |
 | `testutil/` | Shared test helpers (see below) |
-| (root) | Older tests for single utilities |
+
+A few tests use the full production package name (e.g. `com.sdercolin.vlabeler.ui.editor...`) instead of a short
+package; prefer short packages for new tests so that the subset tasks pick them up (the `uiTest` subset covers both
+forms for `ui`).
 
 ## Test infrastructure
 
@@ -129,6 +137,8 @@ The test effort is tracked on the `feature/automated-tests` branch (sub-parts ar
 4. ✅ **Phase 4 — UI tests**: state holders (`ProjectStore`, app states) and Compose UI tests for common
    components and a standalone dialog. Not covered yet: the editor canvas/marker UI, dialogs requiring a full
    `AppState`, and full-application flows.
-5. **Phase 5 — CI polish**: split unit/integration steps, coverage thresholds
+5. ✅ **Phase 5 — CI polish**: per-level test subset tasks, minimal line coverage bound in CI, GitHub Actions
+   upgrades. (Splitting CI into per-level steps was evaluated and skipped: Kover only instruments `jvmTest`, so a
+   split would double-run the whole suite for coverage — not worth it at the current suite runtime.)
 
 When adding tests in a new phase, keep this document and the Testing section of `CLAUDE.md` up to date.

--- a/src/jvmTest/kotlin/util/ColorTest.kt
+++ b/src/jvmTest/kotlin/util/ColorTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import androidx.compose.ui.graphics.Color
 import com.sdercolin.vlabeler.util.argbHexString
 import com.sdercolin.vlabeler.util.rgbHexString

--- a/src/jvmTest/kotlin/util/DefaultNewEntryNameTest.kt
+++ b/src/jvmTest/kotlin/util/DefaultNewEntryNameTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.getDefaultNewEntryName
 import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.test.Test

--- a/src/jvmTest/kotlin/util/FileUtilTest.kt
+++ b/src/jvmTest/kotlin/util/FileUtilTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.containsFileRecursively
 import com.sdercolin.vlabeler.util.findUnusedFile
 import java.io.File

--- a/src/jvmTest/kotlin/util/GroupingTest.kt
+++ b/src/jvmTest/kotlin/util/GroupingTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.groupContinuouslyBy
 import kotlin.test.Test
 import kotlin.test.assertContentEquals

--- a/src/jvmTest/kotlin/util/JavaScriptTest.kt
+++ b/src/jvmTest/kotlin/util/JavaScriptTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.JavaScript
 import java.io.File
 import kotlin.test.BeforeTest

--- a/src/jvmTest/kotlin/util/PixelListTest.kt
+++ b/src/jvmTest/kotlin/util/PixelListTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.roundPixels
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/jvmTest/kotlin/util/RegexTest.kt
+++ b/src/jvmTest/kotlin/util/RegexTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.matchGroups
 import com.sdercolin.vlabeler.util.replaceWithVariables
 import kotlin.test.Test

--- a/src/jvmTest/kotlin/util/TextUtilTest.kt
+++ b/src/jvmTest/kotlin/util/TextUtilTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.removeControlCharacters
 import com.sdercolin.vlabeler.util.toStringTrimmed
 import kotlin.test.Test

--- a/src/jvmTest/kotlin/util/UnicodeNormalizerTest.kt
+++ b/src/jvmTest/kotlin/util/UnicodeNormalizerTest.kt
@@ -1,3 +1,5 @@
+package util
+
 import com.sdercolin.vlabeler.util.UnicodeNormalizer
 import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.test.Test


### PR DESCRIPTION
## Summary

Phase 5 (final phase) of the automated-tests effort — CI and tooling polish:

- **Coverage gate**: `koverVerify` with a minimal line coverage bound of **30%** (current baseline: 32%) now runs in both PR and dev CI. Raise the bound in `build.gradle.kts` as coverage grows.
- **Per-level test tasks** for local development: `./gradlew unitTest` (util/model/env/strings/testutil), `integrationTest` (io/fixtures/plugins), `uiTest` (ui). Together they partition the full suite exactly (249 + 115 + 128 = 492).
- **Test layout cleanup**: the nine remaining root-package test files moved into the `util` package.
- **GitHub Actions upgrades**: `actions/checkout` and `actions/setup-java` v3 → v4 in the PR/dev workflows (Node 20 deprecation warnings). The release workflows still use v3 — left untouched to avoid risk near releases; can be upgraded separately.
- Docs updated (`docs/testing.md`, `CLAUDE.md`).

**Design note**: splitting CI into per-level test *steps* (the original phase-5 idea) was evaluated and deliberately skipped — Kover 0.7 only instruments the `jvmTest` task in this MPP setup, so a split would require running the whole suite twice to keep coverage data. At the current ~40s suite runtime the split buys nothing; the subset tasks provide the per-level granularity locally where it matters.

## Test plan

- [x] `./gradlew unitTest integrationTest uiTest jvmTest koverVerify ktlintCheck` — all green, subsets partition the suite exactly
- [x] Coverage gate verified passing at the 30% bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)