### PR TITLE
Coverage batch 1: marker drag logic, project creator, repositories, IPC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,12 @@ kotlin {
                 "compose.application.resources.dir",
                 project.layout.projectDirectory.dir("resources").dir("common").asFile.absolutePath,
             )
+            // Redirect the application directory (logs, records, custom labelers/plugins) away from the real
+            // `~/vLabeler` so tests never read or write user data. See `AppDir` in `util/Path.kt`.
+            environment(
+                "VLABELER_APP_DIR",
+                project.layout.buildDirectory.dir("test-app-dir").get().asFile.absolutePath,
+            )
         }
     }
     sourceSets {
@@ -119,6 +125,10 @@ fun registerTestSubset(name: String, subsetDescription: String, packages: List<S
             "compose.application.resources.dir",
             project.layout.projectDirectory.dir("resources").dir("common").asFile.absolutePath,
         )
+        environment(
+            "VLABELER_APP_DIR",
+            project.layout.buildDirectory.dir("test-app-dir").get().asFile.absolutePath,
+        )
         filter { packages.forEach { includeTestsMatching("$it.*") } }
     }
 
@@ -141,9 +151,9 @@ registerTestSubset(
 koverReport {
     defaults {
         verify {
-            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 32% on 2026-07-07).
+            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 36% on 2026-07-08).
             rule("Minimal line coverage") {
-                minBound(30)
+                minBound(34)
             }
         }
     }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,10 @@ mirroring the production area rather than full package paths:
 | `io/` | Label parsing/writing, reloading, project files/lifecycle, wave loading, DSP (power/spectrogram/fundamental) |
 | `model/` | Domain model: `Module`, `ProjectHistory`, `LabelerConf`, `Entry`, serialization |
 | `plugins/` | Integration tests executing all bundled template and macro plugins through the real plugin runner |
-| `ui/` | State-holder tests (`ProjectStore`, app states) and Compose UI tests (`*UiTest`) for common components |
+| `repository/` | Cache repositories: versioning/invalidation, move/clear |
+| `ipc/` | Remote-control API: wire-level JSON contract and real ZeroMQ round trips |
+| `ui/` | State-holder tests (`ProjectStore`, project creator wizard, app states) and Compose UI tests (`*UiTest`) |
+| `com.sdercolin.vlabeler.ui.editor.labeler.marker` | Editor marker drag/constraint logic (`MarkerStateFactory` builds real states) |
 | `util/` | Pure helper functions |
 | `env/`, `strings/` | Environment and localization helpers |
 | `fixtures/` | Smoke tests creating projects from the fixture data with the bundled labelers |
@@ -109,9 +112,12 @@ implementations against fixture projects.
 
 ### Environment gotchas
 
+- **Application directory**: the test tasks set the `VLABELER_APP_DIR` environment variable to `build/test-app-dir`,
+  so `AppDir` (logs, records, custom labelers/plugins) never points at the real user directory. Tests must still not
+  write outside temp directories or that build directory.
 - **Logging**: set `Log.muted = true` in `@BeforeTest` and back to `false` in `@AfterTest` when the tested code logs.
 - **Log directory**: constructing `util.JavaScript()` with default arguments opens the info log file directly, which
-  fails on machines where the app has never run (e.g. CI). Call `testutil.TestEnv.ensureLogDirectory()` first
+  fails if the (redirected) log directory does not exist yet. Call `testutil.TestEnv.ensureLogDirectory()` first
   (`createTestProject` already does).
 - **License report**: the `test` Gradle task depends on `checkLicenseReportUpdate`; run
   `./gradlew updateLicenseReport` after changing dependencies.

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/EntryConverterTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/EntryConverterTest.kt
@@ -1,0 +1,147 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.EntryNotes
+import com.sdercolin.vlabeler.ui.editor.IndexedEntry
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class EntryConverterTest {
+
+    @Test
+    fun convertMillisToPixelDividesFramesByResolution() {
+        // 100 ms at 44100 Hz = 4410 frames; at resolution 50 -> 88.2 px
+        val converter = EntryConverter(sampleRate = 44100f, resolution = 50)
+        assertEquals(88.2f, converter.convertToPixel(100f), 0.001f)
+    }
+
+    @Test
+    fun convertPixelToMillisIsInverseOfConvertToPixel() {
+        val converter = EntryConverter(sampleRate = 44100f, resolution = 50)
+        val millis = 123.4f
+        assertEquals(millis, converter.convertToMillis(converter.convertToPixel(millis)), 0.001f)
+    }
+
+    @Test
+    fun convertPixelToFrameMultipliesByResolution() {
+        val converter = EntryConverter(sampleRate = 44100f, resolution = 50)
+        assertEquals(4410f, converter.convertToFrame(88.2f), 0.001f)
+    }
+
+    @Test
+    fun oneMillisecondEqualsOnePixelWithSampleRate1000AndResolution1() {
+        val converter = EntryConverter(sampleRate = 1000f, resolution = 1)
+        assertEquals(250f, converter.convertToPixel(250f))
+        assertEquals(250f, converter.convertToMillis(250f))
+    }
+
+    @Test
+    fun convertEntryToPixelScalesAllValues() {
+        // 1000 Hz at resolution 2 -> 1 px == 2 ms
+        val converter = EntryConverter(sampleRate = 1000f, resolution = 2)
+        val entry = IndexedEntry(
+            entry = Entry(
+                sample = "a.wav",
+                name = "a",
+                start = 100f,
+                end = 500f,
+                points = listOf(200f, 300f),
+                extras = listOf("x"),
+            ),
+            index = 3,
+        )
+        val converted = converter.convertToPixel(entry, sampleFileLengthMillis = 1000f)
+        assertEquals(3, converted.index)
+        assertEquals("a.wav", converted.sample)
+        assertEquals("a", converted.name)
+        assertEquals(50f, converted.start)
+        assertEquals(250f, converted.end)
+        assertEquals(listOf(100f, 150f), converted.points)
+        assertEquals(listOf("x"), converted.extras)
+    }
+
+    @Test
+    fun convertEntryToPixelResolvesNegativeEndAgainstSampleLength() {
+        // end < 0 means "relative to the end of the sample": -100 ms in a 1000 ms sample -> 900 ms -> 450 px
+        val converter = EntryConverter(sampleRate = 1000f, resolution = 2)
+        val entry = IndexedEntry(
+            entry = Entry(
+                sample = "a.wav",
+                name = "a",
+                start = 100f,
+                end = -100f,
+                points = listOf(),
+                extras = listOf(),
+            ),
+            index = 0,
+        )
+        val converted = converter.convertToPixel(entry, sampleFileLengthMillis = 1000f)
+        assertEquals(450f, converted.end)
+    }
+
+    @Test
+    fun convertEntryToPixelResolvesZeroEndAgainstSampleLengthWhenNeedSync() {
+        // needSync && end == 0 also means "relative to the end of the sample": 1000 ms -> 500 px
+        val converter = EntryConverter(sampleRate = 1000f, resolution = 2)
+        val entry = IndexedEntry(
+            entry = Entry(
+                sample = "a.wav",
+                name = "a",
+                start = 100f,
+                end = 0f,
+                points = listOf(),
+                extras = listOf(),
+                needSync = true,
+            ),
+            index = 0,
+        )
+        val converted = converter.convertToPixel(entry, sampleFileLengthMillis = 1000f)
+        assertEquals(500f, converted.end)
+    }
+
+    @Test
+    fun convertEntryToMillisScalesAllValuesBack() {
+        val converter = EntryConverter(sampleRate = 1000f, resolution = 2)
+        val entryInPixel = EntryInPixel(
+            index = 5,
+            sample = "a.wav",
+            name = "a",
+            start = 50f,
+            end = 250f,
+            points = listOf(100f, 150f),
+            extras = listOf("x"),
+            notes = EntryNotes(),
+        )
+        val converted = converter.convertToMillis(entryInPixel)
+        assertEquals(5, converted.index)
+        assertEquals("a.wav", converted.sample)
+        assertEquals("a", converted.name)
+        assertEquals(100f, converted.start)
+        assertEquals(500f, converted.end)
+        assertEquals(listOf(200f, 300f), converted.points)
+        assertEquals(listOf("x"), converted.extras)
+    }
+
+    @Test
+    fun entryRoundTripPreservesValues() {
+        val converter = EntryConverter(sampleRate = 44100f, resolution = 40)
+        val entry = IndexedEntry(
+            entry = Entry(
+                sample = "a.wav",
+                name = "a",
+                start = 100f,
+                end = 500f,
+                points = listOf(200f, 300f),
+                extras = listOf(),
+            ),
+            index = 0,
+        )
+        val roundTrip = converter.convertToMillis(converter.convertToPixel(entry, sampleFileLengthMillis = 1000f))
+        assertEquals(entry.start, roundTrip.start, 0.001f)
+        assertEquals(entry.end, roundTrip.end, 0.001f)
+        assertEquals(entry.points.size, roundTrip.points.size)
+        entry.points.zip(roundTrip.points).forEach { (expected, actual) ->
+            assertEquals(expected, actual, 0.001f)
+        }
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/EntryInPixelTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/EntryInPixelTest.kt
@@ -1,0 +1,173 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import com.sdercolin.vlabeler.model.EntryNotes
+import org.junit.jupiter.api.Test
+import testutil.TestLabelers
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EntryInPixelTest {
+
+    /**
+     * The `utau-singer-labeler` has fields [fixed, preu, ovl, left] where "left" (index 3) has `replaceStart == true`,
+     * so the labeler uses an implicit start.
+     */
+    private val utauSinger get() = TestLabelers.utauSinger
+
+    /**
+     * The `nnsvs-singer-labeler` is continuous and has no fields, so start/end are explicit.
+     */
+    private val nnsvsSinger get() = TestLabelers.nnsvsSinger
+
+    private fun entry(
+        start: Float,
+        end: Float,
+        points: List<Float> = emptyList(),
+    ) = EntryInPixel(
+        index = 0,
+        sample = "sample.wav",
+        name = "entry",
+        start = start,
+        end = end,
+        points = points,
+        extras = emptyList(),
+        notes = EntryNotes(),
+    )
+
+    @Test
+    fun movedShiftsStartEndAndAllPoints() {
+        val moved = entry(start = 100f, end = 600f, points = listOf(400f, 250f)).moved(50f)
+        assertEquals(150f, moved.start)
+        assertEquals(650f, moved.end)
+        assertEquals(listOf(450f, 300f), moved.points)
+    }
+
+    @Test
+    fun movedWithNegativeDeltaShiftsLeft() {
+        val moved = entry(start = 100f, end = 600f, points = listOf(400f)).moved(-100f)
+        assertEquals(0f, moved.start)
+        assertEquals(500f, moved.end)
+        assertEquals(listOf(300f), moved.points)
+    }
+
+    @Test
+    fun validateCoercesAllValuesToCanvasWidth() {
+        val validated = entry(start = 100f, end = 1200f, points = listOf(1100f, 500f)).validate(1000f)
+        assertEquals(100f, validated.start)
+        assertEquals(1000f, validated.end)
+        assertEquals(listOf(1000f, 500f), validated.points)
+    }
+
+    @Test
+    fun collapsedCoercesEntryIntoBorders() {
+        // start is pulled up to the left border; points are then coerced into [start, end]
+        val collapsed = entry(start = 100f, end = 600f, points = listOf(150f, 400f))
+            .collapsed(leftBorder = 200f, rightBorder = 500f)
+        assertEquals(200f, collapsed.start)
+        assertEquals(500f, collapsed.end)
+        assertEquals(listOf(200f, 400f), collapsed.points)
+    }
+
+    @Test
+    fun collapsedProducesZeroLengthEntryWhenFullyLeftOfBorder() {
+        // The whole entry is left of the left border, so it collapses to [border, border]
+        val collapsed = entry(start = 100f, end = 200f, points = listOf(150f)).collapsed(leftBorder = 300f)
+        assertEquals(300f, collapsed.start)
+        assertEquals(300f, collapsed.end)
+        assertEquals(listOf(300f), collapsed.points)
+    }
+
+    @Test
+    fun getPointResolvesStartEndAndFieldIndexes() {
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f))
+        assertEquals(100f, target.getPoint(MarkerCursorState.START_POINT_INDEX))
+        assertEquals(600f, target.getPoint(MarkerCursorState.END_POINT_INDEX))
+        assertEquals(400f, target.getPoint(0))
+        assertEquals(250f, target.getPoint(1))
+    }
+
+    @Test
+    fun isValidCutPositionIsExclusiveOnBothEnds() {
+        val target = entry(start = 100f, end = 600f)
+        assertTrue(target.isValidCutPosition(100.5f))
+        assertTrue(target.isValidCutPosition(599.5f))
+        assertFalse(target.isValidCutPosition(100f))
+        assertFalse(target.isValidCutPosition(600f))
+        assertFalse(target.isValidCutPosition(50f))
+        assertFalse(target.isValidCutPosition(700f))
+    }
+
+    @Test
+    fun getActualStartUsesReplaceStartFieldForImplicitStartLabeler() {
+        // utau-singer: field 3 ("left") replaces start
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f, 150f, 120f))
+        assertEquals(120f, target.getActualStart(utauSinger))
+    }
+
+    @Test
+    fun getActualStartUsesStartForExplicitStartLabeler() {
+        val target = entry(start = 100f, end = 600f)
+        assertEquals(100f, target.getActualStart(nnsvsSinger))
+    }
+
+    @Test
+    fun setActualStartWritesReplaceStartFieldForImplicitStartLabeler() {
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f, 150f, 120f))
+        val updated = target.setActualStart(utauSinger, 200f)
+        assertEquals(listOf(400f, 250f, 150f, 200f), updated.points)
+        // The raw start is not touched; it is only synced later by validateImplicit
+        assertEquals(100f, updated.start)
+    }
+
+    @Test
+    fun setActualStartWritesStartForExplicitStartLabeler() {
+        val updated = entry(start = 100f, end = 600f).setActualStart(nnsvsSinger, 200f)
+        assertEquals(200f, updated.start)
+    }
+
+    @Test
+    fun getAndSetActualEndUseEndWhenNoReplaceEndField() {
+        // Neither labeler defines a replaceEnd field
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f, 150f, 120f))
+        assertEquals(600f, target.getActualEnd(utauSinger))
+        assertEquals(650f, target.setActualEnd(utauSinger, 650f).end)
+        assertEquals(600f, target.getActualEnd(nnsvsSinger))
+        assertEquals(650f, target.setActualEnd(nnsvsSinger, 650f).end)
+    }
+
+    @Test
+    fun validateImplicitSetsStartToMinimumPointForImplicitStartLabeler() {
+        // points min is 120 ("left"), so start becomes 120; end stays because utau-singer has no implicit end
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f, 150f, 120f))
+        val validated = target.validateImplicit(utauSinger)
+        assertEquals(120f, validated.start)
+        assertEquals(600f, validated.end)
+    }
+
+    @Test
+    fun validateImplicitUsesMinimumAcrossAllPoints() {
+        // "ovl" (index 2) was dragged below "left" (index 3): min point is 50
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f, 50f, 120f))
+        assertEquals(50f, target.validateImplicit(utauSinger).start)
+    }
+
+    @Test
+    fun validateImplicitKeepsEntryUntouchedForExplicitLabeler() {
+        val target = entry(start = 100f, end = 600f)
+        assertEquals(target, target.validateImplicit(nnsvsSinger))
+    }
+
+    @Test
+    fun getActualMiddlePointsExcludesReplaceStartField() {
+        // Fields 0..2 (fixed, preu, ovl) are middle points; field 3 (left) replaces start and is excluded
+        val target = entry(start = 100f, end = 600f, points = listOf(400f, 250f, 150f, 120f))
+        assertEquals(listOf(400f, 250f, 150f), target.getActualMiddlePoints(utauSinger))
+    }
+
+    @Test
+    fun getActualMiddlePointsIsEmptyForLabelerWithoutFields() {
+        val target = entry(start = 100f, end = 600f)
+        assertEquals(emptyList<Float>(), target.getActualMiddlePoints(nnsvsSinger))
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerCursorStateMoveTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerCursorStateMoveTest.kt
@@ -1,0 +1,72 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the parts of [MarkerCursorState] that are not covered by [MarkerCursorStateTest].
+ */
+class MarkerCursorStateMoveTest {
+
+    @Test
+    fun moveToHoverSetsPointAndHoveringMouse() {
+        val state = MarkerCursorState().moveToHover(index = 2, position = 300f)
+        assertEquals(2, state.pointIndex)
+        assertEquals(300f, state.pointPosition)
+        assertEquals(MarkerCursorState.Mouse.Hovering, state.mouse)
+    }
+
+    @Test
+    fun moveToNothingClearsPointAndMouse() {
+        val state = MarkerCursorState(
+            mouse = MarkerCursorState.Mouse.Hovering,
+            pointIndex = 2,
+            pointPosition = 300f,
+            position = 305f,
+        ).moveToNothing()
+        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.pointIndex)
+        assertNull(state.pointPosition)
+        assertEquals(MarkerCursorState.Mouse.None, state.mouse)
+        // the raw cursor position is kept
+        assertEquals(305f, state.position)
+    }
+
+    @Test
+    fun usingStartPointAndUsingEndPointReflectPointIndex() {
+        assertTrue(MarkerCursorState(pointIndex = MarkerCursorState.START_POINT_INDEX).usingStartPoint)
+        assertFalse(MarkerCursorState(pointIndex = MarkerCursorState.START_POINT_INDEX).usingEndPoint)
+        assertTrue(MarkerCursorState(pointIndex = MarkerCursorState.END_POINT_INDEX).usingEndPoint)
+        assertFalse(MarkerCursorState(pointIndex = MarkerCursorState.END_POINT_INDEX).usingStartPoint)
+        assertFalse(MarkerCursorState().usingStartPoint)
+        assertFalse(MarkerCursorState().usingEndPoint)
+    }
+
+    @Test
+    fun startDraggingWithoutPositionsLeavesOffsetNull() {
+        val state = MarkerCursorState(pointIndex = 0).startDragging(
+            lockedDrag = false,
+            withPreview = false,
+            forcedDrag = false,
+            cascadingDrag = false,
+        )
+        assertNull(state.relativeDraggingIndexOffset)
+    }
+
+    @Test
+    fun startDraggingAtExactPointPositionGivesOffsetZero() {
+        val state = MarkerCursorState(
+            pointIndex = 0,
+            pointPosition = 100f,
+            position = 100f,
+        ).startDragging(
+            lockedDrag = false,
+            withPreview = false,
+            forcedDrag = false,
+            cascadingDrag = false,
+        )
+        assertEquals(0, state.relativeDraggingIndexOffset)
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateDragTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateDragTest.kt
@@ -1,0 +1,326 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import org.junit.jupiter.api.Test
+import testutil.TestLabelers
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [MarkerState.getDraggedEntries], the core drag-constraint logic.
+ *
+ * All states use sampleRate = 1000 Hz / resolution = 1, so 1 ms == 1 px and the canvas is 1000 px long.
+ *
+ * Continuous scenario (nnsvs-singer, no fields): entries at 100..200, 200..350, 350..500 with flattened point indexes
+ * -2 (start), 0 (border at 200), 1 (border at 350), -1 (end).
+ *
+ * Non-continuous scenario (utau-singer): 1 entry with start = 100, end = 600, points = [fixed = 400, preu = 250,
+ * ovl = 150, left = 100]. "left" (index 3) replaces start, so the labeler uses an implicit start. Connected
+ * constraints (a <= b): (left, fixed), (left, preu), (preu, fixed), (ovl, fixed).
+ */
+class MarkerStateDragTest {
+
+    private val start = MarkerCursorState.START_POINT_INDEX
+    private val end = MarkerCursorState.END_POINT_INDEX
+
+    private fun continuousState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 200f, name = "a"),
+            MarkerStateFactory.entry(200f, 350f, name = "b"),
+            MarkerStateFactory.entry(350f, 500f, name = "c"),
+        ),
+    )
+
+    private fun continuousStateEditingMiddleEntry() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 200f, name = "a"),
+            MarkerStateFactory.entry(200f, 350f, name = "b"),
+            MarkerStateFactory.entry(350f, 500f, name = "c"),
+        ),
+        editedIndexes = listOf(1),
+    )
+
+    private fun utauSingerState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.utauSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 600f, points = listOf(400f, 250f, 150f, 100f)),
+        ),
+    )
+
+    private fun MarkerState.entry(index: Int) = entriesInPixel[index]
+
+    // region continuous mode
+
+    @Test
+    fun nonePointIndexReturnsEntriesUnchanged() {
+        val state = continuousState()
+        assertEquals(state.entriesInPixel, state.getDraggedEntries(MarkerCursorState.NONE_POINT_INDEX, 250f, false))
+    }
+
+    @Test
+    fun draggingStartMovesFirstEntryStart() {
+        val state = continuousState()
+        val result = state.getDraggedEntries(start, 150f, forcedDrag = false)
+        assertEquals(
+            listOf(state.entry(0).copy(start = 150f), state.entry(1), state.entry(2)),
+            result,
+        )
+    }
+
+    @Test
+    fun draggingStartIsClampedByFirstMiddlePoint() {
+        val state = continuousState()
+        // the first border (200) is the first middle point, so start cannot pass it
+        val result = state.getDraggedEntries(start, 250f, forcedDrag = false)
+        assertEquals(200f, result[0].start)
+    }
+
+    @Test
+    fun draggingStartIsClampedByLeftBorder() {
+        val state = continuousState()
+        val result = state.getDraggedEntries(start, -50f, forcedDrag = false)
+        assertEquals(0f, result[0].start)
+    }
+
+    @Test
+    fun draggingEndMovesLastEntryEnd() {
+        val state = continuousState()
+        val result = state.getDraggedEntries(end, 400f, forcedDrag = false)
+        assertEquals(
+            listOf(state.entry(0), state.entry(1), state.entry(2).copy(end = 400f)),
+            result,
+        )
+    }
+
+    @Test
+    fun draggingEndIsClampedByLastMiddlePoint() {
+        val state = continuousState()
+        // the last border (350) is the last middle point, so end cannot pass it
+        val result = state.getDraggedEntries(end, 300f, forcedDrag = false)
+        assertEquals(350f, result[2].end)
+    }
+
+    @Test
+    fun draggingEndIsClampedByRightBorder() {
+        val state = continuousState()
+        // right border is the canvas width (1000); max is rightBorder - 1
+        val result = state.getDraggedEntries(end, 1500f, forcedDrag = false)
+        assertEquals(999f, result[2].end)
+    }
+
+    @Test
+    fun draggingBorderMovesBothAdjacentEntries() {
+        val state = continuousState()
+        val result = state.getDraggedEntries(0, 250f, forcedDrag = false)
+        assertEquals(
+            listOf(
+                state.entry(0).copy(end = 250f),
+                state.entry(1).copy(start = 250f),
+                state.entry(2),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun draggingBorderIsClampedByLeftEntryStart() {
+        val state = continuousState()
+        // the left entry (100..200) has no points, so its start (100) is the min
+        val result = state.getDraggedEntries(0, 50f, forcedDrag = false)
+        assertEquals(100f, result[0].end)
+        assertEquals(100f, result[1].start)
+    }
+
+    @Test
+    fun draggingBorderIsClampedByRightEntryEnd() {
+        val state = continuousState()
+        // the right entry (200..350) has no points, so its end (350) is the max
+        val result = state.getDraggedEntries(0, 400f, forcedDrag = false)
+        assertEquals(350f, result[0].end)
+        assertEquals(350f, result[1].start)
+    }
+
+    @Test
+    fun forcedBorderDragPushesFollowingEntries() {
+        val state = continuousState()
+        // border 0 is dragged to 400, past the end (350) of entry "b":
+        // "a" is extended to 100..400; "b" is squeezed to 400..400; "c" is pushed to 400..500
+        val result = state.getDraggedEntries(0, 400f, forcedDrag = true)
+        assertEquals(
+            listOf(
+                state.entry(0).copy(end = 400f),
+                state.entry(1).copy(start = 400f, end = 400f),
+                state.entry(2).copy(start = 400f),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun forcedStartDragPushesFollowingEntries() {
+        val state = continuousState()
+        // start is dragged to 250, past the border at 200:
+        // "a" collapses to 250..250; "b" is squeezed to 250..350; "c" is untouched
+        val result = state.getDraggedEntries(start, 250f, forcedDrag = true)
+        assertEquals(
+            listOf(
+                state.entry(0).copy(start = 250f, end = 250f),
+                state.entry(1).copy(start = 250f),
+                state.entry(2),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun forcedEndDragPushesPrecedingEntries() {
+        val state = continuousState()
+        // end is dragged to 300, past the border at 350:
+        // "c" collapses to 300..300; "b" is squeezed to 200..300; "a" is untouched
+        val result = state.getDraggedEntries(end, 300f, forcedDrag = true)
+        assertEquals(
+            listOf(
+                state.entry(0),
+                state.entry(1).copy(end = 300f),
+                state.entry(2).copy(start = 300f, end = 300f),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun draggingStartOfMiddleEntryIsClampedByPreviousEntryStart() {
+        val state = continuousStateEditingMiddleEntry()
+        // editing only entry "b" (200..350): leftBorder is the previous entry's start (100)
+        val moved = state.getDraggedEntries(start, 150f, forcedDrag = false)
+        assertEquals(150f, moved[0].start)
+        val clamped = state.getDraggedEntries(start, 50f, forcedDrag = false)
+        assertEquals(100f, clamped[0].start)
+    }
+
+    @Test
+    fun draggingEndOfMiddleEntryIsClampedByNextEntryEnd() {
+        val state = continuousStateEditingMiddleEntry()
+        // editing only entry "b" (200..350): rightBorder is the next entry's end (500)
+        val moved = state.getDraggedEntries(end, 400f, forcedDrag = false)
+        assertEquals(400f, moved[0].end)
+        val clamped = state.getDraggedEntries(end, 520f, forcedDrag = false)
+        assertEquals(499f, clamped[0].end)
+    }
+
+    // endregion
+
+    // region utau-singer (implicit start + field constraints)
+
+    @Test
+    fun draggingImplicitStartWritesReplaceStartField() {
+        val state = utauSingerState()
+        // dragging start moves the "left" point (points[3]); the raw start is re-synced to the minimum point
+        val result = state.getDraggedEntries(start, 200f, forcedDrag = false)
+        assertEquals(
+            state.entry(0).copy(start = 150f, points = listOf(400f, 250f, 150f, 200f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun draggingImplicitStartIsClampedByConstrainedFields() {
+        val state = utauSingerState()
+        // "left" <= "fixed" (400) and "left" <= "preu" (250), so the max is 250
+        val result = state.getDraggedEntries(start, 300f, forcedDrag = false)
+        assertEquals(listOf(400f, 250f, 150f, 250f), result[0].points)
+        assertEquals(150f, result[0].start)
+    }
+
+    @Test
+    fun draggingImplicitStartIsClampedByLeftBorder() {
+        val state = utauSingerState()
+        val result = state.getDraggedEntries(start, -50f, forcedDrag = false)
+        assertEquals(listOf(400f, 250f, 150f, 0f), result[0].points)
+        assertEquals(0f, result[0].start)
+    }
+
+    @Test
+    fun draggingFieldPointIsClampedByConstraintsOnBothSides() {
+        val state = utauSingerState()
+        // "preu" (index 1): "left" (100) <= "preu" <= "fixed" (400)
+        val moved = state.getDraggedEntries(1, 350f, forcedDrag = false)
+        assertEquals(listOf(400f, 350f, 150f, 100f), moved[0].points)
+        val clampedLow = state.getDraggedEntries(1, 50f, forcedDrag = false)
+        assertEquals(listOf(400f, 100f, 150f, 100f), clampedLow[0].points)
+        val clampedHigh = state.getDraggedEntries(1, 450f, forcedDrag = false)
+        assertEquals(listOf(400f, 400f, 150f, 100f), clampedHigh[0].points)
+    }
+
+    @Test
+    fun draggingUnconstrainedFieldPointBelowImplicitStartLowersStart() {
+        val state = utauSingerState()
+        // "ovl" (index 2) has no lower constraint; with an implicit start its min is the left canvas border,
+        // and dragging it below "left" re-syncs the raw start to the new minimum point
+        val result = state.getDraggedEntries(2, 20f, forcedDrag = false)
+        assertEquals(listOf(400f, 250f, 20f, 100f), result[0].points)
+        assertEquals(20f, result[0].start)
+    }
+
+    @Test
+    fun draggingFieldPointIsClampedByMaximumOfConstrainingPoints() {
+        val state = utauSingerState()
+        // "fixed" (index 0) must be >= "left" (100), "preu" (250) and "ovl" (150): min is 250
+        val result = state.getDraggedEntries(0, 200f, forcedDrag = false)
+        assertEquals(listOf(250f, 250f, 150f, 100f), result[0].points)
+    }
+
+    @Test
+    fun draggingFieldPointWithoutUpperConstraintIsClampedByEntryEnd() {
+        val state = utauSingerState()
+        // "fixed" has no upper field constraint, and the labeler has no implicit end, so the max is end (600)
+        val result = state.getDraggedEntries(0, 700f, forcedDrag = false)
+        assertEquals(listOf(600f, 250f, 150f, 100f), result[0].points)
+    }
+
+    @Test
+    fun draggingEndIsClampedByLastMiddlePointInSingleEntryMode() {
+        val state = utauSingerState()
+        val moved = state.getDraggedEntries(end, 550f, forcedDrag = false)
+        assertEquals(550f, moved[0].end)
+        // "fixed" (400) is the largest middle point
+        val clamped = state.getDraggedEntries(end, 300f, forcedDrag = false)
+        assertEquals(400f, clamped[0].end)
+    }
+
+    @Test
+    fun forcedFieldDragPastEndExtendsEnd() {
+        val state = utauSingerState()
+        // forced drag ignores constraints: "fixed" goes to 700, and the entry end is extended to follow it
+        val result = state.getDraggedEntries(0, 700f, forcedDrag = true)
+        assertEquals(
+            state.entry(0).copy(end = 700f, points = listOf(700f, 250f, 150f, 100f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun forcedFieldDragPushesConstrainedPointsAlong() {
+        val state = utauSingerState()
+        // "fixed" is force-dragged to 120; "preu" (250) and "ovl" (150) must stay <= "fixed" so they are pushed
+        // down to 120, while "left" (100) is already below and stays
+        val result = state.getDraggedEntries(0, 120f, forcedDrag = true)
+        assertEquals(
+            state.entry(0).copy(points = listOf(120f, 120f, 120f, 100f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun forcedEndDragBeforeStartCollapsesWholeEntry() {
+        val state = utauSingerState()
+        // end is force-dragged to 90, before every point: the entry collapses to a zero-length entry at 90
+        val result = state.getDraggedEntries(end, 90f, forcedDrag = true)
+        assertEquals(
+            state.entry(0).copy(start = 90f, end = 90f, points = listOf(90f, 90f, 90f, 90f)),
+            result[0],
+        )
+    }
+
+    // endregion
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateFactory.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateFactory.kt
@@ -1,0 +1,128 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import androidx.compose.runtime.mutableStateOf
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.LabelerConf
+import com.sdercolin.vlabeler.model.Module
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.ui.editor.IndexedEntry
+import com.sdercolin.vlabeler.ui.editor.labeler.CanvasParams
+import com.sdercolin.vlabeler.ui.editor.labeler.parallel.SnapDrag
+import com.sdercolin.vlabeler.util.getNextOrNull
+import com.sdercolin.vlabeler.util.getPreviousOrNull
+
+/**
+ * Builds a [MarkerState] with plain values in the same way as the production `rememberMarkerState` composable, so
+ * that the pure computation logic of [MarkerState] can be tested without any Compose rendering.
+ *
+ * By default [sampleRate] is 1000 Hz and [resolution] is 1, so that 1 millisecond == 1 frame == 1 pixel, which makes
+ * expected values in tests easy to compute by hand.
+ */
+object MarkerStateFactory {
+
+    const val DEFAULT_SAMPLE_LENGTH_MILLIS = 1000f
+    private const val RAW_FILE_PATH = "label.txt"
+
+    fun entry(
+        start: Float,
+        end: Float,
+        points: List<Float> = emptyList(),
+        name: String = "entry",
+        sample: String = "sample.wav",
+    ) = Entry(
+        sample = sample,
+        name = name,
+        start = start,
+        end = end,
+        points = points,
+        extras = emptyList(),
+    )
+
+    fun parallelModule(name: String, entries: List<Entry>) = Module(
+        name = name,
+        sampleDirectoryPath = "/samples",
+        entries = entries,
+        currentIndex = 0,
+        rawFilePath = RAW_FILE_PATH,
+    )
+
+    /**
+     * @param labelerConf the labeler in use.
+     * @param allEntries all entries of the current module (== the current group), in millis.
+     * @param editedIndexes indexes in [allEntries] that are being edited (all of them by default).
+     * @param parallelModules additional modules that are parallel to the current module (sharing the raw label file).
+     */
+    fun create(
+        labelerConf: LabelerConf,
+        allEntries: List<Entry>,
+        editedIndexes: List<Int> = allEntries.indices.toList(),
+        sampleRate: Float = 1000f,
+        resolution: Int = 1,
+        sampleLengthMillis: Float = DEFAULT_SAMPLE_LENGTH_MILLIS,
+        parallelModules: List<Module> = emptyList(),
+    ): MarkerState {
+        val module = Module(
+            name = "main",
+            sampleDirectoryPath = "/samples",
+            entries = allEntries,
+            currentIndex = editedIndexes.first(),
+            rawFilePath = RAW_FILE_PATH,
+        )
+        val project = Project(
+            rootSampleDirectoryPath = "/",
+            workingDirectoryPath = "/work",
+            projectName = "test",
+            cacheDirectoryPath = "/cache",
+            originalLabelerConf = labelerConf,
+            modules = listOf(module) + parallelModules,
+            currentModuleIndex = 0,
+            autoExport = false,
+        )
+        val canvasParams = CanvasParams(
+            dataLength = (sampleLengthMillis * sampleRate / 1000).toInt(),
+            chunkCount = 1,
+            resolution = resolution,
+        )
+        val entryConverter = EntryConverter(sampleRate, resolution)
+        val indexedEntries = allEntries.mapIndexed { index, entry -> IndexedEntry(entry, index) }
+        val editedEntries = editedIndexes.map { indexedEntries[it] }
+        val entriesInPixel = editedEntries.map {
+            entryConverter.convertToPixel(it, sampleLengthMillis).validate(canvasParams.lengthInPixel)
+        }
+        val entriesInSampleInPixel = indexedEntries.map {
+            entryConverter.convertToPixel(it, sampleLengthMillis).validate(canvasParams.lengthInPixel)
+        }
+        val previousEntry = if (labelerConf.continuous) {
+            entriesInSampleInPixel.getPreviousOrNull { it.index == entriesInPixel.first().index }
+        } else {
+            null
+        }
+        val leftBorder = previousEntry?.start ?: 0f
+        val nextEntry = if (labelerConf.continuous) {
+            entriesInSampleInPixel.getNextOrNull { it.index == entriesInPixel.last().index }
+        } else {
+            null
+        }
+        val rightBorder = nextEntry?.end ?: canvasParams.lengthInPixel
+        return MarkerState(
+            entries = editedEntries,
+            entriesInCurrentGroup = indexedEntries,
+            labelerConf = labelerConf,
+            canvasParams = canvasParams,
+            sampleLengthMillis = sampleLengthMillis,
+            entryConverter = entryConverter,
+            entriesInPixel = entriesInPixel,
+            entriesInSampleInPixel = entriesInSampleInPixel,
+            leftBorder = leftBorder,
+            rightBorder = rightBorder,
+            cursorState = mutableStateOf(MarkerCursorState()),
+            scissorsState = mutableStateOf(null),
+            panState = mutableStateOf(null),
+            playbackState = mutableStateOf(null),
+            canvasHeightState = mutableStateOf(0f),
+            waveformsHeightRatio = 0.8f,
+            snapDrag = SnapDrag(project, canvasParams.lengthInPixel, entryConverter),
+            project = project,
+        )
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateHoverTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateHoverTest.kt
@@ -1,0 +1,137 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import org.junit.jupiter.api.Test
+import testutil.TestLabelers
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [MarkerState.getPointIndexForHovering] and [MarkerState.onLabelHovered].
+ *
+ * All states use sampleRate = 1000 Hz / resolution = 1 (1 ms == 1 px, canvas 1000 px). The hover radius is 20 px for
+ * start/end/borders and 5 px for field points. [labelSize] is zero so the label-rectangle hit test never matches and
+ * only the line hit test is exercised.
+ */
+class MarkerStateHoverTest {
+
+    private val density = Density(1f)
+    private val labelSize = DpSize(0.dp, 0.dp)
+    private val labelShiftUp = 0.dp
+    private val canvasHeight = 1000f
+    private val waveformsHeightRatio = 0.8f
+
+    private fun MarkerState.hover(x: Float, y: Float) = getPointIndexForHovering(
+        x = x,
+        y = y,
+        conf = labelerConf,
+        canvasHeight = canvasHeight,
+        waveformsHeightRatio = waveformsHeightRatio,
+        density = density,
+        labelSize = labelSize,
+        labelShiftUp = labelShiftUp,
+    )
+
+    /**
+     * Continuous entries at 100..200, 200..350, 350..500: start = 100, borders = [200, 350], end = 500.
+     */
+    private fun continuousState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 200f, name = "a"),
+            MarkerStateFactory.entry(200f, 350f, name = "b"),
+            MarkerStateFactory.entry(350f, 500f, name = "c"),
+        ),
+    )
+
+    /**
+     * Utau-singer single entry: implicit start = 100 ("left"), fixed = 400, preu = 250, ovl = 150, end = 600.
+     */
+    private fun utauSingerState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.utauSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 600f, points = listOf(400f, 250f, 150f, 100f)),
+        ),
+    )
+
+    @Test
+    fun hoveringNearEndReturnsEndPointIndex() {
+        val state = continuousState()
+        // right of end
+        assertEquals(MarkerCursorState.END_POINT_INDEX, state.hover(505f, 500f))
+        // left of end, but still closer to the end than to the last border (350)
+        assertEquals(MarkerCursorState.END_POINT_INDEX, state.hover(495f, 500f))
+    }
+
+    @Test
+    fun hoveringNearStartReturnsStartPointIndex() {
+        val state = continuousState()
+        // left of start
+        assertEquals(MarkerCursorState.START_POINT_INDEX, state.hover(95f, 500f))
+        // right of start, but still closer to the start than to the first border (200)
+        assertEquals(MarkerCursorState.START_POINT_INDEX, state.hover(110f, 500f))
+    }
+
+    @Test
+    fun hoveringNearStartOfImplicitStartLabelerReturnsStartPointIndex() {
+        val state = utauSingerState()
+        // the actual start is the "left" point at 100
+        assertEquals(MarkerCursorState.START_POINT_INDEX, state.hover(99f, 500f))
+    }
+
+    @Test
+    fun hoveringNearBorderReturnsBorderIndex() {
+        val state = continuousState()
+        // border 0 is at 200 with a radius of 20 px
+        assertEquals(0, state.hover(205f, 500f))
+        assertEquals(0, state.hover(195f, 500f))
+    }
+
+    @Test
+    fun hoveringFarFromAnyPointReturnsNone() {
+        val state = continuousState()
+        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.hover(275f, 500f))
+    }
+
+    @Test
+    fun hoveringIsDisabledWhileALabelIsHovered() {
+        val state = continuousState()
+        state.onLabelHovered(0, true)
+        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.hover(205f, 500f))
+        state.onLabelHovered(0, false)
+        assertEquals(0, state.hover(205f, 500f))
+    }
+
+    @Test
+    fun hoveringFieldPointLineBelowItsTopReturnsFieldIndex() {
+        val state = utauSingerState()
+        // "fixed" (index 0) is at 400 with a radius of 5 px and height 0.5:
+        // its line top is canvasHeight * ratio * (1 - 0.5) = 400, so y = 800 hits the line
+        assertEquals(0, state.hover(403f, 800f))
+    }
+
+    @Test
+    fun hoveringFieldPointAboveItsLineTopReturnsNone() {
+        val state = utauSingerState()
+        // same x as above, but y = 100 is above the line top (400)
+        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.hover(403f, 100f))
+    }
+
+    @Test
+    fun hoveringNearStartButCloserToNextPointReturnsNone() {
+        // Suspected production bug (pinning current behavior): the final start check in
+        // MarkerState.getPointIndexForHovering computes START_POINT_INDEX without returning it, so a position that
+        // is within the start radius but closer to the next point ends up as NONE instead of START.
+        val state = MarkerStateFactory.create(
+            labelerConf = TestLabelers.nnsvsSinger,
+            allEntries = listOf(
+                MarkerStateFactory.entry(100f, 110f, name = "a"),
+                MarkerStateFactory.entry(110f, 500f, name = "b"),
+            ),
+        )
+        // x = 108 is within 20 px of the start (100) but closer to the border (110); the line hit test skips the
+        // border because the position is also within the start radius and left of the border
+        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.hover(108f, 500f))
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateIndexTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateIndexTest.kt
@@ -1,0 +1,222 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import org.junit.jupiter.api.Test
+import testutil.TestLabelers
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the index math and static geometry of [MarkerState].
+ *
+ * All states are built via [MarkerStateFactory] with sampleRate = 1000 Hz / resolution = 1, so 1 ms == 1 px and the
+ * canvas is 1000 px long.
+ *
+ * Continuous scenario (nnsvs-singer, no fields): 3 entries at 100..200, 200..350, 350..500. Flattened point indexes:
+ * -2 (start = 100), 0 (border = 200), 1 (border = 350), -1 (end = 500).
+ *
+ * Non-continuous scenario (utau-singer, fields [fixed, preu, ovl, left], "left" replaces start): 1 entry with start =
+ * 100, end = 600, points = [400, 250, 150, 100]. Flattened point indexes: -2 (actual start = points[3] = 100), 0
+ * (fixed = 400), 1 (preu = 250), 2 (ovl = 150), -1 (end = 600).
+ */
+class MarkerStateIndexTest {
+
+    private fun continuousState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 200f, name = "a"),
+            MarkerStateFactory.entry(200f, 350f, name = "b"),
+            MarkerStateFactory.entry(350f, 500f, name = "c"),
+        ),
+    )
+
+    private fun utauSingerState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.utauSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 600f, points = listOf(400f, 250f, 150f, 100f)),
+        ),
+    )
+
+    @Test
+    fun entryBordersAreTheSharedBordersOfContinuousEntries() {
+        assertEquals(listOf(200f, 350f), continuousState().entryBorders)
+    }
+
+    @Test
+    fun entryBordersAreEmptyForSingleEntry() {
+        assertEquals(emptyList<Float>(), utauSingerState().entryBorders)
+    }
+
+    @Test
+    fun constructionFailsForNonContinuousEntriesInMultiEntryMode() {
+        // entry "b" starts at 250 but entry "a" ends at 200, so the entries cannot be drawn together
+        assertFailsWith<IllegalArgumentException> {
+            MarkerStateFactory.create(
+                labelerConf = TestLabelers.nnsvsSinger,
+                allEntries = listOf(
+                    MarkerStateFactory.entry(100f, 200f, name = "a"),
+                    MarkerStateFactory.entry(250f, 350f, name = "b"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun everyNonNegativeIndexIsBorderIndexWhenLabelerHasNoFields() {
+        val state = continuousState()
+        assertTrue(state.isBorderIndex(0))
+        assertTrue(state.isBorderIndex(1))
+        assertTrue(state.isBorderIndex(2))
+        assertFalse(state.isBorderIndex(-1))
+        assertFalse(state.isBorderIndex(-2))
+    }
+
+    @Test
+    fun borderIndexesAreEveryFifthIndexWhenLabelerHasFourFields() {
+        val state = utauSingerState()
+        // fields.size + 1 == 5: indexes 0..3 are field points, 4 is a border, 5..8 field points, 9 a border, ...
+        assertFalse(state.isBorderIndex(0))
+        assertFalse(state.isBorderIndex(1))
+        assertFalse(state.isBorderIndex(2))
+        assertFalse(state.isBorderIndex(3))
+        assertTrue(state.isBorderIndex(4))
+        assertFalse(state.isBorderIndex(5))
+        assertFalse(state.isBorderIndex(8))
+        assertTrue(state.isBorderIndex(9))
+        assertFalse(state.isBorderIndex(-1))
+    }
+
+    @Test
+    fun getEntryIndexesByBorderIndexReturnsAdjacentEntryPair() {
+        val state = continuousState()
+        assertEquals(0 to 1, state.getEntryIndexesByBorderIndex(0))
+        assertEquals(1 to 2, state.getEntryIndexesByBorderIndex(1))
+    }
+
+    @Test
+    fun getEntryIndexesByBorderIndexRejectsNonBorderIndex() {
+        val state = utauSingerState()
+        assertFailsWith<IllegalArgumentException> { state.getEntryIndexesByBorderIndex(2) }
+    }
+
+    @Test
+    fun getPointPositionResolvesStartEndAndMiddlePointsInContinuousMode() {
+        val state = continuousState()
+        assertEquals(100f, state.getPointPosition(MarkerCursorState.START_POINT_INDEX))
+        assertEquals(500f, state.getPointPosition(MarkerCursorState.END_POINT_INDEX))
+        assertEquals(200f, state.getPointPosition(0))
+        assertEquals(350f, state.getPointPosition(1))
+    }
+
+    @Test
+    fun getPointPositionUsesImplicitStartAndFieldPoints() {
+        val state = utauSingerState()
+        // actual start is the "left" point (points[3]); middle points are fields 0..2 in field order
+        assertEquals(100f, state.getPointPosition(MarkerCursorState.START_POINT_INDEX))
+        assertEquals(600f, state.getPointPosition(MarkerCursorState.END_POINT_INDEX))
+        assertEquals(400f, state.getPointPosition(0))
+        assertEquals(250f, state.getPointPosition(1))
+        assertEquals(150f, state.getPointPosition(2))
+    }
+
+    @Test
+    fun getPointIndexAsSingleEntryForFirstEntryInContinuousMode() {
+        val state = continuousState()
+        // entry 0: its start is the global start; its end is border 0
+        assertEquals(
+            MarkerCursorState.START_POINT_INDEX,
+            state.getPointIndexAsSingleEntry(0, MarkerCursorState.START_POINT_INDEX),
+        )
+        assertEquals(MarkerCursorState.END_POINT_INDEX, state.getPointIndexAsSingleEntry(0, 0))
+    }
+
+    @Test
+    fun getPointIndexAsSingleEntryForMiddleEntryInContinuousMode() {
+        val state = continuousState()
+        // entry 1: border 0 is its start, border 1 is its end
+        assertEquals(MarkerCursorState.START_POINT_INDEX, state.getPointIndexAsSingleEntry(1, 0))
+        assertEquals(MarkerCursorState.END_POINT_INDEX, state.getPointIndexAsSingleEntry(1, 1))
+    }
+
+    @Test
+    fun getPointIndexAsSingleEntryForLastEntryInContinuousMode() {
+        val state = continuousState()
+        // entry 2: border 1 is its start, the global end is its end
+        assertEquals(MarkerCursorState.START_POINT_INDEX, state.getPointIndexAsSingleEntry(2, 1))
+        assertEquals(
+            MarkerCursorState.END_POINT_INDEX,
+            state.getPointIndexAsSingleEntry(2, MarkerCursorState.END_POINT_INDEX),
+        )
+    }
+
+    @Test
+    fun getPointIndexAsSingleEntryKeepsFieldPointIndexesForSingleEntry() {
+        val state = utauSingerState()
+        assertEquals(
+            MarkerCursorState.START_POINT_INDEX,
+            state.getPointIndexAsSingleEntry(0, MarkerCursorState.START_POINT_INDEX),
+        )
+        assertEquals(
+            MarkerCursorState.END_POINT_INDEX,
+            state.getPointIndexAsSingleEntry(0, MarkerCursorState.END_POINT_INDEX),
+        )
+        assertEquals(0, state.getPointIndexAsSingleEntry(0, 0))
+        assertEquals(1, state.getPointIndexAsSingleEntry(0, 1))
+        assertEquals(2, state.getPointIndexAsSingleEntry(0, 2))
+        assertEquals(3, state.getPointIndexAsSingleEntry(0, 3))
+    }
+
+    @Test
+    fun isValidCutPositionOnlyInsideAnEntry() {
+        val state = continuousState()
+        assertTrue(state.isValidCutPosition(150f))
+        assertTrue(state.isValidCutPosition(250f))
+        // exactly on a border or outside all entries is not cuttable
+        assertFalse(state.isValidCutPosition(200f))
+        assertFalse(state.isValidCutPosition(100f))
+        assertFalse(state.isValidCutPosition(500f))
+        assertFalse(state.isValidCutPosition(50f))
+        assertFalse(state.isValidCutPosition(700f))
+    }
+
+    @Test
+    fun getEntryIndexByCutPositionReturnsIndexOfContainingEntry() {
+        val state = continuousState()
+        assertEquals(0, state.getEntryIndexByCutPosition(150f))
+        assertEquals(1, state.getEntryIndexByCutPosition(250f))
+        assertEquals(2, state.getEntryIndexByCutPosition(499f))
+    }
+
+    @Test
+    fun isValidPlaybackPositionIsBoundedBySampleLength() {
+        val state = continuousState()
+        // sample length is 1000 ms == 1000 px
+        assertTrue(state.isValidPlaybackPosition(999f))
+        assertFalse(state.isValidPlaybackPosition(1000f))
+        assertFalse(state.isValidPlaybackPosition(1500f))
+    }
+
+    @Test
+    fun getClickedAudioRangeReturnsSurroundingBorders() {
+        val state = continuousState()
+        // borders (sorted, distinct): [0, 100, 200, 350, 500, 1000]
+        assertEquals(0f to 100f, state.getClickedAudioRange(50f, leftBorder = 0f, rightBorder = 1000f))
+        assertEquals(200f to 350f, state.getClickedAudioRange(250f, leftBorder = 0f, rightBorder = 1000f))
+        assertEquals(500f to 1000f, state.getClickedAudioRange(700f, leftBorder = 0f, rightBorder = 1000f))
+    }
+
+    @Test
+    fun getClickedAudioRangeReturnsOpenRangeOutsideBorders() {
+        val state = continuousState()
+        assertEquals(null to 0f, state.getClickedAudioRange(-10f, leftBorder = 0f, rightBorder = 1000f))
+        assertEquals(1000f to null, state.getClickedAudioRange(1100f, leftBorder = 0f, rightBorder = 1000f))
+    }
+
+    @Test
+    fun getClickedAudioRangeReturnsNullExactlyOnBorder() {
+        val state = continuousState()
+        assertNull(state.getClickedAudioRange(200f, leftBorder = 0f, rightBorder = 1000f))
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateLockedDragTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateLockedDragTest.kt
@@ -1,0 +1,138 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import org.junit.jupiter.api.Test
+import testutil.TestLabelers
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * Tests for [MarkerState.getLockedDraggedEntries], which translates all points of all entries together.
+ *
+ * All states use sampleRate = 1000 Hz / resolution = 1, so 1 ms == 1 px and the canvas is 1000 px long.
+ *
+ * The utau-singer scenario has 1 entry with start = 100, end = 600, points = [fixed = 400, preu = 250, ovl = 150,
+ * left = 100]; its minimum pixel is 100 and maximum pixel is 600, so without forced drag the translation is limited
+ * to dx in [-100, 399] (leftBorder = 0, rightBorder = 1000).
+ */
+class MarkerStateLockedDragTest {
+
+    private val start = MarkerCursorState.START_POINT_INDEX
+
+    private fun utauSingerState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.utauSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 600f, points = listOf(400f, 250f, 150f, 100f)),
+        ),
+    )
+
+    private fun continuousState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 200f, name = "a"),
+            MarkerStateFactory.entry(200f, 350f, name = "b"),
+            MarkerStateFactory.entry(350f, 500f, name = "c"),
+        ),
+    )
+
+    @Test
+    fun nonePointIndexReturnsEntriesUnchanged() {
+        val state = utauSingerState()
+        assertSame(
+            state.entriesInPixel,
+            state.getLockedDraggedEntries(MarkerCursorState.NONE_POINT_INDEX, 300f, false),
+        )
+    }
+
+    @Test
+    fun lockedDragOnStartTranslatesWholeEntry() {
+        val state = utauSingerState()
+        // start point is at 100 (implicit start = "left"); dragging to 300 translates everything by +200
+        val result = state.getLockedDraggedEntries(start, 300f, forcedDrag = false)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 300f, end = 800f, points = listOf(600f, 450f, 350f, 300f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun lockedDragOnFieldPointTranslatesWholeEntry() {
+        val state = utauSingerState()
+        // "preu" (index 1) is at 250; dragging to 270 translates everything by +20
+        val result = state.getLockedDraggedEntries(1, 270f, forcedDrag = false)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 120f, end = 620f, points = listOf(420f, 270f, 170f, 120f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun lockedDragIsClampedByLeftBorder() {
+        val state = utauSingerState()
+        // requested dx = -300, but the minimum pixel (100) may only move to the left border (0): dx = -100
+        val result = state.getLockedDraggedEntries(start, -200f, forcedDrag = false)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 0f, end = 500f, points = listOf(300f, 150f, 50f, 0f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun lockedDragIsClampedByRightBorder() {
+        val state = utauSingerState()
+        // requested dx = +500, but the maximum pixel (600) may only move to rightBorder - 1 (999): dx = +399
+        val result = state.getLockedDraggedEntries(start, 600f, forcedDrag = false)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 499f, end = 999f, points = listOf(799f, 649f, 549f, 499f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun lockedDragReturnsEntriesUnchangedWhenNoRoomToMove() {
+        // the single entry spans the whole canvas, so dxMax (0) <= dxMin (0)
+        val state = MarkerStateFactory.create(
+            labelerConf = TestLabelers.nnsvsSinger,
+            allEntries = listOf(MarkerStateFactory.entry(0f, 1000f)),
+        )
+        assertSame(state.entriesInPixel, state.getLockedDraggedEntries(start, 500f, forcedDrag = false))
+    }
+
+    @Test
+    fun lockedDragTranslatesAllEntriesInContinuousMode() {
+        val state = continuousState()
+        // border 0 is at 200; dragging to 250 translates all three entries by +50
+        val result = state.getLockedDraggedEntries(0, 250f, forcedDrag = false)
+        assertEquals(
+            listOf(
+                state.entriesInPixel[0].copy(start = 150f, end = 250f),
+                state.entriesInPixel[1].copy(start = 250f, end = 400f),
+                state.entriesInPixel[2].copy(start = 400f, end = 550f),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun forcedLockedDragCollapsesEntryAgainstRightBorder() {
+        val state = utauSingerState()
+        // forced drag allows dx up to rightBorder - 1 - currentX = 899; requested dx = +600 is applied, then the
+        // moved entry (700..1200) is collapsed into the canvas: end becomes 1000 while points stay within it
+        val result = state.getLockedDraggedEntries(start, 700f, forcedDrag = true)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 700f, end = 1000f, points = listOf(1000f, 850f, 750f, 700f)),
+            result[0],
+        )
+    }
+
+    @Test
+    fun forcedLockedDragCollapsesEntryAgainstLeftBorder() {
+        val state = utauSingerState()
+        // in forced mode the range is based on the dragged point itself: dxMin = leftBorder - currentX = -100;
+        // the requested dx = -150 is clamped to -100, so the entry moves to 0..500
+        val result = state.getLockedDraggedEntries(start, -50f, forcedDrag = true)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 0f, end = 500f, points = listOf(300f, 150f, 50f, 0f)),
+            result[0],
+        )
+    }
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateMiscTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateMiscTest.kt
@@ -1,0 +1,251 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.action.KeyAction
+import com.sdercolin.vlabeler.ui.editor.Edition
+import com.sdercolin.vlabeler.ui.editor.Tool
+import org.junit.jupiter.api.Test
+import testutil.TestLabelers
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for tool switching, [MarkerState.getUpdatedEntriesByKeyAction] and [MarkerState.computeCascadeEditions].
+ *
+ * All states use sampleRate = 1000 Hz / resolution = 1 (1 ms == 1 px, canvas 1000 px).
+ */
+class MarkerStateMiscTest {
+
+    /**
+     * Utau-singer single entry: start = 100, end = 600, points = [fixed = 400, preu = 250, ovl = 150, left = 100].
+     * Shortcut indexes: 1 -> "ovl" (field 2), 2 -> "preu" (field 1), 3 -> "fixed" (field 0).
+     */
+    private fun utauSingerState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.utauSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 600f, points = listOf(400f, 250f, 150f, 100f)),
+        ),
+    )
+
+    private fun continuousState() = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(
+            MarkerStateFactory.entry(100f, 200f, name = "a"),
+            MarkerStateFactory.entry(200f, 350f, name = "b"),
+        ),
+    )
+
+    // region tools
+
+    @Test
+    fun switchToolCreatesTheToolStateAndClearsOthers() {
+        val state = utauSingerState()
+        assertTrue(state.isCursor)
+
+        state.switchTool(Tool.Scissors)
+        assertNotNull(state.scissorsState.value)
+        assertNull(state.panState.value)
+        assertNull(state.playbackState.value)
+        assertFalse(state.isCursor)
+
+        state.switchTool(Tool.Pan)
+        assertNull(state.scissorsState.value)
+        assertNotNull(state.panState.value)
+        assertFalse(state.isCursor)
+
+        state.switchTool(Tool.Playback)
+        assertNull(state.panState.value)
+        assertNotNull(state.playbackState.value)
+        assertFalse(state.isCursor)
+
+        state.switchTool(Tool.Cursor)
+        assertNull(state.scissorsState.value)
+        assertNull(state.panState.value)
+        assertNull(state.playbackState.value)
+        assertTrue(state.isCursor)
+    }
+
+    @Test
+    fun switchingToAnotherToolResetsCursorState() {
+        val state = utauSingerState()
+        state.cursorState.value = MarkerCursorState(pointIndex = 1, pointPosition = 250f, position = 250f)
+        state.switchTool(Tool.Scissors)
+        assertEquals(MarkerCursorState(), state.cursorState.value)
+    }
+
+    // endregion
+
+    // region getUpdatedEntriesByKeyAction
+
+    private fun MarkerState.setValueWithCursorAt(action: KeyAction, position: Float) =
+        also { cursorState.value = MarkerCursorState(position = position) }
+            .getUpdatedEntriesByKeyAction(action, AppConf(), labelerConf)
+
+    @Test
+    fun setValue1SetsStartWithCursorPosition() {
+        val state = utauSingerState()
+        val result = state.setValueWithCursorAt(KeyAction.SetValue1, 200f)
+        assertNotNull(result)
+        val (entries, pointIndex) = result
+        assertEquals(MarkerCursorState.START_POINT_INDEX, pointIndex)
+        // same as getDraggedEntries(START, 200): "left" -> 200, raw start re-synced to min point (150)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 150f, points = listOf(400f, 250f, 150f, 200f)),
+            entries[0],
+        )
+    }
+
+    @Test
+    fun setValue2SetsFieldWithShortcutIndex1() {
+        val state = utauSingerState()
+        // shortcutIndex 1 is "ovl" (field 2), which is not a drag base, so this is a plain drag;
+        // "ovl" has no lower constraint (min is the canvas border), so it goes to 50 and start follows
+        val result = state.setValueWithCursorAt(KeyAction.SetValue2, 50f)
+        assertNotNull(result)
+        val (entries, pointIndex) = result
+        assertEquals(2, pointIndex)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 50f, points = listOf(400f, 250f, 50f, 100f)),
+            entries[0],
+        )
+    }
+
+    @Test
+    fun setValue3UsesLockedDragForDragBaseField() {
+        val state = utauSingerState()
+        // shortcutIndex 2 is "preu" (field 1) with dragBase == true, and the labeler enables locked drag on the
+        // drag base, so the whole entry is translated: preu 250 -> 300 means dx = +50
+        val result = state.setValueWithCursorAt(KeyAction.SetValue3, 300f)
+        assertNotNull(result)
+        val (entries, pointIndex) = result
+        assertEquals(1, pointIndex)
+        assertEquals(
+            state.entriesInPixel[0].copy(start = 150f, end = 650f, points = listOf(450f, 300f, 200f, 150f)),
+            entries[0],
+        )
+    }
+
+    @Test
+    fun setValue4SetsFieldWithShortcutIndex3() {
+        val state = utauSingerState()
+        // shortcutIndex 3 is "fixed" (field 0), not a drag base: plain drag within [250, 600]
+        val result = state.setValueWithCursorAt(KeyAction.SetValue4, 500f)
+        assertNotNull(result)
+        val (entries, pointIndex) = result
+        assertEquals(0, pointIndex)
+        assertEquals(
+            state.entriesInPixel[0].copy(points = listOf(500f, 250f, 150f, 100f)),
+            entries[0],
+        )
+    }
+
+    @Test
+    fun setValue5SetsEndWhenAllShortcutsAreUsed() {
+        val state = utauSingerState()
+        // 3 fields have shortcut indexes, so paramIndex 4 == fieldCount + 1 maps to the end point
+        val result = state.setValueWithCursorAt(KeyAction.SetValue5, 700f)
+        assertNotNull(result)
+        val (entries, pointIndex) = result
+        assertEquals(MarkerCursorState.END_POINT_INDEX, pointIndex)
+        assertEquals(state.entriesInPixel[0].copy(end = 700f), entries[0])
+    }
+
+    @Test
+    fun setValueBeyondAvailablePointsReturnsNull() {
+        val state = utauSingerState()
+        assertNull(state.setValueWithCursorAt(KeyAction.SetValue6, 300f))
+    }
+
+    @Test
+    fun setValueWithoutCursorPositionReturnsNull() {
+        val state = utauSingerState()
+        assertNull(state.getUpdatedEntriesByKeyAction(KeyAction.SetValue1, AppConf(), state.labelerConf))
+    }
+
+    @Test
+    fun setValueInMultiEntryModeReturnsNull() {
+        val state = continuousState()
+        assertNull(state.setValueWithCursorAt(KeyAction.SetValue1, 150f))
+    }
+
+    @Test
+    fun nonSetValueActionReturnsNull() {
+        val state = utauSingerState()
+        assertNull(state.setValueWithCursorAt(KeyAction.NewProject, 150f))
+    }
+
+    // endregion
+
+    // region computeCascadeEditions
+
+    private fun cascadeState(): Pair<MarkerState, List<Entry>> {
+        val parallelEntries = listOf(
+            MarkerStateFactory.entry(0f, 150f, name = "p0"),
+            MarkerStateFactory.entry(150f, 300f, name = "p1"),
+        )
+        val state = MarkerStateFactory.create(
+            labelerConf = TestLabelers.nnsvsSinger,
+            allEntries = listOf(
+                MarkerStateFactory.entry(0f, 150f, name = "a"),
+                MarkerStateFactory.entry(150f, 300f, name = "b"),
+            ),
+            parallelModules = listOf(MarkerStateFactory.parallelModule("tier2", parallelEntries)),
+        )
+        return state to parallelEntries
+    }
+
+    @Test
+    fun computeCascadeEditionsEditsMatchingBordersOfParallelModules() {
+        val (state, parallelEntries) = cascadeState()
+        // the border at 150 px matches the border of "tier2" at 150 ms; the new border is 155 px == 155 ms
+        val result = state.computeCascadeEditions(snappedPosition = 155f, originalPosition = 150f)
+        assertEquals(
+            mapOf(
+                "tier2" to listOf(
+                    Edition(
+                        index = 0,
+                        newValue = parallelEntries[0].copy(end = 155f),
+                        fieldNames = listOf("end"),
+                        method = Edition.Method.Dragging,
+                    ),
+                    Edition(
+                        index = 1,
+                        newValue = parallelEntries[1].copy(start = 155f),
+                        fieldNames = listOf("start"),
+                        method = Edition.Method.Dragging,
+                    ),
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun computeCascadeEditionsReturnsEmptyWhenPositionUnchanged() {
+        val (state, _) = cascadeState()
+        val result = state.computeCascadeEditions(snappedPosition = 150f, originalPosition = 150f)
+        assertEquals(emptyMap<String, List<Edition>>(), result)
+    }
+
+    @Test
+    fun computeCascadeEditionsReturnsEmptyWhenNoBorderMatches() {
+        val (state, _) = cascadeState()
+        // no parallel border is within 1 px of 50
+        val result = state.computeCascadeEditions(snappedPosition = 55f, originalPosition = 50f)
+        assertEquals(emptyMap<String, List<Edition>>(), result)
+    }
+
+    @Test
+    fun computeCascadeEditionsDropsModuleWhenNewBorderIsOutOfRange() {
+        val (state, _) = cascadeState()
+        // the new border (310 ms) is beyond the end (300 ms) of the right entry in "tier2"
+        val result = state.computeCascadeEditions(snappedPosition = 310f, originalPosition = 150f)
+        assertEquals(emptyMap<String, List<Edition>>(), result)
+    }
+
+    // endregion
+}

--- a/src/jvmTest/kotlin/ipc/IpcJsonTest.kt
+++ b/src/jvmTest/kotlin/ipc/IpcJsonTest.kt
@@ -1,0 +1,202 @@
+package ipc
+
+import com.sdercolin.vlabeler.ipc.IpcMessageType
+import com.sdercolin.vlabeler.ipc.jsonForIpc
+import com.sdercolin.vlabeler.ipc.request.HeartbeatRequest
+import com.sdercolin.vlabeler.ipc.request.IpcRequest
+import com.sdercolin.vlabeler.ipc.request.OpenOrCreateRequest
+import com.sdercolin.vlabeler.ipc.response.HeartbeatResponse
+import com.sdercolin.vlabeler.ipc.response.IpcResponse
+import com.sdercolin.vlabeler.ipc.response.OpenOrCreateResponse
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import java.nio.charset.Charset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the external JSON contract of the IPC API: raw JSON strings exactly as an external client would produce
+ * (requests) or consume (responses) through [jsonForIpc], including the `type` class discriminator.
+ */
+class IpcJsonTest {
+
+    @Test
+    fun `heartbeat request is decoded from raw client json`() {
+        val raw = """{"type":"Heartbeat","sentAt":1234567890123}"""
+        val request = jsonForIpc.decodeFromString<IpcRequest>(raw)
+        val heartbeat = assertIs<HeartbeatRequest>(request)
+        assertEquals(1234567890123L, heartbeat.sentAt)
+        assertEquals(IpcMessageType.Heartbeat, heartbeat.type)
+    }
+
+    @Test
+    fun `heartbeat request is encoded with type discriminator`() {
+        val request: IpcRequest = HeartbeatRequest(sentAt = 5)
+        assertEquals("""{"type":"Heartbeat","sentAt":5}""", jsonForIpc.encodeToString(request))
+    }
+
+    @Test
+    fun `heartbeat response is encoded exactly as a client consumes it`() {
+        val response: IpcResponse = HeartbeatResponse(requestedAt = 1, sentAt = 2)
+        assertEquals("""{"type":"Heartbeat","requestedAt":1,"sentAt":2}""", jsonForIpc.encodeToString(response))
+    }
+
+    @Test
+    fun `openOrCreate response is encoded exactly as a client consumes it`() {
+        val response: IpcResponse = OpenOrCreateResponse(requestedAt = 10, sentAt = 20)
+        assertEquals("""{"type":"OpenOrCreate","requestedAt":10,"sentAt":20}""", jsonForIpc.encodeToString(response))
+    }
+
+    @Test
+    fun `openOrCreate request with all fields is decoded from raw client json`() {
+        val raw = """
+            {
+                "type": "OpenOrCreate",
+                "projectFile": "/home/user/project.lbp",
+                "gotoEntryByName": {
+                    "parentFolderName": "",
+                    "entryName": "あ"
+                },
+                "gotoEntryByIndex": {
+                    "parentFolderName": "module1",
+                    "entryIndex": 3
+                },
+                "newProjectArgs": {
+                    "labelerName": "utau-oto-labeler",
+                    "sampleDirectory": "/home/user/samples",
+                    "cacheDirectory": "/home/user/cache",
+                    "labelerParams": {
+                        "offset": {"type": "integer", "value": 5},
+                        "useNegative": {"type": "boolean", "value": true}
+                    },
+                    "pluginName": "some-template-plugin",
+                    "pluginParams": {
+                        "prefix": {"type": "string", "value": "_"},
+                        "scale": {"type": "float", "value": 1.5}
+                    },
+                    "inputFile": "/home/user/oto.ini",
+                    "encoding": "Shift-JIS",
+                    "autoExport": true
+                },
+                "sentAt": 1700000000000
+            }
+        """.trimIndent()
+        val request = jsonForIpc.decodeFromString<IpcRequest>(raw)
+        val openOrCreate = assertIs<OpenOrCreateRequest>(request)
+        assertEquals(IpcMessageType.OpenOrCreate, openOrCreate.type)
+        assertEquals("/home/user/project.lbp", openOrCreate.projectFile)
+        assertEquals(1700000000000L, openOrCreate.sentAt)
+
+        val byName = assertNotNull(openOrCreate.gotoEntryByName)
+        assertEquals("", byName.parentFolderName)
+        assertEquals("あ", byName.entryName)
+
+        val byIndex = assertNotNull(openOrCreate.gotoEntryByIndex)
+        assertEquals("module1", byIndex.parentFolderName)
+        assertEquals(3, byIndex.entryIndex)
+
+        val args = openOrCreate.newProjectArgs
+        assertEquals("utau-oto-labeler", args.labelerName)
+        assertEquals("/home/user/samples", args.sampleDirectory)
+        assertEquals("/home/user/cache", args.cacheDirectory)
+        assertEquals("some-template-plugin", args.pluginName)
+        assertEquals("/home/user/oto.ini", args.inputFile)
+        assertEquals("Shift-JIS", args.encoding)
+        assertTrue(args.autoExport)
+
+        val labelerParams = assertNotNull(args.labelerParams)
+        assertEquals(setOf("offset", "useNegative"), labelerParams.keys)
+        assertEquals("integer", labelerParams.getValue("offset").type)
+        assertEquals(5, labelerParams.getValue("offset").value)
+        assertEquals("boolean", labelerParams.getValue("useNegative").type)
+        assertEquals(true, labelerParams.getValue("useNegative").value)
+
+        val pluginParams = assertNotNull(args.pluginParams)
+        assertEquals(setOf("prefix", "scale"), pluginParams.keys)
+        assertEquals("string", pluginParams.getValue("prefix").type)
+        assertEquals("_", pluginParams.getValue("prefix").value)
+        assertEquals("float", pluginParams.getValue("scale").type)
+        assertEquals(1.5f, pluginParams.getValue("scale").value)
+    }
+
+    @Test
+    fun `openOrCreate request with only required fields is decoded with defaults`() {
+        val raw = """
+            {
+                "type": "OpenOrCreate",
+                "projectFile": "/tmp/minimal.lbp",
+                "newProjectArgs": {
+                    "labelerName": "test-labeler"
+                },
+                "sentAt": 42
+            }
+        """.trimIndent()
+        val request = jsonForIpc.decodeFromString<IpcRequest>(raw)
+        val openOrCreate = assertIs<OpenOrCreateRequest>(request)
+        assertEquals("/tmp/minimal.lbp", openOrCreate.projectFile)
+        assertEquals(42L, openOrCreate.sentAt)
+        assertNull(openOrCreate.gotoEntryByName)
+        assertNull(openOrCreate.gotoEntryByIndex)
+
+        val args = openOrCreate.newProjectArgs
+        assertEquals("test-labeler", args.labelerName)
+        assertNull(args.sampleDirectory)
+        assertNull(args.cacheDirectory)
+        assertNull(args.labelerParams)
+        assertNull(args.pluginName)
+        assertNull(args.pluginParams)
+        assertNull(args.inputFile)
+        assertEquals(Charset.defaultCharset().name(), args.encoding)
+        assertFalse(args.autoExport)
+    }
+
+    @Test
+    fun `openOrCreate request is encoded with defaults included`() {
+        val request: IpcRequest = OpenOrCreateRequest(
+            projectFile = "/tmp/project.lbp",
+            newProjectArgs = OpenOrCreateRequest.NewProjectArgs(
+                labelerName = "utau-oto-labeler",
+                encoding = "UTF-8",
+            ),
+            sentAt = 100,
+        )
+        val expected = """{"type":"OpenOrCreate","projectFile":"/tmp/project.lbp","gotoEntryByName":null,""" +
+            """"gotoEntryByIndex":null,"newProjectArgs":{"labelerName":"utau-oto-labeler","sampleDirectory":null,""" +
+            """"cacheDirectory":null,"labelerParams":null,"pluginName":null,"pluginParams":null,""" +
+            """"inputFile":null,"encoding":"UTF-8","autoExport":false},"sentAt":100}"""
+        assertEquals(expected, jsonForIpc.encodeToString(request))
+    }
+
+    @Test
+    fun `unknown keys in a request are ignored`() {
+        val raw = """{"type":"Heartbeat","sentAt":7,"extraneous":"ignored","futureField":{"a":1}}"""
+        val request = jsonForIpc.decodeFromString<IpcRequest>(raw)
+        assertEquals(7L, assertIs<HeartbeatRequest>(request).sentAt)
+    }
+
+    @Test
+    fun `lenient parsing accepts quoted numbers`() {
+        val raw = """{"type":"Heartbeat","sentAt":"12"}"""
+        val request = jsonForIpc.decodeFromString<IpcRequest>(raw)
+        assertEquals(12L, assertIs<HeartbeatRequest>(request).sentAt)
+    }
+
+    @Test
+    fun `unknown type discriminator fails to decode`() {
+        assertFailsWith<SerializationException> {
+            jsonForIpc.decodeFromString<IpcRequest>("""{"type":"Unknown","sentAt":1}""")
+        }
+    }
+
+    @Test
+    fun `message type enum matches the wire discriminator names`() {
+        assertEquals(listOf("Heartbeat", "OpenOrCreate"), IpcMessageType.values().map { it.name })
+    }
+}

--- a/src/jvmTest/kotlin/ipc/IpcServerTest.kt
+++ b/src/jvmTest/kotlin/ipc/IpcServerTest.kt
@@ -1,0 +1,203 @@
+package ipc
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.ipc.IpcServer
+import com.sdercolin.vlabeler.ipc.request.HeartbeatRequest
+import com.sdercolin.vlabeler.ipc.request.IpcRequest
+import com.sdercolin.vlabeler.ipc.request.OpenOrCreateRequest
+import com.sdercolin.vlabeler.ipc.response.HeartbeatResponse
+import com.sdercolin.vlabeler.ipc.response.OpenOrCreateResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.zeromq.SocketType
+import org.zeromq.ZContext
+import org.zeromq.ZMQ
+import testutil.TestEnv
+import java.io.IOException
+import java.net.ServerSocket
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * End-to-end tests for [IpcServer] over a real ZeroMQ REQ/REP socket pair on `tcp://localhost:32342`.
+ */
+class IpcServerTest {
+
+    private lateinit var scope: CoroutineScope
+    private val servers = mutableListOf<IpcServer>()
+    private val clientContexts = mutableListOf<ZContext>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        requirePortFree()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @AfterTest
+    fun teardown() {
+        try {
+            clientContexts.forEach { runCatching { it.close() } }
+            clientContexts.clear()
+            servers.forEach { runCatching { it.close() } }
+            servers.clear()
+        } finally {
+            runCatching { scope.cancel() }
+            Log.muted = false
+        }
+    }
+
+    /**
+     * [IpcServer.bind] swallows bind failures, which would make the test hang until timeout instead of failing
+     * clearly, so check the fixed port up front and fail fast with an explanation.
+     */
+    private fun requirePortFree() {
+        try {
+            ServerSocket(PORT).close()
+        } catch (e: IOException) {
+            fail(
+                "Port $PORT is already in use (a running vLabeler instance or a leaked server from a previous " +
+                    "test run?). Free the port and re-run. Cause: $e",
+            )
+        }
+    }
+
+    private fun isPortFree(): Boolean = try {
+        ServerSocket(PORT).close()
+        true
+    } catch (e: IOException) {
+        false
+    }
+
+    private fun startServer(requestFlow: MutableSharedFlow<IpcRequest>): IpcServer {
+        val server = IpcServer(scope)
+        servers.add(server)
+        server.bind()
+        server.startReceive(requestFlow)
+        return server
+    }
+
+    private fun createClient(): ZMQ.Socket {
+        val context = ZContext()
+        clientContexts.add(context)
+        val socket = context.createSocket(SocketType.REQ)
+        socket.receiveTimeOut = TIMEOUT_MS.toInt()
+        socket.sendTimeOut = TIMEOUT_MS.toInt()
+        socket.linger = 0
+        socket.connect("tcp://localhost:$PORT")
+        return socket
+    }
+
+    /**
+     * Collects requests emitted by the server into a channel. The default [MutableSharedFlow] drops emissions when
+     * there is no subscriber, so this suspends until the subscription is actually active before returning.
+     */
+    private suspend fun subscribe(requestFlow: MutableSharedFlow<IpcRequest>): Channel<IpcRequest> {
+        val received = Channel<IpcRequest>(Channel.UNLIMITED)
+        scope.launch { requestFlow.collect { received.send(it) } }
+        withTimeout(TIMEOUT_MS) { requestFlow.subscriptionCount.first { it > 0 } }
+        return received
+    }
+
+    @Test
+    fun `heartbeat request and response round trip over the socket`() = runBlocking {
+        val requestFlow = MutableSharedFlow<IpcRequest>()
+        val received = subscribe(requestFlow)
+        startServer(requestFlow).let { server ->
+            val client = createClient()
+
+            assertTrue(client.send("""{"type":"Heartbeat","sentAt":42}"""), "Client failed to send the request")
+            val request = withTimeout(TIMEOUT_MS) { received.receive() }
+            val heartbeat = assertIs<HeartbeatRequest>(request)
+            assertEquals(42L, heartbeat.sentAt)
+
+            server.send(HeartbeatResponse(requestedAt = 42, sentAt = 100))
+            val responseJson = assertNotNull(client.recvStr(), "Client did not receive a response within timeout")
+            assertEquals("""{"type":"Heartbeat","requestedAt":42,"sentAt":100}""", responseJson)
+        }
+    }
+
+    @Test
+    fun `sequential requests of different types are served on the same socket`() = runBlocking {
+        val requestFlow = MutableSharedFlow<IpcRequest>()
+        val received = subscribe(requestFlow)
+        val server = startServer(requestFlow)
+        val client = createClient()
+
+        // First exchange: heartbeat.
+        assertTrue(client.send("""{"type":"Heartbeat","sentAt":1}"""), "Client failed to send the first request")
+        val first = withTimeout(TIMEOUT_MS) { received.receive() }
+        assertEquals(1L, assertIs<HeartbeatRequest>(first).sentAt)
+        server.send(HeartbeatResponse(requestedAt = 1, sentAt = 2))
+        assertEquals(
+            """{"type":"Heartbeat","requestedAt":1,"sentAt":2}""",
+            assertNotNull(client.recvStr(), "Client did not receive the first response within timeout"),
+        )
+
+        // Second exchange: openOrCreate on the same REQ/REP pair.
+        val openOrCreateJson = """{"type":"OpenOrCreate","projectFile":"/tmp/ipc-test.lbp",""" +
+            """"newProjectArgs":{"labelerName":"test-labeler"},"sentAt":7}"""
+        assertTrue(client.send(openOrCreateJson), "Client failed to send the second request")
+        val second = withTimeout(TIMEOUT_MS) { received.receive() }
+        val openOrCreate = assertIs<OpenOrCreateRequest>(second)
+        assertEquals("/tmp/ipc-test.lbp", openOrCreate.projectFile)
+        assertEquals("test-labeler", openOrCreate.newProjectArgs.labelerName)
+        assertEquals(7L, openOrCreate.sentAt)
+        server.send(OpenOrCreateResponse(requestedAt = 7, sentAt = 8))
+        assertEquals(
+            """{"type":"OpenOrCreate","requestedAt":7,"sentAt":8}""",
+            assertNotNull(client.recvStr(), "Client did not receive the second response within timeout"),
+        )
+    }
+
+    @Test
+    fun `close releases the port so a new server can bind and serve`() = runBlocking {
+        val firstFlow = MutableSharedFlow<IpcRequest>()
+        subscribe(firstFlow)
+        val firstServer = startServer(firstFlow)
+        firstServer.close()
+
+        // ZeroMQ context termination is expected to release the port; poll with a deadline instead of sleeping
+        // blindly so the test stays fast when the port is released immediately.
+        withTimeout(TIMEOUT_MS) {
+            while (!isPortFree()) {
+                delay(50)
+            }
+        }
+
+        val secondFlow = MutableSharedFlow<IpcRequest>()
+        val received = subscribe(secondFlow)
+        val secondServer = startServer(secondFlow)
+        val client = createClient()
+
+        assertTrue(client.send("""{"type":"Heartbeat","sentAt":9}"""), "Client failed to send the request")
+        val request = withTimeout(TIMEOUT_MS) { received.receive() }
+        assertEquals(9L, assertIs<HeartbeatRequest>(request).sentAt)
+        secondServer.send(HeartbeatResponse(requestedAt = 9, sentAt = 10))
+        assertEquals(
+            """{"type":"Heartbeat","requestedAt":9,"sentAt":10}""",
+            assertNotNull(client.recvStr(), "Client did not receive a response from the rebound server"),
+        )
+    }
+
+    companion object {
+        private const val PORT = 32342
+        private const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/src/jvmTest/kotlin/repository/ChartRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/ChartRepositoryTest.kt
@@ -1,0 +1,297 @@
+package repository
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.res.loadImageBitmap
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.SampleInfo
+import com.sdercolin.vlabeler.repository.ChartRepository
+import com.sdercolin.vlabeler.util.parseJson
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ChartRepository]: cache versioning/invalidation, cache file path computation, and move/clear logic.
+ */
+class ChartRepositoryTest {
+
+    private lateinit var tempDir: File
+    private var project: Project? = null
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        // reset the singleton's cache map so tests stay order-independent
+        project?.let { ChartRepository.clear(it) }
+        project = null
+        tempDir.deleteRecursively()
+        Log.muted = false
+    }
+
+    private fun createProject(): Project {
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        return createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        ).also { project = it }
+    }
+
+    private fun sampleInfo(
+        name: String = "x.wav",
+        file: String = name,
+        moduleName: String = "mod",
+    ) = SampleInfo(
+        name = name,
+        file = file,
+        convertedFile = null,
+        moduleName = moduleName,
+        sampleRate = 44100f,
+        maxSampleRate = 44100,
+        normalize = false,
+        normalizeRatio = null,
+        channels = 1,
+        length = 44100,
+        lengthMillis = 1000f,
+        chunkSize = 44100,
+        chunkCount = 1,
+        hasSpectrogram = false,
+        hasPower = false,
+        powerChannels = 1,
+        hasFundamental = false,
+        lastModified = 0L,
+        algorithmVersion = 1,
+    )
+
+    private fun createImageBitmap(width: Int = 4, height: Int = 4): ImageBitmap {
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        for (x in 0 until width) {
+            for (y in 0 until height) {
+                image.setRGB(x, y, 0xFF336699.toInt())
+            }
+        }
+        val pngFile = tempDir.resolve("input-${System.nanoTime()}.png")
+        ImageIO.write(image, "png", pngFile)
+        return pngFile.inputStream().buffered().use(::loadImageBitmap)
+    }
+
+    private val Project.chartsDir get() = cacheDirectory.resolve("charts")
+
+    @Test
+    fun testNeedResetOnVersionOrPainterChange() {
+        val project = createProject()
+        val appConf = AppConf()
+        ChartRepository.init(project, appConf, version = 1)
+
+        assertFalse(ChartRepository.needReset(appConf, version = 1))
+        assertTrue(ChartRepository.needReset(appConf, version = 2))
+        val changedConf = appConf.copy(
+            painter = appConf.painter.copy(
+                amplitude = appConf.painter.amplitude.copy(
+                    normalize = appConf.painter.amplitude.normalize.not(),
+                ),
+            ),
+        )
+        assertTrue(ChartRepository.needReset(changedConf, version = 1))
+    }
+
+    @Test
+    fun testInitKeepsCacheWhenParamsMatch() {
+        val project = createProject()
+        val appConf = AppConf()
+        ChartRepository.init(project, appConf, version = 1)
+        assertTrue(project.chartsDir.resolve("params.json").isFile)
+        val marker = project.chartsDir.resolve("marker.png")
+        marker.writeText("marker")
+
+        ChartRepository.init(project, appConf, version = 1)
+
+        assertTrue(marker.exists())
+    }
+
+    @Test
+    fun testInitClearsCacheWhenVersionChanges() {
+        val project = createProject()
+        val appConf = AppConf()
+        ChartRepository.init(project, appConf, version = 1)
+        val marker = project.chartsDir.resolve("marker.png")
+        marker.writeText("marker")
+
+        ChartRepository.init(project, appConf, version = 2)
+
+        assertFalse(marker.exists())
+        val params = project.chartsDir.resolve("params.json").readText().parseJson<JsonObject>()
+        assertEquals(2, params.getValue("algorithmVersion").jsonPrimitive.int)
+    }
+
+    @Test
+    fun testInitClearsCacheWhenPainterConfigChanges() {
+        val project = createProject()
+        val appConf = AppConf()
+        ChartRepository.init(project, appConf, version = 1)
+        val marker = project.chartsDir.resolve("marker.png")
+        marker.writeText("marker")
+
+        val changedConf = appConf.copy(
+            painter = appConf.painter.copy(
+                spectrogram = appConf.painter.spectrogram.copy(
+                    enabled = appConf.painter.spectrogram.enabled.not(),
+                ),
+            ),
+        )
+        ChartRepository.init(project, changedConf, version = 1)
+
+        assertFalse(marker.exists())
+    }
+
+    @Test
+    fun testImageFileNamesForFreshCache() {
+        val project = createProject()
+        ChartRepository.init(project, AppConf(), version = 1)
+        val info = sampleInfo(name = "x.wav", moduleName = "mod")
+        val chartsDir = project.chartsDir
+
+        assertEquals(
+            chartsDir.resolve("mod_x.wav_waveform_0_0.png"),
+            ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0),
+        )
+        assertEquals(
+            chartsDir.resolve("mod_x.wav_spectrogram_1.png"),
+            ChartRepository.getSpectrogramImageFile(info, chunkIndex = 1),
+        )
+        assertEquals(
+            chartsDir.resolve("mod_x.wav_power_1_2.png"),
+            ChartRepository.getPowerGraphImageFile(info, channelIndex = 1, chunkIndex = 2),
+        )
+        assertEquals(
+            chartsDir.resolve("mod_x.wav_fundamental_0.png"),
+            ChartRepository.getFundamentalGraphImageFile(info, chunkIndex = 0),
+        )
+    }
+
+    @Test
+    fun testPutAndGetWaveformRoundTrip() {
+        val project = createProject()
+        ChartRepository.init(project, AppConf(), version = 1)
+        val info = sampleInfo()
+
+        ChartRepository.putWaveform(info, channelIndex = 0, chunkIndex = 0, waveform = createImageBitmap(8, 5))
+
+        val file = ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0)
+        assertEquals(project.chartsDir.resolve("mod_x.wav_waveform_0_0.png"), file)
+        assertTrue(file.isFile)
+        val map = project.chartsDir.resolve("map.json").readText().parseJson<Map<String, String>>()
+        assertEquals("mod_x.wav_waveform_0_0.png", map["${info.file}//waveform//0//0"])
+
+        val loaded = runBlocking { ChartRepository.getWaveform(info, channelIndex = 0, chunkIndex = 0) }
+        assertEquals(8, loaded.width)
+        assertEquals(5, loaded.height)
+    }
+
+    @Test
+    fun testCacheMapIsReloadedByInit() {
+        val project = createProject()
+        val appConf = AppConf()
+        ChartRepository.init(project, appConf, version = 1)
+        val info = sampleInfo()
+        ChartRepository.putWaveform(info, channelIndex = 0, chunkIndex = 0, waveform = createImageBitmap())
+        val file = ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0)
+
+        // simulate a restart with the same params: the cache map is reloaded from map.json
+        ChartRepository.init(project, appConf, version = 1)
+
+        assertTrue(file.isFile)
+        assertEquals(file, ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0))
+    }
+
+    @Test
+    fun testFileNameCollisionBetweenDifferentSamplesWithSameName() {
+        val project = createProject()
+        ChartRepository.init(project, AppConf(), version = 1)
+        val infoA = sampleInfo(name = "x.wav", file = "a/x.wav")
+        ChartRepository.putWaveform(infoA, channelIndex = 0, chunkIndex = 0, waveform = createImageBitmap())
+
+        val infoB = sampleInfo(name = "x.wav", file = "b/x.wav")
+        val fileB = ChartRepository.getWaveformImageFile(infoB, channelIndex = 0, chunkIndex = 0)
+
+        assertEquals("mod_x.wav_waveform_0_0.1.png", fileB.name)
+    }
+
+    @Test
+    fun testClearRemovesDirectoryAndCacheMap() {
+        val project = createProject()
+        ChartRepository.init(project, AppConf(), version = 1)
+        val info = sampleInfo()
+        ChartRepository.putWaveform(info, channelIndex = 0, chunkIndex = 0, waveform = createImageBitmap())
+
+        ChartRepository.clear(project)
+
+        assertFalse(project.chartsDir.exists())
+        // the cache map is cleared, so the base file name is offered again
+        assertEquals(
+            project.chartsDir.resolve("mod_x.wav_waveform_0_0.png"),
+            ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0),
+        )
+    }
+
+    @Test
+    fun testMoveToCopiesCache() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        oldDir.resolve("charts").also { it.mkdirs() }.resolve("a.png").writeText("a")
+        val newDir = tempDir.resolve("new")
+
+        ChartRepository.moveTo(oldDir, newDir, clearOld = false)
+
+        assertEquals("a", newDir.resolve("charts").resolve("a.png").readText())
+        assertTrue(oldDir.resolve("charts").resolve("a.png").exists())
+    }
+
+    @Test
+    fun testMoveToClearsOldCache() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        oldDir.resolve("charts").also { it.mkdirs() }.resolve("a.png").writeText("a")
+        val newDir = tempDir.resolve("new")
+
+        ChartRepository.moveTo(oldDir, newDir, clearOld = true)
+
+        assertEquals("a", newDir.resolve("charts").resolve("a.png").readText())
+        assertFalse(oldDir.resolve("charts").exists())
+    }
+
+    @Test
+    fun testMoveToWithoutExistingCacheIsNoOp() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        val newDir = tempDir.resolve("new")
+
+        ChartRepository.moveTo(oldDir, newDir, clearOld = true)
+
+        assertFalse(newDir.exists())
+    }
+}

--- a/src/jvmTest/kotlin/repository/ColorPaletteRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/ColorPaletteRepositoryTest.kt
@@ -1,0 +1,112 @@
+package repository
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.palette.ColorPaletteDefinition
+import com.sdercolin.vlabeler.repository.ColorPaletteRepository
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ColorPaletteRepository] and the palette definitions it serves.
+ *
+ * Note: [ColorPaletteRepository.initialize] and [ColorPaletteRepository.load] operate on the real application
+ * directory (`AppDir/color_palettes`), which must not be touched by tests, so only the parts that are independent of
+ * that directory are covered here: the fallback behaviors and the bundled palette definitions including the JSON
+ * format used for custom palette files.
+ */
+class ColorPaletteRepositoryTest {
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    @Test
+    fun testGetUnknownNameFallsBackToFirstPreset() {
+        assertEquals(
+            ColorPaletteDefinition.presets.first(),
+            ColorPaletteRepository.get("nonexistent-palette-name"),
+        )
+    }
+
+    @Test
+    fun testHasUnknownNameReturnsFalse() {
+        assertFalse(ColorPaletteRepository.has("nonexistent-palette-name"))
+    }
+
+    @Test
+    fun testPresetsAreValidAndUnique() {
+        val presets = ColorPaletteDefinition.presets
+        presets.forEach { it.validate() }
+        assertEquals(presets.size, presets.map { it.name }.distinct().size)
+        // bundled in code
+        assertTrue(presets.any { it.name == "Plain" })
+        // bundled as resource files
+        listOf("Inferno", "Magma", "Plasma", "Viridis").forEach { name ->
+            assertTrue(presets.any { it.name == name }, "Missing bundled palette: $name")
+        }
+    }
+
+    @Test
+    fun testPaletteDefinitionJsonRoundTrip() {
+        // the same format is used for custom palette files loaded by ColorPaletteRepository.load
+        ColorPaletteDefinition.presets.forEach { preset ->
+            assertEquals(preset, preset.stringifyJson().parseJson<ColorPaletteDefinition>())
+        }
+    }
+
+    @Test
+    fun testCustomPaletteFileFormatParsing() {
+        val json = """
+            {
+                "name": "Custom",
+                "items": [
+                    { "color": "#00FFFFFF", "weight": 0.0 },
+                    { "color": "#FF0000", "weight": 1.0 }
+                ]
+            }
+        """.trimIndent()
+
+        val definition = json.parseJson<ColorPaletteDefinition>().validate()
+
+        assertEquals("Custom", definition.name)
+        assertEquals(
+            listOf(
+                ColorPaletteDefinition.Item("#00FFFFFF", 0f),
+                ColorPaletteDefinition.Item("#FF0000", 1f),
+            ),
+            definition.items,
+        )
+    }
+
+    @Test
+    fun testValidateRejectsInvalidPalettes() {
+        assertFailsWith<IllegalArgumentException> {
+            ColorPaletteDefinition(
+                name = "TooFewItems",
+                items = listOf(ColorPaletteDefinition.Item("#FFFFFF", 0f)),
+            ).validate()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ColorPaletteDefinition(
+                name = "NonZeroFirstWeight",
+                items = listOf(
+                    ColorPaletteDefinition.Item("#FFFFFF", 1f),
+                    ColorPaletteDefinition.Item("#000000", 1f),
+                ),
+            ).validate()
+        }
+    }
+}

--- a/src/jvmTest/kotlin/repository/ConvertedAudioRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/ConvertedAudioRepositoryTest.kt
@@ -1,0 +1,187 @@
+package repository
+
+import com.sdercolin.vlabeler.audio.conversion.WaveConverter
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.repository.ConvertedAudioRepository
+import com.sdercolin.vlabeler.util.parseJson
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ConvertedAudioRepository]: cache path computation, cache map persistence, and move/clear logic. A fake
+ * [WaveConverter] is used so that no real ffmpeg execution is required.
+ */
+class ConvertedAudioRepositoryTest {
+
+    private class FakeWaveConverter : WaveConverter {
+        override fun accept(inputFile: File, conf: AppConf.Conversion): Boolean = true
+
+        override suspend fun convert(inputFile: File, outputFile: File, conf: AppConf.Conversion) {
+            inputFile.copyTo(outputFile, overwrite = true)
+        }
+    }
+
+    private lateinit var tempDir: File
+    private var project: Project? = null
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        project?.let { ConvertedAudioRepository.clear(it) }
+        project = null
+        tempDir.deleteRecursively()
+        Log.muted = false
+    }
+
+    private fun createProject(): Project {
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        return createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        ).also { project = it }
+    }
+
+    private fun create(project: Project, file: File): File = runBlocking {
+        ConvertedAudioRepository.create(
+            project = project,
+            file = file,
+            moduleName = "",
+            converter = FakeWaveConverter(),
+            appConf = AppConf(),
+        )
+    }
+
+    private val Project.wavCacheDir get() = cacheDirectory.resolve("wav")
+
+    @Test
+    fun testCreateWritesConvertedFileAndCacheMap() {
+        val project = createProject()
+        ConvertedAudioRepository.init(project)
+        val wavFile = project.rootSampleDirectory.resolve("_a_ka.wav")
+
+        val output = create(project, wavFile)
+
+        assertEquals(project.wavCacheDir.resolve("__a_ka.wav.converted.wav"), output)
+        assertTrue(output.isFile)
+        assertContentEquals(wavFile.readBytes(), output.readBytes())
+        val map = project.wavCacheDir.resolve("map.json").readText().parseJson<Map<String, String>>()
+        assertEquals("__a_ka.wav.converted.wav", map["_a_ka.wav"])
+    }
+
+    @Test
+    fun testCreateReusesCachedPathAfterRestart() {
+        val project = createProject()
+        ConvertedAudioRepository.init(project)
+        val wavFile = project.rootSampleDirectory.resolve("_a_ka.wav")
+        val first = create(project, wavFile)
+
+        // simulate a restart: the cache map is reloaded from map.json
+        ConvertedAudioRepository.init(project)
+        val second = create(project, wavFile)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun testFileNameCollisionBetweenDifferentSamplesWithSameName() {
+        val project = createProject()
+        ConvertedAudioRepository.init(project)
+        val wavFile = project.rootSampleDirectory.resolve("_a_ka.wav")
+        create(project, wavFile)
+
+        val otherFile = project.rootSampleDirectory.resolve("sub").resolve("_a_ka.wav")
+        otherFile.parentFile.mkdirs()
+        wavFile.copyTo(otherFile)
+        val output = create(project, otherFile)
+
+        assertEquals("__a_ka.wav.converted.1.wav", output.name)
+        assertTrue(output.isFile)
+    }
+
+    @Test
+    fun testClearRemovesDirectory() {
+        val project = createProject()
+        ConvertedAudioRepository.init(project)
+        create(project, project.rootSampleDirectory.resolve("_a_ka.wav"))
+        assertTrue(project.wavCacheDir.isDirectory)
+
+        ConvertedAudioRepository.clear(project)
+
+        assertFalse(project.wavCacheDir.exists())
+    }
+
+    @Test
+    fun testClearKeepsCacheMapEntries() {
+        // Pins current behavior: unlike SampleInfoRepository.clear and ChartRepository.clear, this clear() does not
+        // reset the in-memory cache map, so the next conversion of the same sample gets a suffixed file name
+        // because the stale map entry still reserves the base name. Suspected bug in production code.
+        val project = createProject()
+        ConvertedAudioRepository.init(project)
+        val wavFile = project.rootSampleDirectory.resolve("_a_ka.wav")
+        create(project, wavFile)
+
+        ConvertedAudioRepository.clear(project)
+        val output = create(project, wavFile)
+
+        assertEquals("__a_ka.wav.converted.1.wav", output.name)
+    }
+
+    @Test
+    fun testMoveToCopiesCache() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        oldDir.resolve("wav").also { it.mkdirs() }.resolve("a.converted.wav").writeText("a")
+        val newDir = tempDir.resolve("new")
+
+        ConvertedAudioRepository.moveTo(oldDir, newDir, clearOld = false)
+
+        assertEquals("a", newDir.resolve("wav").resolve("a.converted.wav").readText())
+        assertTrue(oldDir.resolve("wav").resolve("a.converted.wav").exists())
+    }
+
+    @Test
+    fun testMoveToClearsOldCache() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        oldDir.resolve("wav").also { it.mkdirs() }.resolve("a.converted.wav").writeText("a")
+        val newDir = tempDir.resolve("new")
+
+        ConvertedAudioRepository.moveTo(oldDir, newDir, clearOld = true)
+
+        assertEquals("a", newDir.resolve("wav").resolve("a.converted.wav").readText())
+        assertFalse(oldDir.resolve("wav").exists())
+    }
+
+    @Test
+    fun testMoveToWithoutExistingCacheIsNoOp() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        val newDir = tempDir.resolve("new")
+
+        ConvertedAudioRepository.moveTo(oldDir, newDir, clearOld = true)
+
+        assertFalse(newDir.exists())
+    }
+}

--- a/src/jvmTest/kotlin/repository/FontRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/FontRepositoryTest.kt
@@ -1,0 +1,98 @@
+package repository
+
+import androidx.compose.ui.text.font.FontFamily
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.repository.FontRepository
+import com.sdercolin.vlabeler.util.parseJson
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FontRepository].
+ *
+ * Note: [FontRepository.initialize] and [FontRepository.load] operate on the real application directory
+ * (`AppDir/fonts`), which must not be touched by tests, so only the parts that are independent of that directory are
+ * covered here: the fallback behaviors and the JSON format of custom font definition files.
+ */
+class FontRepositoryTest {
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    @Test
+    fun testGetUnknownFontFamilyFallsBackToDefault() {
+        assertEquals(FontFamily.Default, FontRepository.getFontFamily("nonexistent-font-family"))
+    }
+
+    @Test
+    fun testHasUnknownFontFamilyReturnsFalse() {
+        assertFalse(FontRepository.hasFontFamily("nonexistent-font-family"))
+    }
+
+    @Test
+    fun testFontFamilyDefinitionParsingWithDefaults() {
+        val json = """
+            {
+                "name": "My Font",
+                "fonts": [
+                    { "path": "my-font.ttf" }
+                ]
+            }
+        """.trimIndent()
+
+        val definition = json.parseJson<FontRepository.FontFamilyDefinition>()
+
+        assertEquals("My Font", definition.name)
+        assertEquals(1, definition.fonts.size)
+        assertEquals("my-font.ttf", definition.fonts[0].path)
+        assertNull(definition.fonts[0].weight)
+        assertNull(definition.fonts[0].isItalic)
+    }
+
+    @Test
+    fun testFontFamilyDefinitionParsingWithAllFields() {
+        val json = """
+            {
+                "name": "My Font",
+                "fonts": [
+                    { "path": "my-font-bold-italic.otf", "weight": 700, "isItalic": true }
+                ]
+            }
+        """.trimIndent()
+
+        val definition = json.parseJson<FontRepository.FontFamilyDefinition>()
+
+        val font = definition.fonts.single()
+        assertEquals("my-font-bold-italic.otf", font.path)
+        assertEquals(700, font.weight)
+        assertEquals(true, font.isItalic)
+    }
+
+    @Test
+    fun testBuiltInFontOptions() {
+        assertEquals("Default", FontRepository.FontOption.BuiltIn.Default.name)
+        assertEquals(FontFamily.Default, FontRepository.FontOption.BuiltIn.Default.fontFamily)
+        assertEquals(FontFamily.SansSerif, FontRepository.FontOption.BuiltIn.SansSerif.fontFamily)
+        assertEquals(FontFamily.Serif, FontRepository.FontOption.BuiltIn.Serif.fontFamily)
+        assertEquals(FontFamily.Monospace, FontRepository.FontOption.BuiltIn.Monospace.fontFamily)
+        assertEquals(FontFamily.Cursive, FontRepository.FontOption.BuiltIn.Cursive.fontFamily)
+    }
+
+    @Test
+    fun testFontDirectoryIsUnderAppDir() {
+        assertEquals("fonts", FontRepository.fontDirectory.name)
+        assertTrue(FontRepository.fontDirectory.isAbsolute)
+    }
+}

--- a/src/jvmTest/kotlin/repository/SampleInfoRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/SampleInfoRepositoryTest.kt
@@ -1,0 +1,225 @@
+package repository
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.WAVE_LOADING_ALGORITHM_VERSION
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.SampleInfo
+import com.sdercolin.vlabeler.repository.SampleInfoRepository
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [SampleInfoRepository]: load/store round-trip of [SampleInfo] JSON, memory/file cache hits, eviction on
+ * configuration or content changes, and move/clear logic.
+ */
+class SampleInfoRepositoryTest {
+
+    private lateinit var tempDir: File
+    private var project: Project? = null
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        // reset the singleton's memory cache and cache map so tests stay order-independent
+        project?.let { SampleInfoRepository.clear(it) }
+        project = null
+        tempDir.deleteRecursively()
+        Log.muted = false
+    }
+
+    private fun createProject(): Project {
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        return createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        ).also { project = it }
+    }
+
+    private fun load(project: Project, appConf: AppConf = AppConf()): SampleInfo = runBlocking {
+        SampleInfoRepository.load(
+            project = project,
+            sampleFile = project.rootSampleDirectory.resolve("_a_ka.wav"),
+            moduleName = "",
+            appConf = appConf,
+        ).getOrThrow()
+    }
+
+    private val Project.sampleInfoDir get() = cacheDirectory.resolve("sample-info")
+
+    private val Project.infoFile get() = sampleInfoDir.resolve("__a_ka.wav.info.json")
+
+    @Test
+    fun testLoadStoresInfoFileAndCacheMap() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+
+        val info = load(project)
+
+        assertEquals("_a_ka.wav", info.name)
+        assertEquals("_a_ka.wav", info.file)
+        assertEquals(WAVE_LOADING_ALGORITHM_VERSION, info.algorithmVersion)
+        assertTrue(project.infoFile.isFile)
+        assertEquals(info, project.infoFile.readText().parseJson<SampleInfo>())
+        val map = project.sampleInfoDir.resolve("map.json").readText().parseJson<Map<String, String>>()
+        assertEquals("__a_ka.wav.info.json", map["_a_ka.wav"])
+    }
+
+    @Test
+    fun testLoadReturnsMemoryCachedInstance() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+
+        val first = load(project)
+        val second = load(project)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun testMemoryCacheEvictedWhenPainterConfigChanges() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+        val appConf = AppConf()
+        val first = load(project, appConf)
+        assertFalse(first.normalize)
+
+        val changedConf = appConf.copy(
+            painter = appConf.painter.copy(
+                amplitude = appConf.painter.amplitude.copy(normalize = true),
+            ),
+        )
+        val second = load(project, changedConf)
+
+        assertNotSame(first, second)
+        assertTrue(second.normalize)
+    }
+
+    @Test
+    fun testMemoryCacheEvictedWhenSampleFileIsModified() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+        val first = load(project)
+
+        val wavFile = project.rootSampleDirectory.resolve("_a_ka.wav")
+        assertTrue(wavFile.setLastModified(first.lastModified + 10000))
+        val second = load(project)
+
+        assertNotSame(first, second)
+        assertEquals(wavFile.lastModified(), second.lastModified)
+    }
+
+    @Test
+    fun testFileCacheIsUsedAfterRestart() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+        val info = load(project)
+
+        // simulate a restart: drop the memory cache but keep the cache files
+        val backup = tempDir.resolve("backup")
+        project.sampleInfoDir.copyRecursively(backup)
+        SampleInfoRepository.clear(project)
+        backup.copyRecursively(project.sampleInfoDir)
+        // tamper a field that is not checked by shouldReload to detect whether the file cache is used
+        project.infoFile.writeText(info.copy(lengthMillis = 123.456f).stringifyJson())
+        SampleInfoRepository.init(project)
+
+        val reloaded = load(project)
+
+        assertEquals(123.456f, reloaded.lengthMillis)
+    }
+
+    @Test
+    fun testFileCacheEvictedOnAlgorithmVersionMismatch() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+        val info = load(project)
+
+        val backup = tempDir.resolve("backup")
+        project.sampleInfoDir.copyRecursively(backup)
+        SampleInfoRepository.clear(project)
+        backup.copyRecursively(project.sampleInfoDir)
+        project.infoFile.writeText(info.copy(algorithmVersion = -1, lengthMillis = 123.456f).stringifyJson())
+        SampleInfoRepository.init(project)
+
+        val reloaded = load(project)
+
+        // the stale cache is not returned; the sample is reloaded from the wav file and the cache file is rewritten
+        assertEquals(WAVE_LOADING_ALGORITHM_VERSION, reloaded.algorithmVersion)
+        assertNotEquals(123.456f, reloaded.lengthMillis)
+        assertEquals(reloaded, project.infoFile.readText().parseJson<SampleInfo>())
+    }
+
+    @Test
+    fun testClearRemovesDirectory() {
+        val project = createProject()
+        SampleInfoRepository.init(project)
+        load(project)
+        assertTrue(project.sampleInfoDir.isDirectory)
+
+        SampleInfoRepository.clear(project)
+
+        assertFalse(project.sampleInfoDir.exists())
+    }
+
+    @Test
+    fun testMoveToCopiesCache() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        oldDir.resolve("sample-info").also { it.mkdirs() }.resolve("a.info.json").writeText("a")
+        val newDir = tempDir.resolve("new")
+
+        SampleInfoRepository.moveTo(oldDir, newDir, clearOld = false)
+
+        assertEquals("a", newDir.resolve("sample-info").resolve("a.info.json").readText())
+        assertTrue(oldDir.resolve("sample-info").resolve("a.info.json").exists())
+    }
+
+    @Test
+    fun testMoveToClearsOldCache() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        oldDir.resolve("sample-info").also { it.mkdirs() }.resolve("a.info.json").writeText("a")
+        val newDir = tempDir.resolve("new")
+
+        SampleInfoRepository.moveTo(oldDir, newDir, clearOld = true)
+
+        assertEquals("a", newDir.resolve("sample-info").resolve("a.info.json").readText())
+        assertFalse(oldDir.resolve("sample-info").exists())
+    }
+
+    @Test
+    fun testMoveToWithoutExistingCacheIsNoOp() {
+        val oldDir = tempDir.resolve("old").also { it.mkdirs() }
+        val newDir = tempDir.resolve("new")
+
+        SampleInfoRepository.moveTo(oldDir, newDir, clearOld = true)
+
+        assertFalse(newDir.exists())
+    }
+}

--- a/src/jvmTest/kotlin/repository/ToolCursorRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/ToolCursorRepositoryTest.kt
@@ -1,0 +1,45 @@
+package repository
+
+import androidx.compose.ui.res.useResource
+import com.sdercolin.vlabeler.repository.ToolCursorRepository
+import com.sdercolin.vlabeler.ui.editor.Tool
+import java.awt.Cursor
+import java.awt.GraphicsEnvironment
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Tests for [ToolCursorRepository].
+ */
+class ToolCursorRepositoryTest {
+
+    @Test
+    fun testCursorToolUsesDefaultCursor() {
+        // Tool.Cursor has no cursor image, so the default system cursor is used
+        assertEquals(Cursor.getDefaultCursor(), ToolCursorRepository.get(Tool.Cursor))
+    }
+
+    @Test
+    fun testCursorImagesExistWithExpectedSize() {
+        // the hotspot is hard-coded to the center of a 24x24 image, so all cursor images must have that size
+        Tool.values().mapNotNull { it.cursorPath }.forEach { path ->
+            val image = assertNotNull(useResource(path) { ImageIO.read(it) }, "Cannot read cursor image: $path")
+            assertEquals(24, image.width, "Unexpected width of cursor image: $path")
+            assertEquals(24, image.height, "Unexpected height of cursor image: $path")
+        }
+    }
+
+    @Test
+    fun testCustomCursorCreation() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // custom cursors cannot be created in a headless environment
+            return
+        }
+        Tool.values().filter { it.cursorPath != null }.forEach { tool ->
+            val cursor = ToolCursorRepository.get(tool)
+            assertEquals(tool.name, cursor.name)
+        }
+    }
+}

--- a/src/jvmTest/kotlin/ui/ProjectCreatorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/ProjectCreatorStateTest.kt
@@ -1,0 +1,909 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.Sample
+import com.sdercolin.vlabeler.io.loadPlugins
+import com.sdercolin.vlabeler.model.AppRecord
+import com.sdercolin.vlabeler.model.LabelerConf
+import com.sdercolin.vlabeler.model.Plugin
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.ui.AppRecordStore
+import com.sdercolin.vlabeler.ui.AppState
+import com.sdercolin.vlabeler.ui.starter.PathPicker
+import com.sdercolin.vlabeler.ui.starter.ProjectCreatorState
+import com.sdercolin.vlabeler.ui.string.Language
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.util.AppRecordFile
+import com.sdercolin.vlabeler.util.HomeDir
+import com.sdercolin.vlabeler.util.toParamMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import java.io.File
+import java.nio.charset.Charset
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ProjectCreatorState].
+ *
+ * [ProjectCreatorState] only dereferences its [AppState] in the `appConf` getter and in `create()`
+ * (`showError`/`onCreateProject`), none of which are exercised here, so the tests pass an uninitialized [AppState]
+ * instance allocated without running its constructor (a real construction would start IPC/audio side effects).
+ *
+ * The [AppRecordStore] is constructed with an already-cancelled scope so that its `collectAndWrite()` loop never
+ * runs and nothing is ever written to the real application directory. This safety assumption is itself asserted in
+ * [app record store on cancelled scope never updates or writes the record file].
+ */
+class ProjectCreatorStateTest {
+
+    private lateinit var scope: CoroutineScope
+    private val tempDirs = mutableListOf<File>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @AfterTest
+    fun teardown() {
+        scope.cancel()
+        tempDirs.forEach { it.deleteRecursively() }
+        tempDirs.clear()
+        Log.muted = false
+    }
+
+    private fun newTempDir(): File = createTempDirectory("vlabeler-test").toFile().also { tempDirs += it }
+
+    private fun uninitializedAppState(): AppState {
+        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(AppState::class.java) as AppState
+    }
+
+    private fun cancelledScope(): CoroutineScope = CoroutineScope(Job().apply { cancel() })
+
+    private fun createState(
+        appRecord: AppRecord = AppRecord(),
+        labelers: List<LabelerConf> = defaultLabelers,
+        plugins: List<Plugin> = emptyList(),
+        initialFile: File? = null,
+    ): ProjectCreatorState = ProjectCreatorState(
+        uninitializedAppState(),
+        scope,
+        labelers,
+        plugins,
+        AppRecordStore(appRecord, cancelledScope()),
+        initialFile,
+    )
+
+    /** Waits until all coroutines launched on [scope] by the state under test have finished. */
+    private fun awaitIdle() = runBlocking {
+        while (true) {
+            val children = scope.coroutineContext.job.children.toList()
+            if (children.isEmpty()) break
+            children.joinAll()
+        }
+    }
+
+    /* region AppRecordStore safety */
+
+    @Test
+    fun `app record store on cancelled scope never updates or writes the record file`() {
+        val before = Triple(AppRecordFile.exists(), AppRecordFile.lastModified(), AppRecordFile.length())
+        val store = AppRecordStore(AppRecord(), cancelledScope())
+        store.update { copy(autoExport = true) }
+        // longer than the 500 ms write throttle in AppRecordStore
+        Thread.sleep(800)
+        assertEquals(AppRecord(), store.value)
+        val after = Triple(AppRecordFile.exists(), AppRecordFile.lastModified(), AppRecordFile.length())
+        assertEquals(before, after)
+    }
+
+    /* endregion */
+
+    /* region Page */
+
+    @Test
+    fun `page enum orders directory labeler and data source`() {
+        assertEquals(ProjectCreatorState.Page.Labeler, ProjectCreatorState.Page.Directory.next())
+        assertEquals(ProjectCreatorState.Page.DataSource, ProjectCreatorState.Page.Labeler.next())
+        assertNull(ProjectCreatorState.Page.DataSource.next())
+        assertNull(ProjectCreatorState.Page.Directory.previous())
+        assertEquals(ProjectCreatorState.Page.Directory, ProjectCreatorState.Page.Labeler.previous())
+        assertEquals(ProjectCreatorState.Page.Labeler, ProjectCreatorState.Page.DataSource.previous())
+    }
+
+    @Test
+    fun `navigation moves between pages`() {
+        val state = createState()
+        assertEquals(ProjectCreatorState.Page.Directory, state.page)
+        assertFalse(state.hasPrevious)
+        assertTrue(state.hasNext)
+
+        state.goNext()
+        assertEquals(ProjectCreatorState.Page.Labeler, state.page)
+        assertTrue(state.hasPrevious)
+        assertTrue(state.hasNext)
+
+        state.goNext()
+        assertEquals(ProjectCreatorState.Page.DataSource, state.page)
+        assertTrue(state.hasPrevious)
+        assertFalse(state.hasNext)
+
+        state.goPrevious()
+        assertEquals(ProjectCreatorState.Page.Labeler, state.page)
+        state.goPrevious()
+        assertEquals(ProjectCreatorState.Page.Directory, state.page)
+        // no previous page: stays
+        state.goPrevious()
+        assertEquals(ProjectCreatorState.Page.Directory, state.page)
+    }
+
+    @Test
+    fun `detail expanded state is restored from app record per page`() {
+        val record = AppRecord(projectCreatorDetailsExpanded = listOf(true, false, true))
+        val state = createState(appRecord = record)
+        assertTrue(state.isDetailExpanded)
+        state.goNext()
+        assertFalse(state.isDetailExpanded)
+        state.goNext()
+        assertTrue(state.isDetailExpanded)
+    }
+
+    @Test
+    fun `toggle detail expanded only affects the current page`() {
+        val state = createState()
+        assertFalse(state.isDetailExpanded)
+        state.toggleDetailExpanded()
+        assertTrue(state.isDetailExpanded)
+        state.goNext()
+        assertFalse(state.isDetailExpanded)
+        state.goPrevious()
+        assertTrue(state.isDetailExpanded)
+    }
+
+    /* endregion */
+
+    /* region Directory page */
+
+    @Test
+    fun `directories default to home directory when app record is empty`() {
+        val state = createState()
+        assertEquals(HomeDir.absolutePath, state.sampleDirectory)
+        assertEquals(HomeDir.absolutePath, state.workingDirectory)
+        assertEquals("", state.projectName)
+        assertEquals("", state.cacheDirectory)
+    }
+
+    @Test
+    fun `directories are restored from app record`() {
+        val sample = newTempDir()
+        val working = newTempDir()
+        val state = createState(
+            appRecord = AppRecord(sampleDirectory = sample.absolutePath, workingDirectory = working.absolutePath),
+        )
+        assertEquals(sample.absolutePath, state.sampleDirectory)
+        assertEquals(working.absolutePath, state.workingDirectory)
+    }
+
+    @Test
+    fun `update sample directory fills project name working directory and cache directory`() {
+        val state = createState()
+        val dir = newTempDir().resolve("MySinger").apply { mkdir() }
+
+        state.updateSampleDirectory(dir.absolutePath)
+
+        assertEquals(dir.absolutePath, state.sampleDirectory)
+        assertEquals("MySinger", state.projectName)
+        assertEquals(dir.absolutePath, state.workingDirectory)
+        assertEquals(
+            Project.getDefaultCacheDirectory(dir.absolutePath, "MySinger"),
+            state.cacheDirectory,
+        )
+    }
+
+    @Test
+    fun `update sample directory to home clears the default project name`() {
+        val state = createState()
+        val dir = newTempDir().resolve("MySinger").apply { mkdir() }
+        state.updateSampleDirectory(dir.absolutePath)
+
+        state.updateSampleDirectory(HomeDir.absolutePath)
+
+        assertEquals("", state.projectName)
+        assertEquals(HomeDir.absolutePath, state.workingDirectory)
+        // the previously filled cache directory is kept because the default filler skips empty project names
+        assertEquals(Project.getDefaultCacheDirectory(dir.absolutePath, "MySinger"), state.cacheDirectory)
+    }
+
+    @Test
+    fun `project name edited by user is kept when sample directory changes`() {
+        val state = createState()
+        state.updateProjectName("custom-name")
+        val dir = newTempDir().resolve("MySinger").apply { mkdir() }
+
+        state.updateSampleDirectory(dir.absolutePath)
+
+        assertEquals("custom-name", state.projectName)
+        assertEquals(Project.getDefaultCacheDirectory(dir.absolutePath, "custom-name"), state.cacheDirectory)
+    }
+
+    @Test
+    fun `edited working directory is kept when sample directory changes`() {
+        val state = createState()
+        val working = newTempDir().resolve("workspace").apply { mkdir() }
+        val sample = newTempDir().resolve("MySinger").apply { mkdir() }
+
+        state.updateWorkingDirectory(working.absolutePath)
+        state.updateSampleDirectory(sample.absolutePath)
+
+        assertEquals(working.absolutePath, state.workingDirectory)
+        assertEquals("MySinger", state.projectName)
+        // pins current behavior: with an edited working directory, changing the sample directory refills the
+        // project name but does not refresh the not-yet-edited cache directory, which keeps its previous value
+        assertEquals("", state.cacheDirectory)
+    }
+
+    @Test
+    fun `update working directory refreshes the default cache directory`() {
+        val state = createState()
+        state.updateProjectName("proj")
+        val working = newTempDir()
+
+        state.updateWorkingDirectory(working.absolutePath)
+
+        assertEquals(working.absolutePath, state.workingDirectory)
+        assertEquals(Project.getDefaultCacheDirectory(working.absolutePath, "proj"), state.cacheDirectory)
+    }
+
+    @Test
+    fun `edited cache directory is kept on further changes`() {
+        val state = createState()
+        val cache = newTempDir()
+        state.updateCacheDirectory(cache.absolutePath)
+
+        state.updateProjectName("proj")
+        state.updateWorkingDirectory(newTempDir().absolutePath)
+        state.updateSampleDirectory(newTempDir().resolve("MySinger").apply { mkdir() }.absolutePath)
+
+        assertEquals(cache.absolutePath, state.cacheDirectory)
+    }
+
+    @Test
+    fun `initial project file fills sample directory and project name`() {
+        val dir = newTempDir()
+        val projectFile = dir.resolve("my-project.${Project.PROJECT_FILE_EXTENSION}")
+        val state = createState(initialFile = projectFile)
+
+        assertEquals(dir.absolutePath, state.sampleDirectory)
+        assertEquals("my-project", state.projectName)
+    }
+
+    @Test
+    fun `initial project file name is not treated as a user edit`() {
+        val dir = newTempDir()
+        val projectFile = dir.resolve("my-project.${Project.PROJECT_FILE_EXTENSION}")
+        val state = createState(initialFile = projectFile)
+
+        val other = newTempDir().resolve("OtherSinger").apply { mkdir() }
+        state.updateSampleDirectory(other.absolutePath)
+
+        assertEquals("OtherSinger", state.projectName)
+    }
+
+    @Test
+    fun `initial directory fills sample directory and derives project name`() {
+        val dir = newTempDir().resolve("MySinger").apply { mkdir() }
+        val state = createState(initialFile = dir)
+
+        assertEquals(dir.absolutePath, state.sampleDirectory)
+        assertEquals("MySinger", state.projectName)
+    }
+
+    @Test
+    fun `sample directory validation`() {
+        val state = createState()
+        val dir = newTempDir()
+        state.updateSampleDirectory(dir.absolutePath)
+        assertTrue(state.isSampleDirectoryValid())
+
+        state.updateSampleDirectory(dir.resolve("not-existing").absolutePath)
+        assertFalse(state.isSampleDirectoryValid())
+
+        val file = dir.resolve("file.txt").apply { writeText("") }
+        state.updateSampleDirectory(file.absolutePath)
+        assertFalse(state.isSampleDirectoryValid())
+    }
+
+    @Test
+    fun `project name validation`() {
+        val state = createState()
+        state.updateProjectName("valid-name")
+        assertTrue(state.isProjectNameValid())
+
+        state.updateProjectName("in/valid")
+        assertFalse(state.isProjectNameValid())
+
+        state.updateProjectName("")
+        assertFalse(state.isProjectNameValid())
+
+        state.updateProjectName("  ")
+        assertFalse(state.isProjectNameValid())
+    }
+
+    @Test
+    fun `working directory validation requires an existing directory`() {
+        val state = createState()
+        val dir = newTempDir()
+        state.updateWorkingDirectory(dir.absolutePath)
+        assertTrue(state.isWorkingDirectoryValid())
+
+        state.updateWorkingDirectory(dir.resolve("not-existing").absolutePath)
+        assertFalse(state.isWorkingDirectoryValid())
+
+        state.updateWorkingDirectory(dir.resolve("no-parent").resolve("child").absolutePath)
+        assertFalse(state.isWorkingDirectoryValid())
+    }
+
+    @Test
+    fun `project file existing check`() {
+        val state = createState()
+        val dir = newTempDir()
+        state.updateWorkingDirectory(dir.absolutePath)
+        state.updateProjectName("proj")
+        assertFalse(state.isProjectFileExisting())
+
+        dir.resolve("proj.${Project.PROJECT_FILE_EXTENSION}").writeText("{}")
+        assertTrue(state.isProjectFileExisting())
+    }
+
+    @Test
+    fun `cache directory validation`() {
+        val state = createState()
+        val working = newTempDir()
+        state.updateWorkingDirectory(working.absolutePath)
+
+        // not existing yet, but directly under the working directory
+        state.updateCacheDirectory(working.resolve("proj.lbp.caches").absolutePath)
+        assertTrue(state.isCacheDirectoryValid())
+
+        // existing directory elsewhere
+        state.updateCacheDirectory(newTempDir().resolve("caches").apply { mkdir() }.absolutePath)
+        assertTrue(state.isCacheDirectoryValid())
+
+        // parent does not exist and is not the working directory
+        state.updateCacheDirectory(newTempDir().resolve("missing").resolve("caches").absolutePath)
+        assertFalse(state.isCacheDirectoryValid())
+
+        // existing plain file
+        val file = working.resolve("file.txt").apply { writeText("") }
+        state.updateCacheDirectory(file.absolutePath)
+        assertFalse(state.isCacheDirectoryValid())
+
+        state.updateCacheDirectory("")
+        assertFalse(state.isCacheDirectoryValid())
+    }
+
+    @Test
+    fun `has error reflects directory page validity`() {
+        val state = createState()
+        val dir = newTempDir().resolve("MySinger").apply { mkdir() }
+        state.updateSampleDirectory(dir.absolutePath)
+        assertFalse(state.hasError)
+
+        state.updateProjectName("in/valid")
+        assertTrue(state.hasError)
+    }
+
+    /* endregion */
+
+    /* region Labeler page */
+
+    @Test
+    fun `labeler categories put built-in categories first and empty category last`() {
+        val state = createState(
+            labelers = listOf(
+                TestLabelers.audacity,
+                TestLabelers.utauOto.copy(categoryTag = "Zebra"),
+                TestLabelers.nnsvsSinger,
+                TestLabelers.utauOto.copy(categoryTag = "Apple"),
+                TestLabelers.utauSinger,
+            ),
+        )
+        assertEquals(listOf("UTAU", "NNSVS", "Apple", "Zebra", ""), state.labelerCategories.toList())
+    }
+
+    @Test
+    fun `initial category and labeler fall back to the first available`() {
+        val state = createState()
+        assertEquals("UTAU", state.labelerCategory)
+        // utau-singer.default has displayOrder 0, oto-plus.default has 1
+        assertEquals(TestLabelers.utauSinger.name, state.labeler.name)
+    }
+
+    @Test
+    fun `selectable labelers are sorted by display order then name`() {
+        val state = createState()
+        assertEquals(
+            listOf(TestLabelers.utauSinger.name, TestLabelers.utauOto.name),
+            state.selectableLabelers.map { it.name },
+        )
+
+        val tieState = createState(labelers = listOf(TestLabelers.sinsy, TestLabelers.audacity))
+        assertEquals(
+            listOf(TestLabelers.audacity.name, TestLabelers.sinsy.name),
+            tieState.selectableLabelers.map { it.name },
+        )
+    }
+
+    @Test
+    fun `initial labeler is restored from app record`() {
+        val state = createState(
+            appRecord = AppRecord(labelerCategory = "UTAU", labelerName = TestLabelers.utauOto.name),
+        )
+        assertEquals("UTAU", state.labelerCategory)
+        assertEquals(TestLabelers.utauOto.name, state.labeler.name)
+    }
+
+    @Test
+    fun `recorded labeler name of another category falls back to first selectable`() {
+        val state = createState(
+            appRecord = AppRecord(labelerCategory = "NNSVS", labelerName = TestLabelers.utauOto.name),
+        )
+        assertEquals("NNSVS", state.labelerCategory)
+        assertEquals(TestLabelers.nnsvsSinger.name, state.labeler.name)
+    }
+
+    @Test
+    fun `update labeler category selects first labeler and remembers previous selections`() {
+        val state = createState(appRecord = AppRecord(sampleDirectory = newTempDir().absolutePath))
+        state.updateLabeler(TestLabelers.utauOto)
+        awaitIdle()
+        assertEquals(TestLabelers.utauOto.name, state.labeler.name)
+
+        state.updateLabelerCategory("NNSVS")
+        awaitIdle()
+        assertEquals("NNSVS", state.labelerCategory)
+        assertEquals(TestLabelers.nnsvsSinger.name, state.labeler.name)
+
+        state.updateLabelerCategory("UTAU")
+        awaitIdle()
+        assertEquals(TestLabelers.utauOto.name, state.labeler.name)
+    }
+
+    @Test
+    fun `update labeler category to the current category keeps the labeler`() {
+        val state = createState()
+        state.updateLabelerCategory("UTAU")
+        assertEquals(TestLabelers.utauSinger.name, state.labeler.name)
+    }
+
+    @Test
+    fun `update labeler loads params`() {
+        val state = createState(appRecord = AppRecord(sampleDirectory = newTempDir().absolutePath))
+        assertNull(state.labelerParams)
+
+        state.updateLabeler(TestLabelers.utauOto)
+        awaitIdle()
+
+        assertEquals(TestLabelers.utauOto.name, state.labeler.name)
+        assertNotNull(state.labelerParams)
+        assertEquals(state.labelerParams, state.labelerSavedParams)
+    }
+
+    @Test
+    fun `update labeler params flags invalid values`() {
+        val state = createState()
+        val labeler = state.labeler
+
+        state.updateLabelerParams(labeler.getDefaultParams())
+        assertFalse(state.labelerError)
+
+        val invalid = (labeler.getDefaultParams() + mapOf("dragBase" to "NotAnOption")).toParamMap()
+        state.updateLabelerParams(invalid)
+        assertTrue(state.labelerError)
+
+        state.goNext()
+        assertEquals(ProjectCreatorState.Page.Labeler, state.page)
+        assertTrue(state.hasError)
+    }
+
+    @Test
+    fun `update labeler with self-constructed labeler resets content type and encoding`() {
+        val state = createState(
+            appRecord = AppRecord(projectContentType = ProjectCreatorState.ContentType.File),
+            labelers = listOf(TestLabelers.audacity),
+        )
+        assertEquals(ProjectCreatorState.ContentType.File, state.contentType)
+        assertEquals("UTF-8", state.encoding)
+
+        state.updateLabeler(TestLabelers.utauSinger)
+        awaitIdle()
+
+        assertEquals(ProjectCreatorState.ContentType.Default, state.contentType)
+        assertEquals("Shift-JIS", state.encoding)
+    }
+
+    @Test
+    fun `update labeler autofills the default input file from the sample directory`() {
+        val sampleDirectory = TestFixtures.deploy("oto", newTempDir())
+        val state = createState(appRecord = AppRecord(sampleDirectory = sampleDirectory.absolutePath))
+
+        state.updateLabeler(TestLabelers.utauOto)
+        awaitIdle()
+
+        assertEquals(sampleDirectory.resolve("oto.ini").absolutePath, state.inputFile)
+    }
+
+    @Test
+    fun `input file edited by user is not overwritten by labeler autofill`() {
+        val sampleDirectory = TestFixtures.deploy("oto", newTempDir())
+        val state = createState(appRecord = AppRecord(sampleDirectory = sampleDirectory.absolutePath))
+        val ownFile = newTempDir().resolve("own.ini").apply { writeText("") }
+
+        state.updateInputFile(ownFile.absolutePath, editedByUser = true, detectEncoding = false)
+        awaitIdle()
+        state.updateLabeler(TestLabelers.utauOto)
+        awaitIdle()
+
+        assertEquals(ownFile.absolutePath, state.inputFile)
+    }
+
+    /* endregion */
+
+    /* region Data source page */
+
+    @Test
+    fun `selectable content types depend on the labeler kind`() {
+        val state = createState()
+        // default labeler utau-singer is self-constructed
+        assertEquals(
+            listOf(ProjectCreatorState.ContentType.Default, ProjectCreatorState.ContentType.Plugin),
+            state.selectableContentTypes,
+        )
+
+        val plainState = createState(labelers = listOf(TestLabelers.audacity))
+        assertEquals(ProjectCreatorState.ContentType.entries.toList(), plainState.selectableContentTypes)
+    }
+
+    @Test
+    fun `initial content type is taken from app record only when selectable`() {
+        val record = AppRecord(projectContentType = ProjectCreatorState.ContentType.File)
+        val selfConstructedState = createState(appRecord = record)
+        assertEquals(ProjectCreatorState.ContentType.Default, selfConstructedState.contentType)
+
+        val plainState = createState(appRecord = record, labelers = listOf(TestLabelers.audacity))
+        assertEquals(ProjectCreatorState.ContentType.File, plainState.contentType)
+    }
+
+    @Test
+    fun `select content type plugin picks the first supported plugin`() {
+        val state = createState(
+            appRecord = AppRecord(
+                sampleDirectory = newTempDir().absolutePath,
+                labelerCategory = "UTAU",
+                labelerName = TestLabelers.utauOto.name,
+            ),
+            plugins = allTemplatePlugins,
+        )
+        state.selectContentType(ProjectCreatorState.ContentType.Plugin, Language.English)
+        awaitIdle()
+
+        assertEquals(ProjectCreatorState.ContentType.Plugin, state.contentType)
+        val plugin = assertNotNull(state.templatePlugin)
+        assertTrue(plugin.isLabelFileExtensionSupported("ini"))
+    }
+
+    @Test
+    fun `select content type plugin without available plugins keeps none selected`() {
+        val state = createState()
+        state.selectContentType(ProjectCreatorState.ContentType.Plugin, Language.English)
+        awaitIdle()
+
+        assertEquals(ProjectCreatorState.ContentType.Plugin, state.contentType)
+        assertNull(state.templatePlugin)
+
+        // an empty plugin selection makes the data source page invalid
+        state.goNext()
+        state.goNext()
+        assertEquals(ProjectCreatorState.Page.DataSource, state.page)
+        assertTrue(state.hasError)
+    }
+
+    @Test
+    fun `supported plugins are filtered by the labeler extension`() {
+        val state = createState(
+            appRecord = AppRecord(labelerCategory = "UTAU", labelerName = TestLabelers.utauOto.name),
+            plugins = allTemplatePlugins,
+        )
+        val supported = state.getSupportedPlugins(Language.English).map { it.name }
+
+        listOf("cv-oto-gen", "cvvc-oto-gen", "vcv-oto-gen", "regex-raw-gen").forEach {
+            assertTrue(it in supported, "expected $it to support .ini")
+        }
+        listOf("ust2lab-ja-kana", "audacity2lab", "lab2audacity").forEach {
+            assertFalse(it in supported, "expected $it not to support .ini")
+        }
+    }
+
+    @Test
+    fun `update plugin loads its params`() {
+        val state = createState(
+            appRecord = AppRecord(
+                sampleDirectory = newTempDir().absolutePath,
+                labelerCategory = "UTAU",
+                labelerName = TestLabelers.utauOto.name,
+            ),
+            plugins = allTemplatePlugins,
+        )
+        val plugin = allTemplatePlugins.first { it.name == "cvvc-oto-gen" }
+
+        state.updatePlugin(plugin)
+        awaitIdle()
+
+        assertEquals(plugin, state.templatePlugin)
+        assertNotNull(state.templatePluginParams)
+        assertEquals(state.templatePluginParams, state.templatePluginSavedParams)
+        assertNull(state.warningText)
+    }
+
+    @Test
+    fun `update plugin on a self-constructed labeler shows a warning`() {
+        val state = createState(plugins = allTemplatePlugins)
+        val plugin = allTemplatePlugins.first { it.name == "cvvc-oto-gen" }
+
+        state.updatePlugin(plugin)
+        awaitIdle()
+
+        assertEquals(Strings.StarterNewWarningSelfConstructedLabelerWithTemplatePlugin, state.warningText)
+
+        state.updatePlugin(null)
+        assertNull(state.templatePlugin)
+        assertNull(state.templatePluginParams)
+        assertNull(state.templatePluginSavedParams)
+        assertFalse(state.templatePluginError)
+        assertNull(state.warningText)
+    }
+
+    @Test
+    fun `update labeler clears a plugin that does not support the new extension`() {
+        val state = createState(
+            appRecord = AppRecord(
+                sampleDirectory = newTempDir().absolutePath,
+                labelerCategory = "UTAU",
+                labelerName = TestLabelers.utauOto.name,
+            ),
+            plugins = allTemplatePlugins,
+        )
+        state.updatePlugin(allTemplatePlugins.first { it.name == "cvvc-oto-gen" })
+        awaitIdle()
+        assertNotNull(state.templatePlugin)
+
+        // nnsvs-singer uses .lab, which cvvc-oto-gen does not support
+        state.updateLabeler(TestLabelers.nnsvsSinger)
+        awaitIdle()
+
+        assertNull(state.templatePlugin)
+    }
+
+    @Test
+    fun `update plugin params flags invalid values`() {
+        val state = createState(
+            appRecord = AppRecord(
+                sampleDirectory = newTempDir().absolutePath,
+                labelerCategory = "UTAU",
+                labelerName = TestLabelers.utauOto.name,
+            ),
+            plugins = allTemplatePlugins,
+        )
+        val plugin = allTemplatePlugins.first { it.name == "cvvc-oto-gen" }
+        state.updatePlugin(plugin)
+        awaitIdle()
+
+        state.updatePluginParams(plugin.getDefaultParams())
+        assertFalse(state.templatePluginError)
+
+        // bpm has min 0
+        val invalid = (plugin.getDefaultParams() + mapOf("bpm" to -1f)).toParamMap()
+        state.updatePluginParams(invalid)
+        assertTrue(state.templatePluginError)
+    }
+
+    @Test
+    fun `encoding defaults to the labeler parser encoding`() {
+        val state = createState()
+        assertEquals("Shift-JIS", state.encoding)
+
+        val plainState = createState(labelers = listOf(TestLabelers.audacity))
+        assertEquals("UTF-8", plainState.encoding)
+    }
+
+    @Test
+    fun `update input file detects the file encoding`() {
+        val state = createState(labelers = listOf(TestLabelers.audacity))
+        assertEquals("UTF-8", state.encoding)
+        val text = "これはボイスバンクの音源設定ファイルのテストです。あいうえおかきくけこ。".repeat(10)
+        val file = newTempDir().resolve("input.txt").apply {
+            writeBytes(text.toByteArray(Charset.forName("Shift_JIS")))
+        }
+
+        state.updateInputFile(file.absolutePath, editedByUser = true)
+        awaitIdle()
+
+        assertEquals(file.absolutePath, state.inputFile)
+        assertEquals("Shift-JIS", state.encoding)
+    }
+
+    @Test
+    fun `input file validation checks extension and existence`() {
+        val state = createState(labelers = listOf(TestLabelers.audacity))
+        assertFalse(state.isInputFileValid())
+
+        val dir = newTempDir()
+        val wrongExtension = dir.resolve("labels.ini").apply { writeText("") }
+        state.updateInputFile(wrongExtension.absolutePath, editedByUser = true, detectEncoding = false)
+        awaitIdle()
+        assertFalse(state.isInputFileValid())
+
+        state.updateInputFile(dir.resolve("missing.txt").absolutePath, editedByUser = true, detectEncoding = false)
+        awaitIdle()
+        assertFalse(state.isInputFileValid())
+
+        val valid = dir.resolve("labels.txt").apply { writeText("") }
+        state.updateInputFile(valid.absolutePath, editedByUser = true, detectEncoding = false)
+        awaitIdle()
+        assertTrue(state.isInputFileValid())
+    }
+
+    @Test
+    fun `can auto export depends on labeler and content type`() {
+        // self-constructed labeler: always
+        assertTrue(createState().canAutoExport)
+
+        // labeler with a default input file path: always
+        val otoState = createState(
+            appRecord = AppRecord(labelerCategory = "UTAU", labelerName = TestLabelers.utauOto.name),
+        )
+        assertTrue(otoState.canAutoExport)
+
+        // plain labeler without default input: only with content type File
+        val plainState = createState(labelers = listOf(TestLabelers.audacity))
+        assertFalse(plainState.canAutoExport)
+        plainState.selectContentType(ProjectCreatorState.ContentType.File, Language.English)
+        assertTrue(plainState.canAutoExport)
+    }
+
+    @Test
+    fun `toggle auto export updates the state`() {
+        val state = createState()
+        assertFalse(state.autoExport)
+        state.toggleAutoExport(true)
+        assertTrue(state.autoExport)
+        state.toggleAutoExport(false)
+        assertFalse(state.autoExport)
+    }
+
+    /* endregion */
+
+    /* region File pickers */
+
+    @Test
+    fun `pick methods set the current path picker`() {
+        val state = createState()
+        assertNull(state.currentPathPicker)
+        state.pickSampleDirectory()
+        assertEquals(PathPicker.SampleDirectory, state.currentPathPicker)
+        state.pickWorkingDirectory()
+        assertEquals(PathPicker.WorkingDirectory, state.currentPathPicker)
+        state.pickCacheDirectory()
+        assertEquals(PathPicker.CacheDirectory, state.currentPathPicker)
+        state.pickInputFile()
+        assertEquals(PathPicker.InputFile, state.currentPathPicker)
+    }
+
+    @Test
+    fun `file picker modes and extensions`() {
+        val state = createState()
+        assertTrue(state.getFilePickerDirectoryMode(PathPicker.SampleDirectory))
+        assertTrue(state.getFilePickerDirectoryMode(PathPicker.WorkingDirectory))
+        assertTrue(state.getFilePickerDirectoryMode(PathPicker.CacheDirectory))
+        assertFalse(state.getFilePickerDirectoryMode(PathPicker.InputFile))
+
+        assertEquals(Sample.acceptableSampleFileExtensions, state.getFilePickerExtensions(PathPicker.SampleDirectory))
+        assertNull(state.getFilePickerExtensions(PathPicker.WorkingDirectory))
+        assertNull(state.getFilePickerExtensions(PathPicker.CacheDirectory))
+        assertEquals(listOf(state.labeler.extension), state.getFilePickerExtensions(PathPicker.InputFile))
+    }
+
+    @Test
+    fun `file picker initial directories`() {
+        val state = createState(labelers = listOf(TestLabelers.audacity))
+        val sample = newTempDir()
+        val working = newTempDir()
+        val cache = newTempDir()
+        state.updateSampleDirectory(sample.absolutePath)
+        state.updateWorkingDirectory(working.absolutePath)
+        state.updateCacheDirectory(cache.absolutePath)
+
+        assertEquals(sample.absolutePath, state.getFilePickerInitialDirectory(PathPicker.SampleDirectory))
+        assertEquals(working.absolutePath, state.getFilePickerInitialDirectory(PathPicker.WorkingDirectory))
+        assertEquals(cache.absolutePath, state.getFilePickerInitialDirectory(PathPicker.CacheDirectory))
+        // no valid input file yet: falls back to the sample directory
+        assertEquals(sample.absolutePath, state.getFilePickerInitialDirectory(PathPicker.InputFile))
+
+        val inputDir = newTempDir()
+        val input = inputDir.resolve("labels.txt").apply { writeText("") }
+        state.updateInputFile(input.absolutePath, editedByUser = true, detectEncoding = false)
+        awaitIdle()
+        assertEquals(inputDir.absolutePath, state.getFilePickerInitialDirectory(PathPicker.InputFile))
+    }
+
+    @Test
+    fun `handle file picker result updates the picked field`() {
+        val state = createState(labelers = listOf(TestLabelers.audacity))
+        val dir = newTempDir().resolve("MySinger").apply { mkdir() }
+
+        state.pickSampleDirectory()
+        state.handleFilePickerResult(PathPicker.SampleDirectory, dir.parent, dir.name)
+        assertNull(state.currentPathPicker)
+        assertEquals(dir.absolutePath, state.sampleDirectory)
+
+        val input = dir.resolve("labels.txt").apply { writeText("") }
+        state.pickInputFile()
+        state.handleFilePickerResult(PathPicker.InputFile, input.parent, input.name)
+        awaitIdle()
+        assertNull(state.currentPathPicker)
+        assertEquals(input.absolutePath, state.inputFile)
+    }
+
+    @Test
+    fun `handle file picker result with no selection only closes the picker`() {
+        val state = createState()
+        val originalSampleDirectory = state.sampleDirectory
+        state.pickSampleDirectory()
+
+        state.handleFilePickerResult(PathPicker.SampleDirectory, null, null)
+
+        assertNull(state.currentPathPicker)
+        assertEquals(originalSampleDirectory, state.sampleDirectory)
+    }
+
+    /* endregion */
+
+    companion object {
+
+        private val defaultLabelers by lazy {
+            listOf(
+                TestLabelers.utauSinger,
+                TestLabelers.utauOto,
+                TestLabelers.nnsvsSinger,
+                TestLabelers.audacity,
+                TestLabelers.sinsy,
+            )
+        }
+
+        private val allTemplatePlugins: List<Plugin> by lazy {
+            TestEnv.ensureLogDirectory()
+            loadPlugins(Plugin.Type.Template, Language.English)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First batch from the [coverage plan Trello card](https://trello.com/c/WFKEU7I2) — checklist items 1–4 in one PR: **221 new tests (713 total), line coverage 32% → 36.2%**, koverVerify bound raised 30 → 34.

### 1. Marker/editor drag logic (109 tests)
The core label-editing feature. `MarkerStateFactory` replicates the production `rememberMarkerState` wiring (real `EntryConverter`, pixel validation, continuous borders, `SnapDrag`) at 1 ms = 1 px so expectations are hand-computable. Covers `getDraggedEntries` (border clamping, field-point constraints via `connectedConstraints`, forced-drag cascading/collapsing), `getLockedDraggedEntries` (whole-entry translation, no-room cases), point-index math, hover detection, cut positions, `computeCascadeEditions`, and `EntryConverter`/`EntryInPixel` — in both continuous (NNSVS) and non-continuous (UTAU) modes.

### 2. ProjectCreatorState (53 tests)
Page navigation, directory/name/cache autofill cascades with user-edit stickiness, all validators, labeler/category selection with record restore, real template-plugin selection and param validation, Shift-JIS encoding detection, file-picker logic. A dedicated test proves nothing writes to the real app record file.

### 3. Cache repositories (45 tests)
`ChartRepository`/`SampleInfoRepository`/`ConvertedAudioRepository`/`ColorPaletteRepository`/`FontRepository`/`ToolCursorRepository`: version and painter-config invalidation, exact cache file layout, restart simulations proving the file cache is used, `moveTo`/`clear`, name collisions.

### 4. IPC (14 tests)
Wire-level JSON contract per message type (raw strings, as an external client sees them) and end-to-end ZeroMQ REQ/REP round trips against a real `IpcServer`, with port-cleanup verification.

### Infrastructure
Test tasks now set `VLABELER_APP_DIR=build/test-app-dir`, so tests can never read/write the real `~/vLabeler` directory.

### Suspected production bugs found (pinned in tests, NOT fixed)
1. **`MarkerState.getPointIndexForHovering` (`MarkerState.kt:450`)**: the final "check start" block is missing a `return`, so its result is discarded (adjacent comments also swapped) — hover detection near the start point silently fails in that branch
2. **`IpcServer.startReceive`**: the receive loop reads `job?.isActive` but `job` is assigned after `launch` — a startup race can make the server a silent no-op; also REP state-machine churn (EFSM exceptions logged every 200 ms between recv and reply), bind failures swallowed, dead code line in `IpcJson`
3. **`ConvertedAudioRepository.clear`** doesn't clear its in-memory map (unlike its siblings) — re-conversion after clear gets a spurious `.converted.1.wav` name
4. **`ProjectCreatorState`**: cache directory not refreshed when the sample directory changes after a manual working-directory edit; `isCacheDirectoryValid` compares paths by raw string equality; dead double-fallback in `getEncodingByLabeler`
5. Observation: `SampleInfoRepository`'s memory cache key has no project identity — theoretical cross-project stale hit

### Testability refactor suggestions (described, not applied)
- `Marker.kt` pointer/keyboard handlers and `editEntryIfNeeded` are `private` — `internal` visibility or extracting the Edition-building logic would unlock them
- `ProjectCreatorState.create()` needs a narrow `onCreateProject`/`showError` dependency instead of `AppState`

## Test plan

- [x] `./gradlew jvmTest` — 713 tests, 0 failures
- [x] `./gradlew koverVerify ktlintCheck`
- [x] Verified `build/test-app-dir` receives the redirected app data

🤖 Generated with [Claude Code](https://claude.com/claude-code)