### PR TITLE
Fix bugs found by the coverage-batch-1 tests

### DIFF
--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ipc/IpcJson.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ipc/IpcJson.kt
@@ -15,7 +15,6 @@ val jsonForIpc = Json {
     encodeDefaults = true
     ignoreUnknownKeys = true
     isLenient = true
-    serializersModule
     serializersModule = SerializersModule {
         polymorphic(IpcRequest::class) {
             subclass(HeartbeatRequest::class)

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ipc/IpcServer.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ipc/IpcServer.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -42,7 +43,9 @@ class IpcServer(val coroutineScope: CoroutineScope) {
     fun startReceive(requestFlow: MutableSharedFlow<IpcRequest>) {
         job?.cancel()
         job = coroutineScope.launch(Dispatchers.IO) {
-            while (job?.isActive == true && zContext.isClosed.not()) {
+            // `isActive` refers to this coroutine; do not read `job` here, because this body may start running
+            // before the assignment to `job` is visible.
+            while (isActive && zContext.isClosed.not()) {
                 if (hasUncaughtError) {
                     close()
                     return@launch
@@ -54,7 +57,11 @@ class IpcServer(val coroutineScope: CoroutineScope) {
                     val request = jsonForIpc.decodeFromString<IpcRequest>(message)
                     requestFlow.emit(request)
                 } catch (t: Throwable) {
-                    if (t !is CancellationException && (t as? ZMQException)?.errorCode != ZError.ETERM) {
+                    val zmqErrorCode = (t as? ZMQException)?.errorCode
+                    // ETERM: the context is being closed.
+                    // EFSM: the REP socket is waiting for `send` to be called for the previously received request,
+                    // which is expected while a request is still being handled.
+                    if (t !is CancellationException && zmqErrorCode != ZError.ETERM && zmqErrorCode != ZError.EFSM) {
                         Log.error("Failed to receive an IPC request:")
                         Log.error(t)
                     }

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/repository/ConvertedAudioRepository.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/repository/ConvertedAudioRepository.kt
@@ -63,6 +63,7 @@ object ConvertedAudioRepository {
      */
     fun clear(project: Project) {
         project.getCacheDir().resolve(WAVE_CACHE_FOLDER_NAME).deleteRecursivelyLogged()
+        cacheMap.clear()
     }
 
     /**

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/repository/SampleInfoRepository.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/repository/SampleInfoRepository.kt
@@ -31,6 +31,9 @@ object SampleInfoRepository {
      * @param project Current project.
      */
     fun init(project: Project) {
+        // the memory cache is keyed by (module name, sample name) without any project identity, so it has to be
+        // dropped when a(nother) project is initialized to avoid serving stale entries across projects
+        infoMap.clear()
         cacheDirectory = project.getCacheDir().resolve(SAMPLE_INFO_CACHE_FOLDER_NAME)
         cacheDirectory.mkdirs()
         cacheMap = runCatching {

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerState.kt
@@ -442,14 +442,14 @@ class MarkerState(
                 }
             }
 
-        // check start again
+        // check end again
         if ((endInPixel - x).absoluteValue <= NEAR_RADIUS_START_OR_END) {
             return MarkerCursorState.END_POINT_INDEX
         }
 
-        // check end again
+        // check start again
         if ((startInPixel - x).absoluteValue <= NEAR_RADIUS_START_OR_END) {
-            MarkerCursorState.START_POINT_INDEX
+            return MarkerCursorState.START_POINT_INDEX
         }
 
         return MarkerCursorState.NONE_POINT_INDEX

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/starter/ProjectCreatorState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/starter/ProjectCreatorState.kt
@@ -120,9 +120,10 @@ class ProjectCreatorState(
         }
         if (!workingDirectoryEdited) {
             workingDirectory = sampleDirectory
-            if (!cacheDirectoryEdited) {
-                fillInCacheDirectoryByDefault(path, projectName)
-            }
+        }
+        if (!cacheDirectoryEdited) {
+            // refresh with the possibly user-edited working directory and the refilled project name
+            fillInCacheDirectoryByDefault(workingDirectory, projectName)
         }
     }
 
@@ -197,7 +198,12 @@ class ProjectCreatorState(
         return try {
             val file = File(cacheDirectory)
             val parent = file.parent.orEmpty()
-            if (parent != workingDirectory && parent.toFile().exists().not()) return false
+            // compare as files so that e.g. a trailing separator does not create a false mismatch
+            if (File(parent).absolutePath != File(workingDirectory).absolutePath &&
+                parent.toFile().exists().not()
+            ) {
+                return false
+            }
             if (file.isFile) return false
             return file.name.isValidFileName()
         } catch (t: Throwable) {
@@ -366,7 +372,6 @@ class ProjectCreatorState(
     private fun getEncodingByLabeler(): String {
         val parser = labeler.parser
         return encodings.find { encodingNameEquals(parser.defaultEncoding, it) }
-            ?: encodings.first().takeIf { it.isNotBlank() }
             ?: encodings.first()
     }
 

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateHoverTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateHoverTest.kt
@@ -119,10 +119,7 @@ class MarkerStateHoverTest {
     }
 
     @Test
-    fun hoveringNearStartButCloserToNextPointReturnsNone() {
-        // Suspected production bug (pinning current behavior): the final start check in
-        // MarkerState.getPointIndexForHovering computes START_POINT_INDEX without returning it, so a position that
-        // is within the start radius but closer to the next point ends up as NONE instead of START.
+    fun hoveringNearStartButCloserToNextPointReturnsStart() {
         val state = MarkerStateFactory.create(
             labelerConf = TestLabelers.nnsvsSinger,
             allEntries = listOf(
@@ -131,7 +128,8 @@ class MarkerStateHoverTest {
             ),
         )
         // x = 108 is within 20 px of the start (100) but closer to the border (110); the line hit test skips the
-        // border because the position is also within the start radius and left of the border
-        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.hover(108f, 500f))
+        // border because the position is also within the start radius and left of the border, so the fallback
+        // start check applies
+        assertEquals(MarkerCursorState.START_POINT_INDEX, state.hover(108f, 500f))
     }
 }

--- a/src/jvmTest/kotlin/ipc/IpcServerTest.kt
+++ b/src/jvmTest/kotlin/ipc/IpcServerTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assumptions
 import org.zeromq.SocketType
 import org.zeromq.ZContext
 import org.zeromq.ZMQ
@@ -31,7 +32,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 /**
  * End-to-end tests for [IpcServer] over a real ZeroMQ REQ/REP socket pair on `tcp://localhost:32342`.
@@ -65,16 +65,19 @@ class IpcServerTest {
 
     /**
      * [IpcServer.bind] swallows bind failures, which would make the test hang until timeout instead of failing
-     * clearly, so check the fixed port up front and fail fast with an explanation.
+     * clearly, so check the fixed port up front. When the port is taken (typically by a running vLabeler instance
+     * on a developer machine), skip the test instead of failing; CI machines never run the application, so these
+     * tests are always executed there.
      */
     private fun requirePortFree() {
-        try {
+        val portFree = try {
             ServerSocket(PORT).close()
+            true
         } catch (e: IOException) {
-            fail(
-                "Port $PORT is already in use (a running vLabeler instance or a leaked server from a previous " +
-                    "test run?). Free the port and re-run. Cause: $e",
-            )
+            false
+        }
+        Assumptions.assumeTrue(portFree) {
+            "Port $PORT is already in use (probably by a running vLabeler instance); skipping the socket test."
         }
     }
 

--- a/src/jvmTest/kotlin/repository/ConvertedAudioRepositoryTest.kt
+++ b/src/jvmTest/kotlin/repository/ConvertedAudioRepositoryTest.kt
@@ -136,10 +136,7 @@ class ConvertedAudioRepositoryTest {
     }
 
     @Test
-    fun testClearKeepsCacheMapEntries() {
-        // Pins current behavior: unlike SampleInfoRepository.clear and ChartRepository.clear, this clear() does not
-        // reset the in-memory cache map, so the next conversion of the same sample gets a suffixed file name
-        // because the stale map entry still reserves the base name. Suspected bug in production code.
+    fun testClearResetsCacheMapEntries() {
         val project = createProject()
         ConvertedAudioRepository.init(project)
         val wavFile = project.rootSampleDirectory.resolve("_a_ka.wav")
@@ -148,7 +145,8 @@ class ConvertedAudioRepositoryTest {
         ConvertedAudioRepository.clear(project)
         val output = create(project, wavFile)
 
-        assertEquals("__a_ka.wav.converted.1.wav", output.name)
+        // the in-memory map is reset together with the files, so the base name is available again
+        assertEquals("__a_ka.wav.converted.wav", output.name)
     }
 
     @Test

--- a/src/jvmTest/kotlin/ui/ProjectCreatorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/ProjectCreatorStateTest.kt
@@ -258,9 +258,11 @@ class ProjectCreatorStateTest {
 
         assertEquals(working.absolutePath, state.workingDirectory)
         assertEquals("MySinger", state.projectName)
-        // pins current behavior: with an edited working directory, changing the sample directory refills the
-        // project name but does not refresh the not-yet-edited cache directory, which keeps its previous value
-        assertEquals("", state.cacheDirectory)
+        // the not-yet-edited cache directory follows the edited working directory and the refilled project name
+        assertEquals(
+            Project.getDefaultCacheDirectory(working.absolutePath, "MySinger"),
+            state.cacheDirectory,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #104, fixing the pinned bugs:

1. **`MarkerState.getPointIndexForHovering`**: added the missing `return` in the fallback start check — hovering near an entry's start point now works when the position is closer to a skipped neighbor point; also un-swapped the comments on the two fallback blocks
2. **`IpcServer`**: fixed the startup race (receive loop read `job` before the assignment was visible and could exit immediately — now uses the coroutine's own `isActive`); EFSM errors from the REP socket while a request is being handled are no longer error-logged every 200 ms; removed a dead expression in `IpcJson`
3. **`ConvertedAudioRepository.clear`**: resets the in-memory cache map like its siblings, so re-converted files get their base names back instead of spurious `.converted.1.wav` suffixes
4. **`SampleInfoRepository.init`**: drops the memory cache (keyed without project identity) to prevent stale cross-project hits
5. **`ProjectCreatorState`**: the not-yet-edited cache directory now refreshes when the sample directory changes after a manual working-directory edit; `isCacheDirectoryValid` compares directories as files (no trailing-slash false negatives); removed a dead double-fallback in `getEncodingByLabeler`

All tests that pinned the buggy behaviors were flipped to assert the corrected behavior in the same commit.

Test-infrastructure tweak: the `IpcServer` socket tests now **skip with an assumption** (instead of failing) when port 32342 is taken by a running vLabeler instance on a developer machine; CI always runs them.

## Test plan

- [x] `./gradlew jvmTest koverVerify ktlintCheck` — 713 tests, 0 failures
- [x] `IpcServerTest` verified against the fixed server with the port free (3/3, not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)