### PR TITLE
Fix two bundled plugin bugs found by the integration tests

### DIFF
--- a/resources/common/plugins/macro/utau-add-folder/plugin.json
+++ b/resources/common/plugins/macro/utau-add-folder/plugin.json
@@ -1,6 +1,6 @@
 {
-    "name": "utau-add-foler",
-    "version": 3,
+    "name": "utau-add-folder",
+    "version": 4,
     "type": "macro",
     "displayedName": {
         "en": "Add folder as sub-project for UTAU singer",
@@ -16,7 +16,7 @@
         "ja": "音源のルートディレクトリ以下のフォルダを参照しサブプロジェクトを作成する。このプラグインは、`UTAU singer ラベラー` と一緒に使用することを想定しています。",
         "ko": "가수 루트 디렉토리의 속 폴더에서 하위 프로젝트를 만들어 줘요. `UTAU 가수 라벨러`와 함께 사용하도록 설계된 플러그인이에요."
     },
-    "website": "https://github.com/sdercolin/vlabeler/tree/main/resources/common/plugins/macro/utau-add-foler",
+    "website": "https://github.com/sdercolin/vlabeler/tree/main/resources/common/plugins/macro/utau-add-folder",
     "supportedLabelFileExtension": "ini",
     "scope": "Project",
     "parameters": {

--- a/resources/common/plugins/template/cv-oto-gen/cv-oto-gen.js
+++ b/resources/common/plugins/template/cv-oto-gen/cv-oto-gen.js
@@ -23,6 +23,6 @@ points = [fixed, preutterance, overlap]
 points.push(start)
 
 for (sample of samples) {
-    entry = new Entry(sample, sample, start, end, points, extras)
+    entry = new Entry(sample, getNameWithoutExtension(sample), start, end, points, extras)
     output.push(entry)
 }

--- a/resources/common/plugins/template/cv-oto-gen/plugin.json
+++ b/resources/common/plugins/template/cv-oto-gen/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "cv-oto-gen",
-    "version": 7,
+    "version": 8,
     "type": "template",
     "displayedName": {
         "en": "CV oto generator",

--- a/src/jvmTest/kotlin/plugins/MacroPluginUtauAddFolderTest.kt
+++ b/src/jvmTest/kotlin/plugins/MacroPluginUtauAddFolderTest.kt
@@ -7,12 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-/**
- * The name declared in the plugin.json of the "utau-add-folder" plugin. Note that it differs from the directory name
- * "utau-add-folder": the declared name (and the website field) contains a typo ("foler"). This is a suspected bug in
- * the bundled resources; the tests pin the current behavior by loading the plugin with the declared name.
- */
-private const val UTAU_ADD_FOLDER_PLUGIN_NAME = "utau-add-foler"
+private const val UTAU_ADD_FOLDER_PLUGIN_NAME = "utau-add-folder"
 
 /**
  * Integration tests for the bundled "utau-add-folder" macro plugin (project scope).

--- a/src/jvmTest/kotlin/plugins/OtoGenTemplatePluginsTest.kt
+++ b/src/jvmTest/kotlin/plugins/OtoGenTemplatePluginsTest.kt
@@ -45,11 +45,10 @@ class OtoGenTemplatePluginsTest {
         val entries = assertIs<TemplatePluginResult.Parsed>(result).entries
         // defaults: offset 100, overlap 30, preutterance 60, fixed 100, cutoff -1000
         // points are absolute positions: [fixed, preutterance, overlap, offset(start)]
-        // note: the current script uses the full sample file name (with extension) as the entry name
         assertEquals(
             listOf(
-                Entry("あ.wav", "あ.wav", 100f, 1100f, listOf(200f, 160f, 130f, 100f), listOf("-1000")),
-                Entry("か.wav", "か.wav", 100f, 1100f, listOf(200f, 160f, 130f, 100f), listOf("-1000")),
+                Entry("あ.wav", "あ", 100f, 1100f, listOf(200f, 160f, 130f, 100f), listOf("-1000")),
+                Entry("か.wav", "か", 100f, 1100f, listOf(200f, 160f, 130f, 100f), listOf("-1000")),
             ),
             entries,
         )


### PR DESCRIPTION
## Summary

Fixes the two plugin bugs pinned during the phase-3 integration tests (no migrations, per discussion):

1. **`cv-oto-gen`**: generated entry aliases included the `.wav` extension (`new Entry(sample, sample, ...)`); now uses `getNameWithoutExtension(sample)`, consistent with `vcv-oto-gen` and `cvvc-oto-gen`. Version 7 → 8.
2. **`utau-add-folder`**: `plugin.json` declared its own name as `"utau-add-foler"` (typo, also in the `website` URL which 404'd). Corrected. Version 3 → 4. Note: saved quick-launch slots referencing the old misspelled name will no longer resolve (accepted, no migration).

The integration tests that pinned the old behavior now assert the corrected behavior.

## Test plan

- [x] `./gradlew jvmTest` — 492 tests, 0 failures
- [x] `./gradlew ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)