### PR TITLE
Coverage batch 2: preferences editor, io remainder, dialog states

### DIFF
--- a/.github/workflows/release-mac-arm.yml
+++ b/.github/workflows/release-mac-arm.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check version
         run: |
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-13
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check version
         run: |
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'

--- a/.github/workflows/release-ubuntu.yml
+++ b/.github/workflows/release-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check version
         run: |
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'

--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check version
         run: |
@@ -34,7 +34,7 @@ jobs:
           }
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,9 +151,9 @@ registerTestSubset(
 koverReport {
     defaults {
         verify {
-            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 36% on 2026-07-08).
+            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 45% on 2026-07-08).
             rule("Minimal line coverage") {
-                minBound(34)
+                minBound(43)
             }
         }
     }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,7 +32,7 @@ mirroring the production area rather than full package paths:
 | `plugins/` | Integration tests executing all bundled template and macro plugins through the real plugin runner |
 | `repository/` | Cache repositories: versioning/invalidation, move/clear |
 | `ipc/` | Remote-control API: wire-level JSON contract and real ZeroMQ round trips |
-| `ui/` | State-holder tests (`ProjectStore`, project creator wizard, app states) and Compose UI tests (`*UiTest`) |
+| `ui/` | State-holder tests (`ProjectStore`, project creator wizard, preferences editor, plugin/customization dialogs, app states) and Compose UI tests (`*UiTest`) |
 | `com.sdercolin.vlabeler.ui.editor.labeler.marker` | Editor marker drag/constraint logic (`MarkerStateFactory` builds real states) |
 | `util/` | Pure helper functions |
 | `env/`, `strings/` | Environment and localization helpers |

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/ImportProject.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/io/ImportProject.kt
@@ -8,6 +8,7 @@ import com.sdercolin.vlabeler.model.Project
 import com.sdercolin.vlabeler.util.json
 import com.segment.analytics.kotlin.core.utilities.safeJsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
@@ -117,7 +118,9 @@ private fun parseEntryArray(element: JsonElement): List<Entry>? = runCatching {
 }
 
 private fun parseEntry(element: JsonElement): Entry? = runCatching {
-    val entry = json.decodeFromJsonElement<Entry>(element)
+    // "meta" is the legacy name of "notes"; strip it before decoding so that the strict parser used in debug mode
+    // (`ignoreUnknownKeys = false`) does not fail on the unknown key before the compatibility handling below
+    val entry = json.decodeFromJsonElement<Entry>(JsonObject(element.jsonObject.filterKeys { it != "meta" }))
     val notes = if (element.jsonObject["notes"] == null) {
         // backward compatibility for "notes"
         element.jsonObject["meta"]?.let {

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/AppRecordStore.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/AppRecordStore.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AppRecordStore(appRecord: AppRecord, private val scope: CoroutineScope) {
@@ -19,12 +20,6 @@ class AppRecordStore(appRecord: AppRecord, private val scope: CoroutineScope) {
 
     init {
         collectAndWrite()
-    }
-
-    private fun push(appRecord: AppRecord) {
-        scope.launch(Dispatchers.IO) {
-            _stateFlow.emit(appRecord)
-        }
     }
 
     private fun collectAndWrite() {
@@ -41,7 +36,9 @@ class AppRecordStore(appRecord: AppRecord, private val scope: CoroutineScope) {
     val value get() = stateFlow.value
 
     fun update(updater: AppRecord.() -> AppRecord) {
-        push(updater(value))
+        // update the state atomically and synchronously so that consecutive updates never read a stale value;
+        // persisting to the record file stays asynchronous and throttled in `collectAndWrite`
+        _stateFlow.update(updater)
     }
 
     private fun applyLogSettings(appRecord: AppRecord) {

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesPages.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/dialog/preferences/PreferencesPages.kt
@@ -70,7 +70,7 @@ object PreferencesPages {
                     integer(
                         title = Strings.PreferencesChartsMaxDataChunkSize,
                         description = Strings.PreferencesChartsMaxDataChunkSizeDescription,
-                        defaultValue = AppConf.CanvasResolution.DEFAULT_STEP,
+                        defaultValue = AppConf.Painter.DEFAULT_MAX_DATA_CHUNK_SIZE,
                         min = AppConf.Painter.MIN_MAX_DATA_CHUNK_SIZE,
                         max = AppConf.Painter.MAX_MAX_DATA_CHUNK_SIZE,
                         select = { it.maxDataChunkSize },

--- a/src/jvmTest/kotlin/io/ImportProjectEdgeCasesTest.kt
+++ b/src/jvmTest/kotlin/io/ImportProjectEdgeCasesTest.kt
@@ -1,0 +1,291 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.ImportedModule
+import com.sdercolin.vlabeler.io.importModulesFromProject
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.EntryNotes
+import com.sdercolin.vlabeler.model.Project
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the edge cases of [importModulesFromProject], [ImportedModule.validate] and
+ * [ImportedModule.isCompatibleWith], complementing [ImportProjectTest].
+ */
+class ImportProjectEdgeCasesTest {
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private fun entryJson(name: String, points: String = "[1, 2]", extras: String = """["a"]""") = """
+        {
+            "sample": "sample1",
+            "name": "$name",
+            "start": 1,
+            "end": 2,
+            "points": $points,
+            "extras": $extras
+        }
+    """.trimIndent()
+
+    @Test
+    fun testInvalidJsonReturnsEmptyList() {
+        assertEquals(emptyList(), importModulesFromProject("not a json"))
+    }
+
+    @Test
+    fun testMissingLabelerConfReturnsEmptyList() {
+        val json = """
+            {
+                "modules": [
+                    {
+                        "name": "module1",
+                        "entries": [${entryJson("entry1")}]
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        assertEquals(emptyList(), importModulesFromProject(json))
+    }
+
+    @Test
+    fun testNoEntriesAndNoModulesReturnsEmptyList() {
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": false,
+                    "extension": "ini"
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(emptyList(), importModulesFromProject(json))
+    }
+
+    @Test
+    fun testModulesNotAnArrayReturnsEmptyList() {
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": false,
+                    "extension": "ini"
+                },
+                "modules": {
+                    "name": "module1"
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(emptyList(), importModulesFromProject(json))
+    }
+
+    @Test
+    fun testEmptyLegacyEntryArrayReturnsEmptyList() {
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": false,
+                    "extension": "ini"
+                },
+                "entries": []
+            }
+        """.trimIndent()
+
+        assertEquals(emptyList(), importModulesFromProject(json))
+    }
+
+    @Test
+    fun testDuplicateModuleNamesKeepFirst() {
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": false,
+                    "extension": "ini"
+                },
+                "modules": [
+                    {
+                        "name": "dup",
+                        "entries": [${entryJson("first")}]
+                    },
+                    {
+                        "name": "dup",
+                        "entries": [${entryJson("second")}]
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val actual = importModulesFromProject(json)
+
+        assertEquals(1, actual.size)
+        assertEquals("dup", actual.single().name)
+        assertEquals(listOf("first"), actual.single().entries.map { it.name })
+    }
+
+    @Test
+    fun testLegacyEntriesAndModulesAreBothImported() {
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": true,
+                    "extension": "lab"
+                },
+                "entries": [${entryJson("legacy")}],
+                "modules": [
+                    {
+                        "name": "module1",
+                        "entries": [${entryJson("modern")}]
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val actual = importModulesFromProject(json)
+
+        assertEquals(listOf("", "module1"), actual.map { it.name })
+        assertEquals(listOf("legacy"), actual[0].entries.map { it.name })
+        assertEquals(listOf("modern"), actual[1].entries.map { it.name })
+        actual.forEach {
+            assertEquals(true, it.continuous)
+            assertEquals("lab", it.extension)
+        }
+    }
+
+    @Test
+    fun testNotesAreImported() {
+        // NOTE: the backward compatibility path for the legacy "meta" field in `parseEntry` cannot be tested here:
+        // it is only reachable in packaged (non-debug) runs, because in debug runs (including tests)
+        // `json.ignoreUnknownKeys` is false and the unknown "meta" key fails the whole entry deserialization.
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": false,
+                    "extension": "ini"
+                },
+                "entries": [
+                    {
+                        "sample": "sample1",
+                        "name": "entry1",
+                        "start": 1,
+                        "end": 2,
+                        "points": [1, 2],
+                        "extras": ["a"],
+                        "notes": {
+                            "done": true,
+                            "star": true,
+                            "tag": "some-tag"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val actual = importModulesFromProject(json)
+
+        assertEquals(
+            EntryNotes(done = true, star = true, tag = "some-tag"),
+            actual.single().entries.single().notes,
+        )
+    }
+
+    @Test
+    fun testValidateThrowsOnInconsistentSizes() {
+        val module = ImportedModule(
+            name = "module1",
+            entries = listOf(
+                Entry(
+                    sample = "sample1",
+                    name = "entry1",
+                    start = 1f,
+                    end = 2f,
+                    points = listOf(1f),
+                    extras = listOf("a"),
+                ),
+            ),
+            pointSize = 2,
+            extraSize = 1,
+            continuous = false,
+            extension = "ini",
+        )
+
+        assertFailsWith<IllegalArgumentException> { module.validate() }
+    }
+
+    @Test
+    fun testIsCompatibleWith() {
+        val tempDir = createTempDirectory("vlabeler-test").toFile()
+        try {
+            val project = createOtoProject(tempDir)
+            val labeler = project.labelerConf
+            val compatible = importedModuleOf(
+                pointCount = labeler.fields.size,
+                extraCount = labeler.extraFields.size,
+                continuous = labeler.continuous,
+                extension = labeler.extension,
+            )
+
+            assertTrue(compatible.isCompatibleWith(project))
+            assertFalse(compatible.copy(pointSize = labeler.fields.size + 1).isCompatibleWith(project))
+            assertFalse(compatible.copy(extraSize = labeler.extraFields.size + 1).isCompatibleWith(project))
+            assertFalse(compatible.copy(continuous = labeler.continuous.not()).isCompatibleWith(project))
+            assertFalse(compatible.copy(extension = "txt").isCompatibleWith(project))
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    private fun createOtoProject(tempDir: File): Project {
+        val voicebank = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("voice"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        return createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = voicebank,
+            inputFilePath = voicebank.resolve("oto.ini").absolutePath,
+        )
+    }
+
+    private fun importedModuleOf(
+        pointCount: Int,
+        extraCount: Int,
+        continuous: Boolean,
+        extension: String,
+    ) = ImportedModule(
+        name = "imported",
+        entries = listOf(
+            Entry(
+                sample = "sample1",
+                name = "entry1",
+                start = 1f,
+                end = 2f,
+                points = List(pointCount) { it.toFloat() },
+                extras = List(extraCount) { "extra$it" },
+            ),
+        ),
+        pointSize = pointCount,
+        extraSize = extraCount,
+        continuous = continuous,
+        extension = extension,
+    )
+}

--- a/src/jvmTest/kotlin/io/ImportProjectEdgeCasesTest.kt
+++ b/src/jvmTest/kotlin/io/ImportProjectEdgeCasesTest.kt
@@ -172,9 +172,6 @@ class ImportProjectEdgeCasesTest {
 
     @Test
     fun testNotesAreImported() {
-        // NOTE: the backward compatibility path for the legacy "meta" field in `parseEntry` cannot be tested here:
-        // it is only reachable in packaged (non-debug) runs, because in debug runs (including tests)
-        // `json.ignoreUnknownKeys` is false and the unknown "meta" key fails the whole entry deserialization.
         val json = """
             {
                 "labelerConf": {
@@ -203,6 +200,42 @@ class ImportProjectEdgeCasesTest {
 
         assertEquals(
             EntryNotes(done = true, star = true, tag = "some-tag"),
+            actual.single().entries.single().notes,
+        )
+    }
+
+    @Test
+    fun testLegacyMetaNotesAreImported() {
+        // "meta" is the legacy name of "notes"; it is stripped before strict entry deserialization and mapped to
+        // the notes of the imported entry
+        val json = """
+            {
+                "labelerConf": {
+                    "continuous": false,
+                    "extension": "ini"
+                },
+                "entries": [
+                    {
+                        "sample": "sample1",
+                        "name": "entry1",
+                        "start": 1,
+                        "end": 2,
+                        "points": [1, 2],
+                        "extras": ["a"],
+                        "meta": {
+                            "done": true,
+                            "star": false,
+                            "tag": "legacy-tag"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val actual = importModulesFromProject(json)
+
+        assertEquals(
+            EntryNotes(done = true, star = false, tag = "legacy-tag"),
             actual.single().entries.single().notes,
         )
     }

--- a/src/jvmTest/kotlin/io/InitializationTest.kt
+++ b/src/jvmTest/kotlin/io/InitializationTest.kt
@@ -191,6 +191,24 @@ class InitializationTest {
     }
 
     @Test
+    fun testRunMigrationResetsRosettaCheckOnMinorUpdate() {
+        // an older minor version triggers the Rosetta compatibility re-check; both updates issued by runMigration
+        // are applied because AppRecordStore.update is synchronous and atomic
+        val previousRaw = "${appVersion.major}.${appVersion.minor - 1}.0"
+        val store = recordStoreOf(
+            AppRecord(
+                appVersionLastLaunchedRaw = previousRaw,
+                hasCheckedRosettaCompatibleMode = true,
+            ),
+        )
+
+        runMigration(store)
+
+        assertEquals(appVersion, store.value.appVersionLastLaunched)
+        assertFalse(store.value.hasCheckedRosettaCompatibleMode)
+    }
+
+    @Test
     fun testLoadPluginsLoadsBundledPlugins() {
         val plugins = runBlocking { loadPlugins(Language.English) }
 

--- a/src/jvmTest/kotlin/io/InitializationTest.kt
+++ b/src/jvmTest/kotlin/io/InitializationTest.kt
@@ -1,0 +1,219 @@
+package io
+
+import com.sdercolin.vlabeler.env.Locale
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.env.appVersion
+import com.sdercolin.vlabeler.io.ensureDirectories
+import com.sdercolin.vlabeler.io.initializeGlobalRepositories
+import com.sdercolin.vlabeler.io.loadAppConf
+import com.sdercolin.vlabeler.io.loadPlugins
+import com.sdercolin.vlabeler.io.runMigration
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.AppRecord
+import com.sdercolin.vlabeler.model.Plugin
+import com.sdercolin.vlabeler.repository.ColorPaletteRepository
+import com.sdercolin.vlabeler.repository.FontRepository
+import com.sdercolin.vlabeler.ui.AppRecordStore
+import com.sdercolin.vlabeler.ui.string.Language
+import com.sdercolin.vlabeler.util.AppDir
+import com.sdercolin.vlabeler.util.AppRecordFile
+import com.sdercolin.vlabeler.util.CustomAppConfFile
+import com.sdercolin.vlabeler.util.CustomLabelerDir
+import com.sdercolin.vlabeler.util.CustomPluginDir
+import com.sdercolin.vlabeler.util.DefaultAppConfFile
+import com.sdercolin.vlabeler.util.RecordDir
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the app initialization steps in `io/Initialization.kt`.
+ *
+ * These run against the application directory redirected by the `VLABELER_APP_DIR` environment variable (set to
+ * `build/test-app-dir` by the test tasks), so no real user data is touched. Files that are modified are restored in
+ * [teardown] so other tests sharing the directory are unaffected.
+ */
+class InitializationTest {
+
+    private lateinit var scope: CoroutineScope
+    private var originalAppConfText: String? = null
+    private var originalAppRecordText: String? = null
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        ensureDirectories()
+        originalAppConfText = CustomAppConfFile.takeIf { it.exists() }?.readText()
+        originalAppRecordText = AppRecordFile.takeIf { it.exists() }?.readText()
+        scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    }
+
+    @AfterTest
+    fun teardown() {
+        runBlocking {
+            val job = requireNotNull(scope.coroutineContext[Job])
+            job.cancel()
+            job.join()
+        }
+        ensureDirectories()
+        originalAppConfText?.let { CustomAppConfFile.writeText(it) } ?: CustomAppConfFile.delete()
+        originalAppRecordText?.let { AppRecordFile.writeText(it) } ?: AppRecordFile.delete()
+        Log.muted = false
+    }
+
+    private fun awaitCondition(timeoutMs: Long = 5000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(50)
+        }
+        assertTrue(condition(), "Condition not satisfied within $timeoutMs ms")
+    }
+
+    private fun recordStoreOf(appRecord: AppRecord) = AppRecordStore(appRecord, scope)
+
+    private val defaultAppConf: AppConf get() = DefaultAppConfFile.readText().parseJson()
+
+    @Test
+    fun testEnsureDirectoriesCreatesMissingDirectories() {
+        CustomPluginDir.deleteRecursively()
+        assertFalse(CustomPluginDir.exists())
+
+        ensureDirectories()
+
+        assertTrue(AppDir.isDirectory)
+        assertTrue(CustomLabelerDir.isDirectory)
+        assertTrue(CustomPluginDir.isDirectory)
+        assertTrue(RecordDir.isDirectory)
+        Plugin.Type.entries.forEach {
+            assertTrue(CustomPluginDir.resolve(it.directoryName).isDirectory)
+        }
+
+        // calling again on existing directories is a no-op
+        ensureDirectories()
+        assertTrue(CustomPluginDir.isDirectory)
+    }
+
+    @Test
+    fun testLoadAppConfWithoutCustomFileUsesDefault() {
+        CustomAppConfFile.delete()
+        val store = recordStoreOf(AppRecord(hasSavedDetectedLanguage = true))
+
+        val state = loadAppConf(scope, store)
+
+        assertEquals(defaultAppConf, state.value)
+        assertTrue(CustomAppConfFile.exists())
+        assertEquals(defaultAppConf, CustomAppConfFile.readText().parseJson())
+    }
+
+    @Test
+    fun testLoadAppConfUsesValidCustomFile() {
+        val custom = defaultAppConf.let { it.copy(view = it.view.copy(language = Language.Japanese)) }
+        CustomAppConfFile.writeText(custom.stringifyJson())
+        val store = recordStoreOf(AppRecord(hasSavedDetectedLanguage = true))
+
+        val state = loadAppConf(scope, store)
+
+        assertEquals(custom, state.value)
+    }
+
+    @Test
+    fun testLoadAppConfIgnoresInvalidCustomFile() {
+        CustomAppConfFile.writeText("{ this is not a valid app conf")
+        val store = recordStoreOf(AppRecord(hasSavedDetectedLanguage = true))
+
+        val state = loadAppConf(scope, store)
+
+        assertEquals(defaultAppConf, state.value)
+        // the invalid file is overwritten with the loaded conf
+        assertEquals(defaultAppConf, CustomAppConfFile.readText().parseJson())
+    }
+
+    @Test
+    fun testLoadAppConfDetectsLanguageOnFirstLaunch() {
+        CustomAppConfFile.delete()
+        val store = recordStoreOf(AppRecord(hasSavedDetectedLanguage = false))
+
+        val state = loadAppConf(scope, store)
+
+        val detected = Language.find(Locale.toLanguageTag())
+        if (detected != null) {
+            assertEquals(detected, state.value.view.language)
+            awaitCondition { store.value.hasSavedDetectedLanguage }
+        } else {
+            assertEquals(defaultAppConf.view.language, state.value.view.language)
+            assertFalse(store.value.hasSavedDetectedLanguage)
+        }
+    }
+
+    @Test
+    fun testLoadAppConfPersistsStateChanges() {
+        CustomAppConfFile.delete()
+        val store = recordStoreOf(AppRecord(hasSavedDetectedLanguage = true))
+        val state = loadAppConf(scope, store)
+
+        val updated = state.value.let { it.copy(view = it.view.copy(language = Language.Korean)) }
+        state.value = updated
+
+        awaitCondition {
+            runCatching { CustomAppConfFile.readText().parseJson<AppConf>() }.getOrNull() == updated
+        }
+    }
+
+    @Test
+    fun testRunMigrationUpdatesLastLaunchedVersion() {
+        // same major and minor as the current version, so the minor-version migration is not triggered
+        val previousRaw = "${appVersion.major}.${appVersion.minor}.${appVersion.patch + 1}"
+        val store = recordStoreOf(
+            AppRecord(
+                appVersionLastLaunchedRaw = previousRaw,
+                hasCheckedRosettaCompatibleMode = true,
+            ),
+        )
+
+        runMigration(store)
+
+        awaitCondition { store.value.appVersionLastLaunchedRaw == appVersion.toString() }
+        assertEquals(appVersion, store.value.appVersionLastLaunched)
+        assertTrue(store.value.hasCheckedRosettaCompatibleMode)
+    }
+
+    @Test
+    fun testLoadPluginsLoadsBundledPlugins() {
+        val plugins = runBlocking { loadPlugins(Language.English) }
+
+        val names = plugins.map { it.name }
+        assertTrue(plugins.isNotEmpty())
+        assertTrue(names.contains("cv-oto-gen"))
+        assertTrue(names.contains("batch-edit-entry-name"))
+        assertTrue(plugins.first { it.name == "cv-oto-gen" }.type == Plugin.Type.Template)
+        assertTrue(plugins.first { it.name == "batch-edit-entry-name" }.type == Plugin.Type.Macro)
+        assertTrue(plugins.first { it.name == "cv-oto-gen" }.builtIn)
+    }
+
+    @Test
+    fun testInitializeGlobalRepositories() {
+        val store = recordStoreOf(AppRecord())
+
+        initializeGlobalRepositories(store)
+
+        assertTrue(ColorPaletteRepository.directory.isDirectory)
+        assertTrue(
+            ColorPaletteRepository.directory.listFiles().orEmpty().any { it.name.endsWith(".example.json") },
+        )
+        assertTrue(FontRepository.fontDirectory.isDirectory)
+        assertTrue(FontRepository.fontDirectory.resolve("readme.txt").exists())
+    }
+}

--- a/src/jvmTest/kotlin/io/LabelerConfIoTest.kt
+++ b/src/jvmTest/kotlin/io/LabelerConfIoTest.kt
@@ -1,0 +1,159 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.asLabelerConf
+import com.sdercolin.vlabeler.io.getCustomLabelers
+import com.sdercolin.vlabeler.io.install
+import com.sdercolin.vlabeler.io.loadAvailableLabelerConfs
+import com.sdercolin.vlabeler.model.LabelerConf
+import com.sdercolin.vlabeler.util.CustomLabelerDir
+import com.sdercolin.vlabeler.util.DefaultLabelerDir
+import com.sdercolin.vlabeler.util.stringifyJson
+import kotlinx.coroutines.runBlocking
+import testutil.TestLabelers
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for `io/LabelerConf.kt`: [asLabelerConf], [install] and [loadAvailableLabelerConfs].
+ *
+ * Custom labelers are installed into the [CustomLabelerDir] under the redirected application directory
+ * (`build/test-app-dir`) and removed again in [teardown].
+ */
+class LabelerConfIoTest {
+
+    private lateinit var tempDir: File
+    private val installedCustomFiles = mutableListOf<File>()
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+        CustomLabelerDir.mkdirs()
+    }
+
+    @AfterTest
+    fun teardown() {
+        installedCustomFiles.forEach { it.deleteRecursively() }
+        installedCustomFiles.clear()
+        tempDir.deleteRecursively()
+        Log.muted = false
+    }
+
+    @Test
+    fun testAsLabelerConfParsesBuiltInLabeler() {
+        val file = DefaultLabelerDir.resolve("oto-labeler").resolve(LabelerConf.LABELER_FILE_EXTENSION)
+
+        val conf = file.asLabelerConf(isBuiltIn = true).getOrThrow()
+
+        assertEquals("oto-plus.default", conf.name)
+        assertTrue(conf.builtIn)
+        assertFalse(conf.singleFile)
+        assertEquals(file.parentFile, conf.directory)
+        // scripts are preloaded into lines
+        assertTrue(conf.parser.scripts.lines.orEmpty().isNotEmpty())
+        assertTrue(conf.quickProjectBuilders.single().scripts.lines.orEmpty().isNotEmpty())
+    }
+
+    @Test
+    fun testAsLabelerConfReturnsFailureForInvalidFile() {
+        val file = tempDir.resolve("broken.${LabelerConf.LABELER_FILE_EXTENSION}")
+        file.writeText("{ this is not a labeler conf")
+
+        assertTrue(file.asLabelerConf(isBuiltIn = false).isFailure)
+    }
+
+    @Test
+    fun testInstallDirectoryLabeler() {
+        val conf = TestLabelers.utauOto
+
+        val installedFile = conf.install(tempDir).getOrThrow()
+
+        val folder = tempDir.resolve("oto-plus-labeler")
+        assertEquals(folder.resolve(LabelerConf.LABELER_FILE_EXTENSION), installedFile)
+        assertTrue(folder.resolve("parser.js").exists())
+        assertTrue(folder.resolve("fixed-getter.js").exists())
+
+        val reloaded = installedFile.asLabelerConf(isBuiltIn = false).getOrThrow()
+        assertEquals(conf.name, reloaded.name)
+        assertEquals(conf.version, reloaded.version)
+        assertFalse(reloaded.builtIn)
+        assertEquals(
+            conf.parser.scripts.getScripts(conf.directory),
+            reloaded.parser.scripts.getScripts(reloaded.directory),
+        )
+        assertEquals(
+            conf.quickProjectBuilders.single().scripts.getScripts(conf.directory),
+            reloaded.quickProjectBuilders.single().scripts.getScripts(reloaded.directory),
+        )
+    }
+
+    @Test
+    fun testInstallSingleFileLabeler() {
+        val conf = TestLabelers.utauOto.copy(name = "zz-single-test", singleFile = true)
+
+        val installedFile = conf.install(tempDir).getOrThrow()
+
+        assertEquals(tempDir.resolve("zz-single-test.${LabelerConf.LABELER_FILE_EXTENSION}"), installedFile)
+
+        val reloaded = installedFile.asLabelerConf(isBuiltIn = false).getOrThrow()
+        assertEquals("zz-single-test", reloaded.name)
+        assertEquals(conf.version, reloaded.version)
+        assertEquals(
+            conf.parser.scripts.getScripts(conf.directory),
+            reloaded.parser.scripts.getScripts(reloaded.directory),
+        )
+    }
+
+    @Test
+    fun testLoadAvailableLabelerConfsContainsDefaultLabelers() {
+        val labelers = runBlocking { loadAvailableLabelerConfs() }
+
+        val names = labelers.map { it.name }
+        assertTrue(names.contains("oto-plus.default"))
+        assertTrue(names.contains("utau-singer.default"))
+        assertTrue(labelers.first { it.name == "oto-plus.default" }.builtIn)
+        assertEquals(names.sorted(), names)
+    }
+
+    @Test
+    fun testCustomLabelerIsLoadedAndDefaultNameIsShadowed() {
+        val custom = TestLabelers.utauOto.copy(name = "zz-custom-test", singleFile = true)
+        installedCustomFiles += custom.install(CustomLabelerDir).getOrThrow()
+        // a custom labeler with the same name as a default one is ignored, even with a higher version
+        val conflicting = TestLabelers.utauOto.copy(version = 9999, singleFile = true)
+        installedCustomFiles += conflicting.install(CustomLabelerDir).getOrThrow()
+
+        val labelers = runBlocking { loadAvailableLabelerConfs() }
+
+        val customLoaded = labelers.single { it.name == "zz-custom-test" }
+        assertFalse(customLoaded.builtIn)
+        val otoLoaded = labelers.single { it.name == "oto-plus.default" }
+        assertTrue(otoLoaded.builtIn)
+        assertEquals(TestLabelers.utauOto.version, otoLoaded.version)
+    }
+
+    @Test
+    fun testCustomLabelersWithSameNameAreDeduplicatedByVersion() {
+        val v1 = TestLabelers.utauOto.copy(name = "zz-dup-test", version = 1, singleFile = true)
+        val v2 = TestLabelers.utauOto.copy(name = "zz-dup-test", version = 2, singleFile = true)
+        val fileV1 = CustomLabelerDir.resolve("zz-dup-1.${LabelerConf.LABELER_FILE_EXTENSION}")
+        val fileV2 = CustomLabelerDir.resolve("zz-dup-2.${LabelerConf.LABELER_FILE_EXTENSION}")
+        fileV1.writeText(v1.stringifyJson())
+        fileV2.writeText(v2.stringifyJson())
+        installedCustomFiles += fileV1
+        installedCustomFiles += fileV2
+
+        assertTrue(getCustomLabelers().containsAll(listOf(fileV1, fileV2)))
+
+        val labelers = runBlocking { loadAvailableLabelerConfs() }
+
+        assertEquals(2, labelers.single { it.name == "zz-dup-test" }.version)
+    }
+}

--- a/src/jvmTest/kotlin/io/QuickEditTest.kt
+++ b/src/jvmTest/kotlin/io/QuickEditTest.kt
@@ -1,0 +1,248 @@
+package io
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.QuickEditRequest
+import com.sdercolin.vlabeler.model.LabelerConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.util.JavaScript
+import com.sdercolin.vlabeler.util.Resources
+import com.sdercolin.vlabeler.util.execResource
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import java.io.File
+import java.nio.charset.Charset
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [QuickEditRequest] construction and [QuickEditRequest.create].
+ *
+ * The request construction part drives the bundled `quickProjectBuilder` scripts of the labelers in the same way as
+ * `startQuickEdit`, without the [com.sdercolin.vlabeler.ui.AppState] dependency.
+ */
+class QuickEditTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setup() {
+        Log.muted = true
+        TestEnv.ensureLogDirectory()
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+        tempDir.deleteRecursively()
+    }
+
+    /**
+     * Runs the labeler's quick project builder script against [file], mirroring the script execution part of
+     * `startQuickEdit` in `io/QuickEdit.kt`.
+     */
+    private fun buildRequestViaScript(labelerConf: LabelerConf, file: File): QuickEditRequest {
+        val builder = labelerConf.quickProjectBuilders.single()
+        val js = JavaScript()
+        listOf(
+            Resources.envJs,
+            Resources.fileJs,
+            Resources.expectedErrorJs,
+        ).forEach { js.execResource(it) }
+        js.set("debug", false)
+        js.set("input", file)
+        js.eval("input = new File(input)")
+        val savedParams = runBlocking { labelerConf.loadSavedParamsJson(labelerConf.getSavedParamsFile()) }
+        js.set("savedParams", savedParams)
+        js.eval("savedParams = JSON.parse(savedParams)")
+        js.eval(builder.scripts.getScripts(labelerConf.directory))
+        js.eval("projectFile = projectFile.getAbsolutePath()")
+        js.eval("sampleDirectory = sampleDirectory.getAbsolutePath()")
+        if (js.hasValue("cacheDirectory")) {
+            js.eval("cacheDirectory = cacheDirectory.getAbsolutePath()")
+        }
+        if (!js.hasValue("params")) {
+            js.eval("params = savedParams")
+        }
+        js.eval("params = JSON.stringify(params)")
+        val request = QuickEditRequest(
+            labelerConf = labelerConf,
+            builder = builder,
+            projectFile = js.get("projectFile"),
+            sampleDirectory = js.get("sampleDirectory"),
+            cacheDirectory = js.getOrNull("cacheDirectory"),
+            inputFile = file.absolutePath,
+            params = labelerConf.parseParamMap(js.get("params")),
+            encoding = js.getOrNull("encoding"),
+        )
+        js.close()
+        return request
+    }
+
+    private fun deployOtoVoicebank(): File = TestFixtures.deploy(
+        "oto",
+        tempDir.resolve("voice"),
+        wavFiles = listOf("_a_ka.wav"),
+    )
+
+    private fun otoRequest(
+        projectFile: String,
+        sampleDirectory: String,
+        cacheDirectory: String? = null,
+        inputFile: String? = null,
+        encoding: String? = null,
+    ): QuickEditRequest {
+        val labeler = TestLabelers.utauOto
+        return QuickEditRequest(
+            labelerConf = labeler,
+            builder = labeler.quickProjectBuilders.single(),
+            projectFile = projectFile,
+            sampleDirectory = sampleDirectory,
+            cacheDirectory = cacheDirectory,
+            inputFile = inputFile,
+            params = labeler.getDefaultParams(),
+            encoding = encoding,
+        )
+    }
+
+    private fun QuickEditRequest.createProject(): Project = runBlocking { create() }.getOrThrow()
+
+    @Test
+    fun testOtoBuilderScriptCreatesProject() {
+        val voicebank = deployOtoVoicebank()
+        val otoFile = voicebank.resolve("oto.ini")
+
+        val request = buildRequestViaScript(TestLabelers.utauOto, otoFile)
+
+        assertEquals(voicebank.resolve("voice_oto_quickedit.lbp").absolutePath, request.projectFile)
+        assertEquals(voicebank.absolutePath, request.sampleDirectory)
+        assertNull(request.cacheDirectory)
+        assertEquals("Shift-JIS", request.encoding)
+        assertEquals(otoFile.absolutePath, request.inputFile)
+        assertEquals(true, request.params["useNegativeOvl"])
+
+        val project = request.createProject()
+        assertEquals("voice_oto_quickedit", project.projectName)
+        assertEquals("Shift-JIS", project.encoding)
+        assertTrue(project.autoExport)
+        assertTrue(project.isUsingDefaultCacheDirectory)
+        assertEquals(voicebank.resolve("voice_oto_quickedit.lbp").absolutePath, project.projectFile.absolutePath)
+        assertEquals(1, project.modules.size)
+        assertEquals(listOf("- a", "a ka"), project.modules.single().entries.map { it.name })
+        assertEquals(listOf("_a_ka.wav", "_a_ka.wav"), project.modules.single().entries.map { it.sample })
+    }
+
+    @Test
+    fun testUtauSingerBuilderScriptCreatesMultiModuleProject() {
+        val singer = TestFixtures.deploy(
+            "utau-singer",
+            tempDir.resolve("singer"),
+            wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+        )
+
+        val request = buildRequestViaScript(TestLabelers.utauSinger, singer)
+
+        assertEquals(singer.resolve("singer_quickedit.lbp").absolutePath, request.projectFile)
+        assertEquals(singer.absolutePath, request.sampleDirectory)
+        assertNull(request.cacheDirectory)
+        assertEquals("Shift-JIS", request.encoding)
+
+        val project = request.createProject()
+        assertEquals("singer_quickedit", project.projectName)
+        assertTrue(project.autoExport)
+        assertEquals(setOf("A3", "C4"), project.modules.map { it.name }.toSet())
+        assertEquals(2, project.modules.first { it.name == "A3" }.entries.size)
+        assertEquals(4, project.modules.first { it.name == "C4" }.entries.size)
+    }
+
+    @Test
+    fun testCreateWithExplicitCacheDirectory() {
+        val voicebank = deployOtoVoicebank()
+        val cacheDirectory = tempDir.resolve("custom-caches")
+
+        val project = otoRequest(
+            projectFile = voicebank.resolve("project.lbp").absolutePath,
+            sampleDirectory = voicebank.absolutePath,
+            cacheDirectory = cacheDirectory.absolutePath,
+            inputFile = voicebank.resolve("oto.ini").absolutePath,
+            encoding = "Shift-JIS",
+        ).createProject()
+
+        assertEquals(cacheDirectory.absolutePath, project.cacheDirectory.absolutePath)
+        assertEquals(false, project.isUsingDefaultCacheDirectory)
+    }
+
+    @Test
+    fun testCreateWithNullEncodingUsesDefaultCharset() {
+        val voicebank = deployOtoVoicebank()
+
+        val project = otoRequest(
+            projectFile = voicebank.resolve("project.lbp").absolutePath,
+            sampleDirectory = voicebank.absolutePath,
+            inputFile = voicebank.resolve("oto.ini").absolutePath,
+            encoding = null,
+        ).createProject()
+
+        assertEquals(Charset.defaultCharset().name(), project.encoding)
+    }
+
+    @Test
+    fun testCreateWithUnknownEncodingFallsBackToDefaultCharset() {
+        val voicebank = deployOtoVoicebank()
+
+        val project = otoRequest(
+            projectFile = voicebank.resolve("project.lbp").absolutePath,
+            sampleDirectory = voicebank.absolutePath,
+            inputFile = voicebank.resolve("oto.ini").absolutePath,
+            encoding = "x-no-such-encoding",
+        ).createProject()
+
+        assertEquals(Charset.defaultCharset().name(), project.encoding)
+    }
+
+    @Test
+    fun testCreateFailsWhenWorkingDirectoryDoesNotExist() {
+        val voicebank = deployOtoVoicebank()
+
+        val request = otoRequest(
+            projectFile = tempDir.resolve("missing").resolve("project.lbp").absolutePath,
+            sampleDirectory = voicebank.absolutePath,
+        )
+
+        val t = assertFailsWith<IllegalArgumentException> { runBlocking { request.create() } }
+        assertTrue(requireNotNull(t.message).startsWith("Working directory"))
+    }
+
+    @Test
+    fun testCreateFailsWhenSampleDirectoryDoesNotExist() {
+        val request = otoRequest(
+            projectFile = tempDir.resolve("project.lbp").absolutePath,
+            sampleDirectory = tempDir.resolve("missing").absolutePath,
+        )
+
+        val t = assertFailsWith<IllegalArgumentException> { runBlocking { request.create() } }
+        assertTrue(requireNotNull(t.message).startsWith("Sample directory"))
+    }
+
+    @Test
+    fun testCreateFailsWhenCacheDirectoryParentDoesNotExist() {
+        val voicebank = deployOtoVoicebank()
+
+        val request = otoRequest(
+            projectFile = voicebank.resolve("project.lbp").absolutePath,
+            sampleDirectory = voicebank.absolutePath,
+            cacheDirectory = tempDir.resolve("missing").resolve("caches").absolutePath,
+        )
+
+        val t = assertFailsWith<IllegalArgumentException> { runBlocking { request.create() } }
+        assertTrue(requireNotNull(t.message).contains("does not exist"))
+    }
+}

--- a/src/jvmTest/kotlin/ui/CustomizableItemManagerTest.kt
+++ b/src/jvmTest/kotlin/ui/CustomizableItemManagerTest.kt
@@ -1,0 +1,581 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.exception.CustomizableItemLoadingException
+import com.sdercolin.vlabeler.io.getCustomLabelers
+import com.sdercolin.vlabeler.io.install
+import com.sdercolin.vlabeler.io.loadAvailableLabelerConfs
+import com.sdercolin.vlabeler.io.loadPlugins
+import com.sdercolin.vlabeler.model.AppRecord
+import com.sdercolin.vlabeler.model.Plugin
+import com.sdercolin.vlabeler.ui.AppRecordStore
+import com.sdercolin.vlabeler.ui.AppState
+import com.sdercolin.vlabeler.ui.dialog.customization.CustomizableItem
+import com.sdercolin.vlabeler.ui.dialog.customization.CustomizableItemManagerDialogState
+import com.sdercolin.vlabeler.ui.dialog.customization.LabelerItem
+import com.sdercolin.vlabeler.ui.dialog.customization.LabelerManagerDialogState
+import com.sdercolin.vlabeler.ui.dialog.customization.MacroPluginItem
+import com.sdercolin.vlabeler.ui.dialog.customization.MacroPluginManagerDialogState
+import com.sdercolin.vlabeler.ui.dialog.customization.TemplatePluginItem
+import com.sdercolin.vlabeler.ui.dialog.customization.TemplatePluginManagerDialogState
+import com.sdercolin.vlabeler.ui.string.Language
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.ui.string.toLocalized
+import com.sdercolin.vlabeler.util.CustomLabelerDir
+import com.sdercolin.vlabeler.util.CustomPluginDir
+import com.sdercolin.vlabeler.util.DefaultPluginDir
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import testutil.TestEnv
+import testutil.TestLabelers
+import java.io.File
+import java.lang.reflect.InvocationTargetException
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Tests for [CustomizableItem], [CustomizableItemManagerDialogState] and its subclasses.
+ *
+ * The custom item directories ([CustomLabelerDir], [CustomPluginDir]) and the app record file live under
+ * `build/test-app-dir` because the test task sets the `VLABELER_APP_DIR` environment variable, so installing and
+ * removing custom items never touches the real application directory. Everything installed by a test is removed in
+ * [teardown].
+ *
+ * The dialog states only receive an [AppState] but never dereference it on the paths exercised here (it is only
+ * touched by `reload`/error/finish paths, see the notes on the individual tests), so an uninitialized instance
+ * allocated without running the constructor is passed, following the pattern proven safe in [ProjectCreatorStateTest].
+ * `importNewItem` is invoked directly (it is protected, so via reflection or a test subclass) instead of through
+ * `handleFileSelectorResult`, because the latter always ends in `reload()`, which needs a real [AppState].
+ */
+class CustomizableItemManagerTest {
+
+    private lateinit var storeScope: CoroutineScope
+    private val tempDirs = mutableListOf<File>()
+    private val installedFiles = mutableListOf<File>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        storeScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @AfterTest
+    fun teardown() {
+        storeScope.cancel()
+        tempDirs.forEach { it.deleteRecursively() }
+        tempDirs.clear()
+        installedFiles.forEach { it.deleteRecursively() }
+        installedFiles.clear()
+        Log.muted = false
+    }
+
+    private fun newTempDir(): File = createTempDirectory("vlabeler-test").toFile().also { tempDirs += it }
+
+    private fun uninitializedAppState(): AppState {
+        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(AppState::class.java) as AppState
+    }
+
+    private fun cancelledScope(): CoroutineScope = CoroutineScope(Job().apply { cancel() })
+
+    private fun recordStore(record: AppRecord = AppRecord(), live: Boolean = false): AppRecordStore =
+        AppRecordStore(record, if (live) storeScope else cancelledScope())
+
+    private fun awaitRecord(store: AppRecordStore, predicate: (AppRecord) -> Boolean) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate(store.value)) return
+            Thread.sleep(10)
+        }
+        fail("The app record was not updated in time")
+    }
+
+    /**
+     * Invokes the protected `importNewItem` of [state] directly. The implementations have no suspension points, so
+     * the reflective call returns the result synchronously.
+     */
+    private fun importItem(state: CustomizableItemManagerDialogState<*>, configFile: File): String {
+        val method = generateSequence<Class<*>>(state.javaClass) { it.superclass }
+            .mapNotNull { cls ->
+                cls.declaredMethods.firstOrNull { it.name == "importNewItem" && it.parameterCount == 2 }
+            }
+            .first()
+        method.isAccessible = true
+        val continuation = object : Continuation<Any?> {
+            override val context: CoroutineContext = EmptyCoroutineContext
+            override fun resumeWith(result: Result<Any?>) = Unit
+        }
+        val result = try {
+            method.invoke(state, configFile, continuation)
+        } catch (e: InvocationTargetException) {
+            throw requireNotNull(e.targetException)
+        }
+        check(result !== COROUTINE_SUSPENDED) { "importNewItem unexpectedly suspended" }
+        return result as String
+    }
+
+    /* region test doubles */
+
+    private class TestItem(
+        name: String,
+        rootFile: File,
+        canRemove: Boolean = true,
+        disabled: Boolean = false,
+        email: String = "",
+        website: String = "",
+        private val executable: Boolean = false,
+    ) : CustomizableItem(
+        name = name,
+        author = "author",
+        version = 1,
+        displayedName = name.toLocalized(),
+        description = "".toLocalized(),
+        email = email,
+        website = website,
+        rootFile = rootFile,
+        canRemove = canRemove,
+        disabled = disabled,
+    ) {
+        var executed: Int = 0
+
+        override fun canExecute(): Boolean = executable
+
+        override fun execute() {
+            executed++
+        }
+    }
+
+    private class TestManagerState(
+        appState: AppState,
+        appRecordStore: AppRecordStore,
+        directory: File,
+        allowExecution: Boolean = true,
+    ) : CustomizableItemManagerDialogState<TestItem>(
+        title = Strings.LabelerManagerTitle,
+        importDialogTitle = Strings.LabelerManagerImportDialogTitle,
+        definitionFileExtension = "json",
+        directory = directory,
+        allowExecution = allowExecution,
+        appState = appState,
+        appRecordStore = appRecordStore,
+    ) {
+        var reloadCount: Int = 0
+        val savedDisabled = mutableListOf<Pair<String, Boolean>>()
+        val imported = mutableListOf<File>()
+
+        override fun reload() {
+            reloadCount++
+        }
+
+        override fun saveDisabled(index: Int) {
+            savedDisabled += items[index].name to items[index].disabled
+        }
+
+        override suspend fun importNewItem(configFile: File): String {
+            imported += configFile
+            return configFile.nameWithoutExtension
+        }
+    }
+
+    private fun createTestManager(allowExecution: Boolean = true): TestManagerState = TestManagerState(
+        appState = uninitializedAppState(),
+        appRecordStore = recordStore(),
+        directory = newTempDir(),
+        allowExecution = allowExecution,
+    )
+
+    private fun testItem(
+        name: String,
+        canRemove: Boolean = true,
+        disabled: Boolean = false,
+        executable: Boolean = false,
+    ): TestItem = TestItem(
+        name = name,
+        rootFile = newTempDir().resolve("$name.json").apply { writeText("{}") },
+        canRemove = canRemove,
+        disabled = disabled,
+        executable = executable,
+    )
+
+    /* endregion */
+
+    /* region CustomizableItem */
+
+    @Test
+    fun `customizable item exposes email and website availability`() {
+        val plain = testItem("plain")
+        assertFalse(plain.hasEmail())
+        assertFalse(plain.hasWebsite())
+        assertFalse(plain.canExecute())
+
+        val rich = TestItem(
+            name = "rich",
+            rootFile = newTempDir().resolve("rich.json").apply { writeText("{}") },
+            email = "someone@example.com",
+            website = "https://example.com",
+        )
+        assertTrue(rich.hasEmail())
+        assertTrue(rich.hasWebsite())
+    }
+
+    @Test
+    fun `toggle disabled flips the state`() {
+        val item = testItem("item")
+        assertFalse(item.disabled)
+        item.toggleDisabled()
+        assertTrue(item.disabled)
+        item.toggleDisabled()
+        assertFalse(item.disabled)
+    }
+
+    @Test
+    fun `remove deletes the root file recursively`() {
+        val root = newTempDir().resolve("item").apply { mkdirs() }
+        root.resolve("content.txt").writeText("content")
+        val item = TestItem(name = "item", rootFile = root)
+
+        assertTrue(item.remove())
+
+        assertFalse(root.exists())
+    }
+
+    /* endregion */
+
+    /* region CustomizableItemManagerDialogState */
+
+    @Test
+    fun `load items keeps the order on first load and moves new items to the bottom`() {
+        val state = createTestManager()
+        val a = testItem("a")
+        val b = testItem("b")
+        val c = testItem("c")
+        state.loadItems(listOf(a, b, c))
+        assertEquals(listOf("a", "b", "c"), state.items.map { it.name })
+        assertNull(state.selectedIndex)
+
+        val new = testItem("new")
+        state.loadItems(listOf(a, new, b, c))
+
+        assertEquals(listOf("a", "b", "c", "new"), state.items.map { it.name })
+        assertEquals(3, state.selectedIndex)
+        assertEquals(new, state.selectedItem)
+    }
+
+    @Test
+    fun `select and cancel selection`() {
+        val state = createTestManager()
+        state.loadItems(listOf(testItem("a"), testItem("b", canRemove = false)))
+        assertNull(state.selectedItem)
+        assertFalse(state.canRemoveCurrentItem())
+
+        state.selectItem(0)
+        assertEquals("a", state.selectedItem?.name)
+        assertTrue(state.canRemoveCurrentItem())
+
+        state.selectItem(1)
+        assertEquals("b", state.selectedItem?.name)
+        assertFalse(state.canRemoveCurrentItem())
+
+        state.cancelSelection()
+        assertNull(state.selectedIndex)
+        assertNull(state.selectedItem)
+    }
+
+    @Test
+    fun `toggle item disabled flips the item and saves it`() {
+        val state = createTestManager()
+        state.loadItems(listOf(testItem("a"), testItem("b")))
+
+        state.toggleItemDisabled(1)
+        assertTrue(state.items[1].disabled)
+        state.toggleItemDisabled(1)
+        assertFalse(state.items[1].disabled)
+
+        assertEquals(listOf("b" to true, "b" to false), state.savedDisabled)
+    }
+
+    @Test
+    fun `remove item deletes its files clears the selection and reloads`() {
+        val state = createTestManager()
+        val item = testItem("a")
+        state.loadItems(listOf(item))
+        state.selectItem(0)
+
+        state.removeItem(item)
+
+        assertFalse(item.rootFile.exists())
+        assertNull(state.selectedIndex)
+        assertEquals(1, state.reloadCount)
+    }
+
+    @Test
+    fun `remove item requires a removable item in the list`() {
+        val state = createTestManager()
+        val fixed = testItem("fixed", canRemove = false)
+        state.loadItems(listOf(fixed))
+        assertFailsWith<IllegalArgumentException> { state.removeItem(fixed) }
+
+        val notInList = testItem("other")
+        assertFailsWith<IllegalArgumentException> { state.removeItem(notInList) }
+    }
+
+    @Test
+    fun `execution is gated by the dialog and the item`() {
+        val state = createTestManager(allowExecution = true)
+        val executable = testItem("executable", executable = true)
+        state.loadItems(listOf(executable, testItem("plain")))
+        assertFalse(state.canExecuteSelectedItem())
+
+        state.selectItem(0)
+        assertTrue(state.canExecuteSelectedItem())
+        state.executeSelectedItem()
+        assertEquals(1, executable.executed)
+
+        state.selectItem(1)
+        assertFalse(state.canExecuteSelectedItem())
+        assertFailsWith<IllegalArgumentException> { state.executeSelectedItem() }
+
+        val noExecutionState = createTestManager(allowExecution = false)
+        val item = testItem("executable", executable = true)
+        noExecutionState.loadItems(listOf(item))
+        noExecutionState.selectItem(0)
+        assertFalse(noExecutionState.canExecuteSelectedItem())
+    }
+
+    @Test
+    fun `file selector flow imports the selected file and reloads`() {
+        val state = createTestManager()
+        assertFalse(state.isShowingFileSelector)
+
+        state.openFileSelectorForNewItem()
+        assertTrue(state.isShowingFileSelector)
+
+        runBlocking { state.handleFileSelectorResult(null) }
+        assertFalse(state.isShowingFileSelector)
+        assertEquals(emptyList(), state.imported)
+        assertEquals(0, state.reloadCount)
+
+        val file = newTempDir().resolve("new-item.json").apply { writeText("{}") }
+        state.openFileSelectorForNewItem()
+        runBlocking { state.handleFileSelectorResult(file) }
+        assertFalse(state.isShowingFileSelector)
+        assertEquals(listOf(file), state.imported)
+        assertEquals(1, state.reloadCount)
+    }
+
+    /* endregion */
+
+    /* region LabelerManagerDialogState */
+
+    @Test
+    fun `labeler manager configuration`() {
+        val state = LabelerManagerDialogState(uninitializedAppState(), recordStore())
+        assertEquals(Strings.LabelerManagerTitle, state.title)
+        assertEquals(Strings.LabelerManagerImportDialogTitle, state.importDialogTitle)
+        assertEquals("labeler.json", state.definitionFileExtension)
+        assertEquals(CustomLabelerDir, state.directory)
+        assertFalse(state.allowExecution)
+    }
+
+    @Test
+    fun `labeler items map the labeler conf`() {
+        val labeler = TestLabelers.utauOto
+        val item = LabelerItem(labeler, disabled = false)
+        assertEquals(labeler.name, item.name)
+        assertEquals(labeler.author, item.author)
+        assertEquals(labeler.version, item.version)
+        assertEquals(labeler.rootFile, item.rootFile)
+        // built-in labelers cannot be removed
+        assertFalse(item.canRemove)
+        assertFalse(item.canExecute())
+    }
+
+    @Test
+    fun `import installs a custom labeler and remove uninstalls it`() {
+        val name = "test-custom-oto"
+        val renamed = TestLabelers.utauOto.copy(name = name)
+        val stagedFile = renamed.install(newTempDir()).getOrThrow()
+        val installTarget = CustomLabelerDir.resolve(stagedFile.parentFile.name).also { installedFiles += it }
+        CustomLabelerDir.mkdirs()
+        val state = LabelerManagerDialogState(uninitializedAppState(), recordStore())
+
+        val importedName = importItem(state, stagedFile)
+
+        assertEquals(name, importedName)
+        assertTrue(installTarget.resolve("labeler.json").isFile)
+
+        // the labeler is listed among the available labelers as a custom (removable) one
+        val available = runBlocking { loadAvailableLabelerConfs() }
+        val installed = available.first { it.name == name }
+        assertFalse(installed.builtIn)
+        val item = LabelerItem(installed, disabled = false)
+        assertTrue(item.canRemove)
+        assertEquals(installTarget, item.rootFile)
+
+        // removing the item deletes it from the custom directory
+        assertTrue(item.remove())
+        assertFalse(installTarget.exists())
+        assertTrue(getCustomLabelers().none { it.parentFile == installTarget })
+        assertTrue(runBlocking { loadAvailableLabelerConfs() }.none { it.name == name })
+    }
+
+    @Test
+    fun `labeler import fails with a loading exception on an invalid file`() {
+        val state = LabelerManagerDialogState(uninitializedAppState(), recordStore())
+        val invalidFile = newTempDir().resolve("invalid.labeler.json").apply { writeText("not a labeler") }
+
+        assertFailsWith<CustomizableItemLoadingException> { importItem(state, invalidFile) }
+    }
+
+    @Test
+    fun `toggling a labeler saves its disabled state to the app record`() {
+        val store = recordStore(live = true)
+        val state = LabelerManagerDialogState(uninitializedAppState(), store)
+        val labeler = TestLabelers.utauOto
+        state.loadItems(listOf(LabelerItem(labeler, disabled = false)))
+
+        state.toggleItemDisabled(0)
+        assertTrue(state.items[0].disabled)
+        awaitRecord(store) { labeler.name in it.disabledLabelerNames }
+
+        state.toggleItemDisabled(0)
+        assertFalse(state.items[0].disabled)
+        awaitRecord(store) { labeler.name !in it.disabledLabelerNames }
+    }
+
+    /* endregion */
+
+    /* region PluginManagerDialogState */
+
+    @Test
+    fun `plugin manager configurations`() {
+        val macroState = MacroPluginManagerDialogState(uninitializedAppState(), recordStore())
+        assertEquals(Strings.MacroPluginManagerTitle, macroState.title)
+        assertEquals(Strings.MacroPluginManagerImportDialogTitle, macroState.importDialogTitle)
+        assertEquals("json", macroState.definitionFileExtension)
+        assertEquals(CustomPluginDir.resolve("macro"), macroState.directory)
+        assertTrue(macroState.allowExecution)
+
+        val templateState = TemplatePluginManagerDialogState(uninitializedAppState(), recordStore())
+        assertEquals(Strings.TemplatePluginManagerTitle, templateState.title)
+        assertEquals(Strings.TemplatePluginManagerImportDialogTitle, templateState.importDialogTitle)
+        assertEquals(CustomPluginDir.resolve("template"), templateState.directory)
+        assertFalse(templateState.allowExecution)
+    }
+
+    @Test
+    fun `plugin items map the plugin`() {
+        val macroPlugin = loadPlugins(Plugin.Type.Macro, Language.English).first { it.builtIn }
+        val macroItem = MacroPluginItem(macroPlugin, uninitializedAppState(), disabled = false)
+        assertEquals(macroPlugin.name, macroItem.name)
+        assertEquals(macroPlugin.directory, macroItem.rootFile)
+        assertFalse(macroItem.canRemove)
+
+        val templatePlugin = loadPlugins(Plugin.Type.Template, Language.English).first { it.builtIn }
+        val templateItem = TemplatePluginItem(templatePlugin, disabled = true)
+        assertEquals(templatePlugin.name, templateItem.name)
+        assertEquals(templatePlugin.directory, templateItem.rootFile)
+        assertFalse(templateItem.canRemove)
+        assertTrue(templateItem.disabled)
+        assertFalse(templateItem.canExecute())
+    }
+
+    @Test
+    fun `import installs a custom macro plugin and remove uninstalls it`() {
+        val name = "test-custom-macro"
+        val stagedConfig = stageRenamedPlugin("batch-remove-entry", Plugin.Type.Macro, name)
+        val installTarget = CustomPluginDir.resolve("macro").resolve(name).also { installedFiles += it }
+        val state = MacroPluginManagerDialogState(uninitializedAppState(), recordStore())
+
+        val importedName = importItem(state, stagedConfig)
+
+        assertEquals(name, importedName)
+        assertTrue(installTarget.resolve("plugin.json").isFile)
+
+        // the plugin is listed as a custom (removable) one
+        val installed = loadPlugins(Plugin.Type.Macro, Language.English).first { it.name == name }
+        assertFalse(installed.builtIn)
+        val item = MacroPluginItem(installed, uninitializedAppState(), disabled = false)
+        assertTrue(item.canRemove)
+        assertEquals(installTarget, item.rootFile)
+
+        assertTrue(item.remove())
+        assertFalse(installTarget.exists())
+        assertTrue(loadPlugins(Plugin.Type.Macro, Language.English).none { it.name == name })
+    }
+
+    @Test
+    fun `plugin import rejects a plugin of the wrong type`() {
+        val templateConfig = DefaultPluginDir.resolve("template").resolve("cv-oto-gen").resolve("plugin.json")
+        assertTrue(templateConfig.isFile)
+        val state = MacroPluginManagerDialogState(uninitializedAppState(), recordStore())
+
+        assertFailsWith<CustomizableItemLoadingException> { importItem(state, templateConfig) }
+
+        assertFalse(CustomPluginDir.resolve("macro").resolve("cv-oto-gen").exists())
+    }
+
+    @Test
+    fun `plugin import fails with a loading exception on an invalid file`() {
+        val state = TemplatePluginManagerDialogState(uninitializedAppState(), recordStore())
+        val invalidFile = newTempDir().resolve("plugin.json").apply { writeText("not a plugin") }
+
+        assertFailsWith<CustomizableItemLoadingException> { importItem(state, invalidFile) }
+    }
+
+    @Test
+    fun `toggling a plugin saves its disabled state to the app record`() {
+        val store = recordStore(live = true)
+        val state = TemplatePluginManagerDialogState(uninitializedAppState(), store)
+        val plugin = loadPlugins(Plugin.Type.Template, Language.English).first { it.builtIn }
+        state.loadItems(listOf(TemplatePluginItem(plugin, disabled = false)))
+
+        state.toggleItemDisabled(0)
+        assertTrue(state.items[0].disabled)
+        awaitRecord(store) { plugin.name in it.disabledPluginNames }
+
+        state.toggleItemDisabled(0)
+        assertFalse(state.items[0].disabled)
+        awaitRecord(store) { plugin.name !in it.disabledPluginNames }
+    }
+
+    /* endregion */
+
+    /**
+     * Copies the bundled plugin [sourceName] of [type] to a temporary directory and renames it to [newName], so that
+     * installing it does not shadow the bundled plugin.
+     */
+    private fun stageRenamedPlugin(sourceName: String, type: Plugin.Type, newName: String): File {
+        val source = DefaultPluginDir.resolve(type.directoryName).resolve(sourceName)
+        val target = newTempDir().resolve(newName)
+        source.copyRecursively(target)
+        val configFile = target.resolve("plugin.json")
+        val jsonObject = Json.parseToJsonElement(configFile.readText()).jsonObject
+        val edited = JsonObject(jsonObject.toMutableMap().apply { put("name", JsonPrimitive(newName)) })
+        configFile.writeText(edited.toString())
+        return configFile
+    }
+}

--- a/src/jvmTest/kotlin/ui/EntrySelectorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/EntrySelectorStateTest.kt
@@ -1,0 +1,368 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.Entry
+import com.sdercolin.vlabeler.model.EntryNotes
+import com.sdercolin.vlabeler.model.EntrySelector
+import com.sdercolin.vlabeler.model.LogicalExpression
+import com.sdercolin.vlabeler.util.JavaScript
+import testutil.TestEnv
+import testutil.TestLabelers
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the non-composable logic behind the entry selector UI
+ * ([com.sdercolin.vlabeler.ui.dialog.plugin.ParamEntrySelector]): the [LogicalExpression] parsing used to validate the
+ * expression input, and the [EntrySelector] filter/selection model used to compute the preview summary.
+ *
+ * The `oto-plus.default` labeler ([TestLabelers.utauOto]) is used for property based filters. Its `points` are
+ * `[fixed, preu, ovl, left]` and its properties are computed as `left = points[3]`, `ovl = points[2] - points[3]` and
+ * `preu = points[1] - points[3]`.
+ */
+class EntrySelectorStateTest {
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private fun <T> withJs(block: (JavaScript) -> T): T = JavaScript(System.out).use(block)
+
+    private fun entry(
+        name: String,
+        sample: String = "$name.wav",
+        points: List<Float> = listOf(300f, 250f, 150f, 100f),
+        done: Boolean = false,
+        star: Boolean = false,
+        tag: String = "",
+    ) = Entry(
+        sample = sample,
+        name = name,
+        start = 0f,
+        end = 1000f,
+        points = points,
+        extras = listOf("500"),
+        notes = EntryNotes(done = done, star = star, tag = tag),
+    )
+
+    /* region LogicalExpression */
+
+    @Test
+    fun `logical expression parses placeholders and operators`() {
+        val and = LogicalExpression.parse("#1 and #2").getOrThrow()
+        assertEquals(2, and.requiredPlaceholderCount)
+        assertTrue(and.evaluate(listOf(true, true)))
+        assertFalse(and.evaluate(listOf(true, false)))
+
+        val or = LogicalExpression.parse("#1 || #2").getOrThrow()
+        assertTrue(or.evaluate(listOf(false, true)))
+        assertFalse(or.evaluate(listOf(false, false)))
+
+        val xor = LogicalExpression.parse("#1 xor #2").getOrThrow()
+        assertTrue(xor.evaluate(listOf(true, false)))
+        assertFalse(xor.evaluate(listOf(true, true)))
+
+        val not = LogicalExpression.parse("not #1").getOrThrow()
+        assertEquals(1, not.requiredPlaceholderCount)
+        assertTrue(not.evaluate(listOf(false)))
+        assertFalse(not.evaluate(listOf(true)))
+
+        val uppercase = LogicalExpression.parse("#1 AND #2").getOrThrow()
+        assertTrue(uppercase.evaluate(listOf(true, true)))
+    }
+
+    @Test
+    fun `logical expression supports parentheses and left associativity`() {
+        val nested = LogicalExpression.parse("#1 or (#2 and not #3)").getOrThrow()
+        assertEquals(3, nested.requiredPlaceholderCount)
+        assertTrue(nested.evaluate(listOf(true, false, true)))
+        assertTrue(nested.evaluate(listOf(false, true, false)))
+        assertFalse(nested.evaluate(listOf(false, true, true)))
+
+        // without parentheses the expression is evaluated left to right: ((#1 and #2) or #3)
+        val leftAssociative = LogicalExpression.parse("#1 and #2 or #3").getOrThrow()
+        assertTrue(leftAssociative.evaluate(listOf(false, false, true)))
+        assertTrue(leftAssociative.evaluate(listOf(true, true, false)))
+        assertFalse(leftAssociative.evaluate(listOf(true, false, false)))
+
+        val notFirst = LogicalExpression.parse("not #1 and #2").getOrThrow()
+        assertTrue(notFirst.evaluate(listOf(false, true)))
+        assertFalse(notFirst.evaluate(listOf(true, true)))
+    }
+
+    @Test
+    fun `logical expression placeholder count is based on the maximum index`() {
+        val expression = LogicalExpression.parse("#3").getOrThrow()
+        assertEquals(3, expression.requiredPlaceholderCount)
+        assertTrue(expression.evaluate(listOf(false, false, true)))
+    }
+
+    @Test
+    fun `logical expression rejects malformed input`() {
+        listOf(
+            "",
+            "#0",
+            "#1 and",
+            "#1 #2",
+            "(#1",
+            "()",
+            "foo",
+            "and #1",
+        ).forEach { expression ->
+            assertTrue(
+                LogicalExpression.parse(expression).isFailure,
+                "expected \"$expression\" to fail parsing",
+            )
+        }
+    }
+
+    @Test
+    fun `default logical expression combines all placeholders with and`() {
+        val default = LogicalExpression.parse("#1 and #2 and #3").getOrThrow()
+        val built = LogicalExpression.default(3)
+        assertEquals(3, built?.requiredPlaceholderCount)
+        listOf(
+            listOf(true, true, true),
+            listOf(true, false, true),
+            listOf(false, false, false),
+        ).forEach { values ->
+            assertEquals(default.evaluate(values), built?.evaluate(values))
+        }
+        assertNull(LogicalExpression.default(0))
+    }
+
+    /* endregion */
+
+    /* region EntrySelector validity */
+
+    @Test
+    fun `selector validity checks the expression against the filter count`() {
+        val labeler = TestLabelers.utauOto
+        val filter = EntrySelector.TextFilterItem("name", EntrySelector.TextMatchType.Contains, "a")
+        assertTrue(EntrySelector(listOf(filter), "#1").isValid(labeler))
+        assertFalse(EntrySelector(listOf(filter), "#1 and #2").isValid(labeler))
+        assertTrue(EntrySelector(listOf(filter, filter), "#1 and #2").isValid(labeler))
+        assertFalse(EntrySelector(listOf(filter), "#1 and").isValid(labeler))
+        assertTrue(EntrySelector(emptyList()).isValid(labeler))
+        assertTrue(EntrySelector(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `text filter validity checks subject match type and matcher`() {
+        val labeler = TestLabelers.utauOto
+        fun filter(subject: String, matchType: EntrySelector.TextMatchType, text: String) =
+            EntrySelector.TextFilterItem(subject, matchType, text)
+
+        assertTrue(filter("name", EntrySelector.TextMatchType.Equals, "a").isValid(labeler))
+        assertTrue(filter("sample", EntrySelector.TextMatchType.Contains, "a").isValid(labeler))
+        assertTrue(filter("tag", EntrySelector.TextMatchType.Regex, "a+").isValid(labeler))
+        assertFalse(filter("unknown", EntrySelector.TextMatchType.Equals, "a").isValid(labeler))
+        assertFalse(filter("name", EntrySelector.TextMatchType.Equals, "").isValid(labeler))
+        assertFalse(filter("name", EntrySelector.TextMatchType.Regex, "[").isValid(labeler))
+    }
+
+    @Test
+    fun `number filter validity checks property names`() {
+        val labeler = TestLabelers.utauOto
+        val valid = EntrySelector.NumberFilterItem("left", EntrySelector.NumberMatchType.Equals, 0.0, null)
+        assertTrue(valid.isValid(labeler))
+        val withComparer = EntrySelector.NumberFilterItem("left", EntrySelector.NumberMatchType.Equals, 0.0, "preu")
+        assertTrue(withComparer.isValid(labeler))
+        val unknownSubject = EntrySelector.NumberFilterItem("nope", EntrySelector.NumberMatchType.Equals, 0.0, null)
+        assertFalse(unknownSubject.isValid(labeler))
+        val unknownComparer = EntrySelector.NumberFilterItem("left", EntrySelector.NumberMatchType.Equals, 0.0, "nope")
+        assertFalse(unknownComparer.isValid(labeler))
+    }
+
+    @Test
+    fun `boolean and script filter validity`() {
+        val labeler = TestLabelers.utauOto
+        assertTrue(EntrySelector.BooleanFilterItem("done", true).isValid(labeler))
+        assertTrue(EntrySelector.BooleanFilterItem("star", false).isValid(labeler))
+        assertFalse(EntrySelector.BooleanFilterItem("name", true).isValid(labeler))
+        assertTrue(EntrySelector.ScriptFilterItem("entry.name === 'a'").isValid(labeler))
+    }
+
+    /* endregion */
+
+    /* region EntrySelector selection */
+
+    @Test
+    fun `empty selector selects all entries`() {
+        val entries = listOf(entry("a"), entry("b"), entry("c"))
+        val selected = withJs { js ->
+            EntrySelector(emptyList()).select(entries, TestLabelers.utauOto, js)
+        }
+        assertEquals(listOf(0, 1, 2), selected)
+    }
+
+    @Test
+    fun `text filters select entries by name sample and tag`() {
+        val entries = listOf(
+            entry("ka", sample = "first.wav", tag = "todo"),
+            entry("ki", sample = "second.wav", tag = "done"),
+            entry("sa", sample = "second.wav", tag = ""),
+        )
+        val labeler = TestLabelers.utauOto
+        withJs { js ->
+            fun select(subject: String, matchType: EntrySelector.TextMatchType, text: String) =
+                EntrySelector(listOf(EntrySelector.TextFilterItem(subject, matchType, text)))
+                    .select(entries, labeler, js)
+
+            assertEquals(listOf(0), select("name", EntrySelector.TextMatchType.Equals, "ka"))
+            assertEquals(listOf(0, 1), select("name", EntrySelector.TextMatchType.StartsWith, "k"))
+            assertEquals(listOf(0, 2), select("name", EntrySelector.TextMatchType.EndsWith, "a"))
+            assertEquals(listOf(0, 1), select("name", EntrySelector.TextMatchType.Regex, "k."))
+            assertEquals(listOf(1, 2), select("sample", EntrySelector.TextMatchType.Contains, "second"))
+            assertEquals(listOf(1), select("tag", EntrySelector.TextMatchType.Equals, "done"))
+        }
+    }
+
+    @Test
+    fun `boolean filters select entries by done and star`() {
+        val entries = listOf(
+            entry("a", done = true, star = false),
+            entry("b", done = false, star = true),
+            entry("c", done = true, star = true),
+        )
+        val labeler = TestLabelers.utauOto
+        withJs { js ->
+            assertEquals(
+                listOf(0, 2),
+                EntrySelector(listOf(EntrySelector.BooleanFilterItem("done", true))).select(entries, labeler, js),
+            )
+            assertEquals(
+                listOf(0),
+                EntrySelector(listOf(EntrySelector.BooleanFilterItem("star", false))).select(entries, labeler, js),
+            )
+        }
+    }
+
+    @Test
+    fun `number filters select entries by property values`() {
+        // left = points[3], ovl = points[2] - points[3], preu = points[1] - points[3]
+        val entries = listOf(
+            entry("a", points = listOf(300f, 250f, 150f, 100f)), // left = 100, ovl = 50, preu = 150
+            entry("b", points = listOf(300f, 200f, 260f, 50f)), // left = 50, ovl = 210, preu = 150
+        )
+        val labeler = TestLabelers.utauOto
+        withJs { js ->
+            val leftOver60 =
+                EntrySelector.NumberFilterItem("left", EntrySelector.NumberMatchType.GreaterThan, 60.0, null)
+            assertEquals(
+                listOf(0),
+                EntrySelector(listOf(leftOver60)).select(entries, labeler, js),
+            )
+            val ovlOverPreu =
+                EntrySelector.NumberFilterItem("ovl", EntrySelector.NumberMatchType.GreaterThan, 0.0, "preu")
+            assertEquals(
+                listOf(1),
+                EntrySelector(listOf(ovlOverPreu)).select(entries, labeler, js),
+            )
+            assertEquals(
+                listOf(0, 1),
+                EntrySelector(
+                    listOf(EntrySelector.NumberFilterItem("preu", EntrySelector.NumberMatchType.Equals, 150.0, null)),
+                ).select(entries, labeler, js),
+            )
+        }
+    }
+
+    @Test
+    fun `script filters select entries by evaluating the expression`() {
+        val entries = listOf(
+            entry("ka", points = listOf(300f, 250f, 150f, 100f)),
+            entry("sa", points = listOf(300f, 200f, 260f, 50f)),
+        )
+        val labeler = TestLabelers.utauOto
+        withJs { js ->
+            assertEquals(
+                listOf(0),
+                EntrySelector(listOf(EntrySelector.ScriptFilterItem("entry.name.startsWith('k')")))
+                    .select(entries, labeler, js),
+            )
+            // properties are injected into the entry before evaluation
+            assertEquals(
+                listOf(0),
+                EntrySelector(listOf(EntrySelector.ScriptFilterItem("entry.left > 60")))
+                    .select(entries, labeler, js),
+            )
+            // a blank script accepts everything
+            assertEquals(
+                listOf(0, 1),
+                EntrySelector(listOf(EntrySelector.ScriptFilterItem(""))).select(entries, labeler, js),
+            )
+        }
+    }
+
+    @Test
+    fun `script filters require a boolean result`() {
+        val entries = listOf(entry("a"))
+        withJs { js ->
+            assertFailsWith<IllegalStateException> {
+                EntrySelector(listOf(EntrySelector.ScriptFilterItem("1 + 1")))
+                    .select(entries, TestLabelers.utauOto, js)
+            }
+        }
+    }
+
+    @Test
+    fun `raw expression combines filter results`() {
+        val entries = listOf(
+            entry("ka", star = true),
+            entry("ki", star = false),
+            entry("sa", star = true),
+            entry("su", star = false),
+        )
+        val labeler = TestLabelers.utauOto
+        val startsWithK = EntrySelector.TextFilterItem("name", EntrySelector.TextMatchType.StartsWith, "k")
+        val starred = EntrySelector.BooleanFilterItem("star", true)
+        withJs { js ->
+            assertEquals(
+                listOf(0),
+                EntrySelector(listOf(startsWithK, starred)).select(entries, labeler, js),
+            )
+            assertEquals(
+                listOf(0, 1, 2),
+                EntrySelector(listOf(startsWithK, starred), "#1 or #2").select(entries, labeler, js),
+            )
+            assertEquals(
+                listOf(2, 3),
+                EntrySelector(listOf(startsWithK, starred), "not #1").select(entries, labeler, js),
+            )
+            assertEquals(
+                listOf(1, 2),
+                EntrySelector(listOf(startsWithK, starred), "#1 xor #2").select(entries, labeler, js),
+            )
+        }
+    }
+
+    @Test
+    fun `select fails on an unparseable raw expression`() {
+        val entries = listOf(entry("a"))
+        val filter = EntrySelector.TextFilterItem("name", EntrySelector.TextMatchType.Contains, "a")
+        val selector = EntrySelector(listOf(filter), "#1 and")
+        assertFalse(selector.isValid(TestLabelers.utauOto))
+        withJs { js ->
+            // the incomplete expression is rejected by `error()` inside the parser
+            assertFailsWith<IllegalStateException> {
+                selector.select(entries, TestLabelers.utauOto, js)
+            }
+        }
+    }
+
+    /* endregion */
+}

--- a/src/jvmTest/kotlin/ui/KeymapConflictDetectionTest.kt
+++ b/src/jvmTest/kotlin/ui/KeymapConflictDetectionTest.kt
@@ -1,0 +1,74 @@
+package ui
+
+import com.sdercolin.vlabeler.model.action.KeyAction
+import com.sdercolin.vlabeler.model.action.KeyActionKeyBind
+import com.sdercolin.vlabeler.model.action.MouseClickAction
+import com.sdercolin.vlabeler.model.action.MouseClickActionKeyBind
+import com.sdercolin.vlabeler.model.action.getConflictingKeyBinds
+import com.sdercolin.vlabeler.model.key.Key
+import com.sdercolin.vlabeler.model.key.KeySet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the conflict detection used by the keymap item edit dialog
+ * ([com.sdercolin.vlabeler.ui.dialog.preferences.KeymapItemEditConflictDialog]), implemented by
+ * [getConflictingKeyBinds].
+ */
+class KeymapConflictDetectionTest {
+
+    private val keySet = KeySet(Key.J, setOf(Key.Ctrl))
+
+    @Test
+    fun `a null key set never conflicts`() {
+        val binds = listOf(
+            KeyActionKeyBind(KeyAction.NewProject, keySet),
+            KeyActionKeyBind(KeyAction.OpenProject, keySet),
+        )
+        assertTrue(binds.getConflictingKeyBinds(null, KeyAction.SaveProject).isEmpty())
+    }
+
+    @Test
+    fun `key binds with the same key set and another action conflict`() {
+        val binds = listOf(
+            KeyActionKeyBind(KeyAction.NewProject, keySet),
+            KeyActionKeyBind(KeyAction.OpenProject, KeySet(Key.O, setOf(Key.Ctrl))),
+            KeyActionKeyBind(KeyAction.SaveProject, null),
+        )
+        assertEquals(
+            listOf(KeyActionKeyBind(KeyAction.NewProject, keySet)),
+            binds.getConflictingKeyBinds(keySet, KeyAction.SaveProject),
+        )
+    }
+
+    @Test
+    fun `the edited action itself is not reported as a conflict`() {
+        val binds = listOf(KeyActionKeyBind(KeyAction.NewProject, keySet))
+        assertTrue(binds.getConflictingKeyBinds(keySet, KeyAction.NewProject).isEmpty())
+    }
+
+    @Test
+    fun `mouse click actions only conflict within the same tool`() {
+        val clickKeySet = KeySet(Key.MouseLeftClick, setOf(Key.Shift))
+        // MoveParameter uses the cursor tool while PlayAudioUntilEnd uses the playback tool
+        val cursorBind = MouseClickActionKeyBind(MouseClickAction.MoveParameter, clickKeySet)
+        val playbackBind = MouseClickActionKeyBind(MouseClickAction.PlayAudioUntilEnd, clickKeySet)
+        val binds = listOf(cursorBind, playbackBind)
+
+        assertEquals(
+            listOf(cursorBind),
+            binds.getConflictingKeyBinds(clickKeySet, MouseClickAction.MoveParameterIgnoringConstraints),
+        )
+        assertEquals(
+            listOf(playbackBind),
+            binds.getConflictingKeyBinds(clickKeySet, MouseClickAction.PlayAudioFromStart),
+        )
+    }
+
+    @Test
+    fun `key binds with different key sets do not conflict`() {
+        val binds = listOf(KeyActionKeyBind(KeyAction.NewProject, KeySet(Key.N, setOf(Key.Ctrl))))
+        assertTrue(binds.getConflictingKeyBinds(keySet, KeyAction.SaveProject).isEmpty())
+    }
+}

--- a/src/jvmTest/kotlin/ui/LabelerDialogStateTest.kt
+++ b/src/jvmTest/kotlin/ui/LabelerDialogStateTest.kt
@@ -1,0 +1,378 @@
+package ui
+
+import androidx.compose.material.SnackbarHostState
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppRecord
+import com.sdercolin.vlabeler.model.Parameter
+import com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginPreset
+import com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginPresetItem
+import com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginPresetTarget
+import com.sdercolin.vlabeler.ui.dialog.plugin.LabelerDialogState
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.ui.string.stringStatic
+import com.sdercolin.vlabeler.util.ParamMap
+import com.sdercolin.vlabeler.util.RecordDir
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import com.sdercolin.vlabeler.util.toParamMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import testutil.TestEnv
+import testutil.TestLabelers
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [LabelerDialogState].
+ *
+ * The state is exercised with the bundled `utau-singer.default` labeler ([TestLabelers.utauSinger]), which declares
+ * both changeable (`dragBase`, ...) and unchangeable (`useRootDirectory`, `forceRecursive`) parameters.
+ *
+ * The saved-params file returned by `getSavedParamsFile()` lives in `RecordDir`, which is redirected to
+ * `build/test-app-dir/.record` by the `VLABELER_APP_DIR` environment variable set on the test task, so nothing is
+ * written to the real application directory. Created files are removed in [teardown].
+ */
+class LabelerDialogStateTest {
+
+    private val tempDirs = mutableListOf<File>()
+    private val recordFiles = mutableListOf<File>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        RecordDir.mkdirs()
+    }
+
+    @AfterTest
+    fun teardown() {
+        tempDirs.forEach { it.deleteRecursively() }
+        tempDirs.clear()
+        recordFiles.forEach { it.delete() }
+        recordFiles.clear()
+        Log.muted = false
+    }
+
+    private fun newTempDir(): File = createTempDirectory("vlabeler-test").toFile().also { tempDirs += it }
+
+    private val labeler = TestLabelers.utauSinger
+
+    private class Callbacks {
+        val submitted = mutableListOf<ParamMap?>()
+        val loaded = mutableListOf<ParamMap>()
+        val saved = mutableListOf<ParamMap>()
+    }
+
+    private fun createState(
+        callbacks: Callbacks = Callbacks(),
+        isExistingProject: Boolean = false,
+        paramMap: ParamMap = labeler.getDefaultParams(),
+        savedParamMap: ParamMap? = labeler.getDefaultParams(),
+    ): LabelerDialogState = LabelerDialogState(
+        labeler = labeler,
+        isExistingProject = isExistingProject,
+        snackbarHostState = SnackbarHostState(),
+        paramMap = paramMap,
+        savedParamMap = savedParamMap,
+        submit = { callbacks.submitted += it },
+        save = { callbacks.saved += it },
+        load = { callbacks.loaded += it },
+    )
+
+    private fun LabelerDialogState.indexOf(name: String): Int = paramDefs.indexOfFirst { it.name == name }
+
+    /**
+     * Runs a suspending dialog action ([LabelerDialogState.import] / [LabelerDialogState.export]) that finishes by
+     * showing a snackbar. Without a composed `SnackbarHost` the `showSnackbar` call suspends until the snackbar is
+     * dismissed, so this helper dismisses it and returns the shown message.
+     */
+    private fun runDialogAction(state: LabelerDialogState, block: suspend () -> Unit): String? {
+        var message: String? = null
+        runBlocking {
+            val job = launch(Dispatchers.Default) { block() }
+            withTimeout(10_000) {
+                while (job.isActive) {
+                    state.snackbarHostState.currentSnackbarData?.let {
+                        message = it.message
+                        it.dismiss()
+                    }
+                    delay(10)
+                }
+            }
+        }
+        return message
+    }
+
+    @Test
+    fun `basic configuration`() {
+        val state = createState()
+        assertNull(state.project)
+        assertEquals(labeler, state.basePlugin)
+        assertTrue(state.hasParams)
+        assertFalse(state.needJsClient)
+        assertEquals(
+            listOf(
+                Parameter.IntParam.Type,
+                Parameter.FloatParam.Type,
+                Parameter.BooleanParam.Type,
+                Parameter.StringParam.Type,
+                Parameter.EnumParam.Type,
+                Parameter.FileParam.Type,
+                Parameter.RawFileParam.Type,
+            ),
+            state.acceptedParamTypes,
+        )
+        assertFalse(state.acceptParamType(Parameter.EntrySelectorParam.Type))
+        assertTrue(state.acceptParamType(Parameter.EnumParam.Type))
+    }
+
+    @Test
+    fun `is changeable returns declared flags only for existing projects`() {
+        val newProjectState = createState(isExistingProject = false)
+        assertTrue(newProjectState.isChangeable("dragBase"))
+        assertTrue(newProjectState.isChangeable("useRootDirectory"))
+        assertTrue(newProjectState.isChangeable("unknown"))
+
+        val existingProjectState = createState(isExistingProject = true)
+        assertTrue(existingProjectState.isChangeable("dragBase"))
+        assertFalse(existingProjectState.isChangeable("useRootDirectory"))
+        assertFalse(existingProjectState.isChangeable("forceRecursive"))
+        assertFailsWith<IllegalArgumentException> { existingProjectState.isChangeable("unknown") }
+    }
+
+    @Test
+    fun `reset retains unchangeable params for existing projects`() {
+        val state = createState(isExistingProject = true)
+        val dragBaseIndex = state.indexOf("dragBase")
+        val useRootDirectoryIndex = state.indexOf("useRootDirectory")
+        val dragBaseDefault = state.paramDefs[dragBaseIndex].defaultValue
+        val useRootDirectoryDefault = state.paramDefs[useRootDirectoryIndex].defaultValue as Boolean
+
+        state.update(dragBaseIndex, "Left")
+        state.update(useRootDirectoryIndex, !useRootDirectoryDefault)
+        assertEquals(0, state.resetKey)
+
+        state.reset()
+
+        assertEquals(1, state.resetKey)
+        assertEquals(dragBaseDefault, state.params[dragBaseIndex])
+        assertEquals(!useRootDirectoryDefault, state.params[useRootDirectoryIndex])
+    }
+
+    @Test
+    fun `reset restores all params for new projects`() {
+        val state = createState(isExistingProject = false)
+        val useRootDirectoryIndex = state.indexOf("useRootDirectory")
+        val default = state.paramDefs[useRootDirectoryIndex].defaultValue as Boolean
+
+        state.update(useRootDirectoryIndex, !default)
+        state.reset()
+
+        assertEquals(default, state.params[useRootDirectoryIndex])
+        assertEquals(labeler.getDefaultParams(), state.getCurrentParamMap())
+    }
+
+    @Test
+    fun `can reset ignores unchangeable params for existing projects`() {
+        val existingProjectState = createState(isExistingProject = true)
+        assertFalse(existingProjectState.canReset())
+        val useRootDirectoryIndex = existingProjectState.indexOf("useRootDirectory")
+        val default = existingProjectState.paramDefs[useRootDirectoryIndex].defaultValue as Boolean
+        existingProjectState.update(useRootDirectoryIndex, !default)
+        assertFalse(existingProjectState.canReset())
+        existingProjectState.update(existingProjectState.indexOf("dragBase"), "Left")
+        assertTrue(existingProjectState.canReset())
+
+        val newProjectState = createState(isExistingProject = false)
+        newProjectState.update(useRootDirectoryIndex, !default)
+        assertTrue(newProjectState.canReset())
+    }
+
+    @Test
+    fun `apply and cancel submit the current params or null`() {
+        val callbacks = Callbacks()
+        val state = createState(callbacks)
+        state.update(state.indexOf("dragBase"), "Left")
+        state.apply()
+        state.cancel()
+        assertEquals(2, callbacks.submitted.size)
+        assertEquals(
+            (labeler.getDefaultParams() + mapOf("dragBase" to "Left")).toParamMap(),
+            callbacks.submitted[0],
+        )
+        assertNull(callbacks.submitted[1])
+    }
+
+    @Test
+    fun `can save requires changed and valid params`() {
+        val callbacks = Callbacks()
+        val state = createState(callbacks)
+        assertFalse(state.canSave())
+
+        val dragBaseIndex = state.indexOf("dragBase")
+        state.update(dragBaseIndex, "Left")
+        assertTrue(state.canSave())
+
+        state.update(dragBaseIndex, "NotAnOption")
+        assertFalse(state.isValid(dragBaseIndex))
+        assertFalse(state.isAllValid())
+        assertFalse(state.canSave())
+
+        state.update(dragBaseIndex, "Left")
+        state.save()
+        assertEquals(
+            listOf((labeler.getDefaultParams() + mapOf("dragBase" to "Left")).toParamMap()),
+            callbacks.saved,
+        )
+
+        val stateWithoutSaved = createState(savedParamMap = null)
+        stateWithoutSaved.update(dragBaseIndex, "Left")
+        assertFalse(stateWithoutSaved.canSave())
+    }
+
+    @Test
+    fun `export to file and import back round trips`() {
+        val state = createState()
+        state.update(state.indexOf("dragBase"), "Left")
+        val file = newTempDir().resolve("preset.json")
+
+        val exportMessage = runDialogAction(state) { state.export(BasePluginPresetTarget.File(file)) }
+        assertEquals(stringStatic(Strings.PluginDialogExportSuccess), exportMessage)
+
+        val preset = file.readText().parseJson<BasePluginPreset>()
+        assertEquals(labeler.name, preset.pluginName)
+        assertEquals(labeler.version, preset.pluginVersion)
+        assertEquals("Left", preset.params?.get("dragBase")?.value)
+        assertNull(preset.params?.get("useNegativeOvl"))
+
+        val callbacks = Callbacks()
+        val freshState = createState(callbacks)
+        val importMessage = runDialogAction(freshState) { freshState.import(BasePluginPresetTarget.File(file)) }
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), importMessage)
+        assertEquals(
+            listOf((labeler.getDefaultParams() + mapOf("dragBase" to "Left")).toParamMap()),
+            callbacks.loaded,
+        )
+    }
+
+    @Test
+    fun `import from file retains unchangeable params for existing projects`() {
+        val state = createState()
+        val useRootDirectoryIndex = state.indexOf("useRootDirectory")
+        val useRootDirectoryDefault = state.paramDefs[useRootDirectoryIndex].defaultValue as Boolean
+        state.update(state.indexOf("dragBase"), "Left")
+        state.update(useRootDirectoryIndex, !useRootDirectoryDefault)
+        val file = newTempDir().resolve("preset.json")
+        runDialogAction(state) { state.export(BasePluginPresetTarget.File(file)) }
+
+        val callbacks = Callbacks()
+        val existingProjectState = createState(callbacks, isExistingProject = true)
+        val message = runDialogAction(existingProjectState) {
+            existingProjectState.import(BasePluginPresetTarget.File(file))
+        }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), message)
+        val loaded = callbacks.loaded.single()
+        assertEquals("Left", loaded["dragBase"])
+        // the unchangeable value from the preset is replaced by the current value of the dialog
+        assertEquals(useRootDirectoryDefault, loaded["useRootDirectory"])
+    }
+
+    @Test
+    fun `import fails on labeler name mismatch`() {
+        val file = newTempDir().resolve("preset.json")
+        file.writeText(
+            BasePluginPreset(pluginName = "some-other-labeler", pluginVersion = 1, params = null).stringifyJson(),
+        )
+        val callbacks = Callbacks()
+        val state = createState(callbacks)
+
+        val message = runDialogAction(state) { state.import(BasePluginPresetTarget.File(file)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportFailure), message)
+        assertEquals(emptyList(), callbacks.loaded)
+    }
+
+    @Test
+    fun `import fails on an unparseable file`() {
+        val file = newTempDir().resolve("preset.json").apply { writeText("not a preset") }
+        val callbacks = Callbacks()
+        val state = createState(callbacks)
+
+        val message = runDialogAction(state) { state.import(BasePluginPresetTarget.File(file)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportFailure), message)
+        assertEquals(emptyList(), callbacks.loaded)
+    }
+
+    @Test
+    fun `export to memory writes the saved params file and import reads it back`() {
+        val savedParamsFile = labeler.getSavedParamsFile().also { recordFiles += it }
+        savedParamsFile.delete()
+        val state = createState()
+        state.update(state.indexOf("dragBase"), "Left")
+        val memoryTarget = BasePluginPresetItem.Memory(
+            pluginName = labeler.name,
+            slot = null,
+            isCurrent = true,
+            available = true,
+        ).resolve()
+
+        val exportMessage = runDialogAction(state) { state.export(memoryTarget) }
+        assertEquals(stringStatic(Strings.PluginDialogExportSuccess), exportMessage)
+        assertTrue(savedParamsFile.exists())
+
+        val callbacks = Callbacks()
+        val freshState = createState(callbacks)
+        val importMessage = runDialogAction(freshState) { freshState.import(memoryTarget) }
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), importMessage)
+        assertEquals(
+            listOf((labeler.getDefaultParams() + mapOf("dragBase" to "Left")).toParamMap()),
+            callbacks.loaded,
+        )
+    }
+
+    @Test
+    fun `import from memory without a saved file loads the defaults`() {
+        labeler.getSavedParamsFile().delete()
+        val callbacks = Callbacks()
+        val state = createState(callbacks)
+        val memoryTarget = BasePluginPresetItem.Memory(
+            pluginName = labeler.name,
+            slot = null,
+            isCurrent = true,
+            available = true,
+        ).resolve()
+
+        val message = runDialogAction(state) { state.import(memoryTarget) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), message)
+        assertEquals(listOf(labeler.getDefaultParams()), callbacks.loaded)
+    }
+
+    @Test
+    fun `preset targets of a labeler are memory and file`() {
+        val state = createState()
+        val record = AppRecord()
+        val importable = state.getImportablePresets(record)
+        assertEquals(2, importable.size)
+        val memory = importable.first() as BasePluginPresetItem.Memory
+        assertEquals(labeler.name, memory.pluginName)
+        assertNull(memory.slot)
+        assertTrue(memory.isCurrent)
+        assertTrue(memory.available)
+        assertEquals(BasePluginPresetItem.File, importable.last())
+        assertEquals(importable.map { it::class }, state.getExportablePresets(record).map { it::class })
+    }
+}

--- a/src/jvmTest/kotlin/ui/PluginDialogStateTest.kt
+++ b/src/jvmTest/kotlin/ui/PluginDialogStateTest.kt
@@ -1,0 +1,553 @@
+package ui
+
+import androidx.compose.material.SnackbarHostState
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.io.loadPlugins
+import com.sdercolin.vlabeler.model.AppRecord
+import com.sdercolin.vlabeler.model.Parameter
+import com.sdercolin.vlabeler.model.Plugin
+import com.sdercolin.vlabeler.model.PluginQuickLaunch
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.ui.AppRecordStore
+import com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginPreset
+import com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginPresetItem
+import com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginPresetTarget
+import com.sdercolin.vlabeler.ui.dialog.plugin.PluginDialogState
+import com.sdercolin.vlabeler.ui.string.Language
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.ui.string.stringStatic
+import com.sdercolin.vlabeler.util.ParamMap
+import com.sdercolin.vlabeler.util.ParamTypedMap
+import com.sdercolin.vlabeler.util.RecordDir
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import com.sdercolin.vlabeler.util.toParamMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Tests for [PluginDialogState] and the shared logic in
+ * [com.sdercolin.vlabeler.ui.dialog.plugin.BasePluginDialogState], using the bundled plugins loaded via [loadPlugins].
+ *
+ * Saved-params files are written to `RecordDir`, and the [AppRecordStore]-backed quick launch slots to
+ * `AppRecordFile`; both live under `build/test-app-dir` because the test task sets the `VLABELER_APP_DIR` environment
+ * variable, so nothing is written to the real application directory. Created files are removed in [teardown].
+ *
+ * When an [AppRecordStore] only needs to be read, it is created with an already-cancelled scope so that its
+ * `collectAndWrite()` loop never runs (the safety of this pattern is asserted in [ProjectCreatorStateTest]). The
+ * export-to-slot test needs `update` to be applied, so it uses a live scope that is cancelled in [teardown].
+ */
+class PluginDialogStateTest {
+
+    private lateinit var storeScope: CoroutineScope
+    private val tempDirs = mutableListOf<File>()
+    private val recordFiles = mutableListOf<File>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        RecordDir.mkdirs()
+        storeScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @AfterTest
+    fun teardown() {
+        storeScope.cancel()
+        tempDirs.forEach { it.deleteRecursively() }
+        tempDirs.clear()
+        recordFiles.forEach { it.delete() }
+        recordFiles.clear()
+        Log.muted = false
+    }
+
+    private fun newTempDir(): File = createTempDirectory("vlabeler-test").toFile().also { tempDirs += it }
+
+    private fun cancelledScope(): CoroutineScope = CoroutineScope(Job().apply { cancel() })
+
+    private class Callbacks {
+        val submitted = mutableListOf<ParamMap?>()
+        val loaded = mutableListOf<ParamMap>()
+        val saved = mutableListOf<ParamMap>()
+    }
+
+    private fun createState(
+        plugin: Plugin,
+        callbacks: Callbacks = Callbacks(),
+        paramMap: ParamMap = plugin.getDefaultParams(),
+        savedParamMap: ParamMap? = plugin.getDefaultParams(),
+        project: Project? = null,
+        store: AppRecordStore = AppRecordStore(AppRecord(), cancelledScope()),
+        slot: Int? = null,
+    ): PluginDialogState = PluginDialogState(
+        plugin = plugin,
+        appRecordStore = store,
+        snackbarHostState = SnackbarHostState(),
+        paramMap = paramMap,
+        savedParamMap = savedParamMap,
+        project = project,
+        submit = { callbacks.submitted += it },
+        load = { callbacks.loaded += it },
+        save = { callbacks.saved += it },
+        executable = false,
+        slot = slot,
+    )
+
+    private fun PluginDialogState.indexOf(name: String): Int = paramDefs.indexOfFirst { it.name == name }
+
+    private fun memoryTarget(pluginName: String?, slot: Int?): BasePluginPresetTarget.Memory =
+        BasePluginPresetItem.Memory(
+            pluginName = pluginName,
+            slot = slot,
+            isCurrent = slot == null,
+            available = true,
+        ).resolve()
+
+    /**
+     * Runs a suspending dialog action ([PluginDialogState.import] / [PluginDialogState.export]) that finishes by
+     * showing a snackbar. Without a composed `SnackbarHost` the `showSnackbar` call suspends until the snackbar is
+     * dismissed, so this helper dismisses it and returns the shown message.
+     */
+    private fun runDialogAction(state: PluginDialogState, block: suspend () -> Unit): String? {
+        var message: String? = null
+        runBlocking {
+            val job = launch(Dispatchers.Default) { block() }
+            withTimeout(10_000) {
+                while (job.isActive) {
+                    state.snackbarHostState.currentSnackbarData?.let {
+                        message = it.message
+                        it.dismiss()
+                    }
+                    delay(10)
+                }
+            }
+        }
+        return message
+    }
+
+    private fun awaitRecord(store: AppRecordStore, predicate: (AppRecord) -> Boolean) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate(store.value)) return
+            Thread.sleep(10)
+        }
+        fail("The app record was not updated in time")
+    }
+
+    /* region params */
+
+    @Test
+    fun `params are initialized from the param map`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val state = createState(plugin)
+        assertTrue(state.hasParams)
+        assertEquals(plugin.parameterDefs, state.paramDefs)
+        assertEquals(plugin.getDefaultParams(), state.getCurrentParamMap())
+        assertTrue(state.isAllValid())
+        assertTrue(state.isChangeable("bpm"))
+    }
+
+    @Test
+    fun `update replaces a param value and validates it`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val state = createState(plugin)
+        val bpmIndex = state.indexOf("bpm")
+
+        state.update(bpmIndex, 90f)
+        assertEquals(90f, state.getCurrentParamMap()["bpm"])
+        assertTrue(state.isValid(bpmIndex))
+
+        // bpm has min 0
+        state.update(bpmIndex, -1f)
+        assertFalse(state.isValid(bpmIndex))
+        assertFalse(state.isAllValid())
+
+        // repeatSuffix is a non-optional string
+        val repeatSuffixIndex = state.indexOf("repeatSuffix")
+        state.update(repeatSuffixIndex, "")
+        assertFalse(state.isValid(repeatSuffixIndex))
+
+        // order is an enum
+        val orderIndex = state.indexOf("order")
+        state.update(orderIndex, "NotAnOption")
+        assertFalse(state.isValid(orderIndex))
+    }
+
+    @Test
+    fun `parse errors invalidate the dialog`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val state = createState(plugin)
+        assertTrue(state.isAllValid())
+        state.setParseError(0, true)
+        assertFalse(state.isAllValid())
+        state.setParseError(0, false)
+        assertTrue(state.isAllValid())
+    }
+
+    @Test
+    fun `reset restores default values and bumps the reset key`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val state = createState(plugin)
+        assertFalse(state.canReset())
+        val bpmIndex = state.indexOf("bpm")
+
+        state.update(bpmIndex, 90f)
+        assertTrue(state.canReset())
+        assertEquals(0, state.resetKey)
+
+        state.reset()
+
+        assertEquals(1, state.resetKey)
+        assertEquals(plugin.getDefaultParams(), state.getCurrentParamMap())
+        assertFalse(state.canReset())
+    }
+
+    @Test
+    fun `apply and cancel submit the current params or null`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks)
+        state.update(state.indexOf("bpm"), 90f)
+
+        state.apply()
+        state.cancel()
+
+        assertEquals(2, callbacks.submitted.size)
+        assertEquals((plugin.getDefaultParams() + mapOf("bpm" to 90f)).toParamMap(), callbacks.submitted[0])
+        assertNull(callbacks.submitted[1])
+    }
+
+    @Test
+    fun `can save requires changed and valid params`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks)
+        assertFalse(state.canSave())
+
+        val bpmIndex = state.indexOf("bpm")
+        state.update(bpmIndex, 90f)
+        assertTrue(state.canSave())
+
+        state.update(bpmIndex, -1f)
+        assertFalse(state.canSave())
+
+        state.update(bpmIndex, 90f)
+        state.save()
+        assertEquals(listOf((plugin.getDefaultParams() + mapOf("bpm" to 90f)).toParamMap()), callbacks.saved)
+
+        val stateWithoutSaved = createState(plugin, savedParamMap = null)
+        stateWithoutSaved.update(bpmIndex, 90f)
+        assertFalse(stateWithoutSaved.canSave())
+    }
+
+    @Test
+    fun `js client and entry selector params are only for macro plugins`() {
+        val macroState = createState(macroPlugin("batch-remove-entry"))
+        assertTrue(macroState.needJsClient)
+        assertTrue(macroState.acceptParamType(Parameter.EntrySelectorParam.Type))
+
+        val templateState = createState(templatePlugin("cvvc-oto-gen"))
+        assertFalse(templateState.needJsClient)
+        assertFalse(templateState.acceptParamType(Parameter.EntrySelectorParam.Type))
+        assertTrue(templateState.acceptParamType(Parameter.FloatParam.Type))
+    }
+
+    @Test
+    fun `entry selector params are laid out in their own row`() {
+        val macroState = createState(macroPlugin("batch-edit-entry-name"))
+        assertFalse(macroState.isParamInRow(macroState.indexOf("selector")))
+        assertTrue(macroState.isParamInRow(macroState.indexOf("from")))
+
+        val templateState = createState(templatePlugin("cvvc-oto-gen"))
+        assertTrue(templateState.isParamInRow(templateState.indexOf("bpm")))
+    }
+
+    @Test
+    fun `entry selector params require a project to be valid`() {
+        val plugin = macroPlugin("batch-remove-entry")
+        val stateWithoutProject = createState(plugin)
+        val selectorIndex = stateWithoutProject.indexOf("selector")
+        assertFalse(stateWithoutProject.isValid(selectorIndex))
+        assertFalse(stateWithoutProject.isAllValid())
+
+        val sampleDirectory = TestFixtures.deploy("oto", newTempDir(), wavFiles = listOf("_a_ka.wav"))
+        val project = createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDirectory,
+            inputFilePath = sampleDirectory.resolve("oto.ini").absolutePath,
+        )
+        val stateWithProject = createState(plugin, project = project)
+        assertTrue(stateWithProject.isValid(selectorIndex))
+        assertTrue(stateWithProject.isAllValid())
+    }
+
+    /* endregion */
+
+    /* region presets */
+
+    @Test
+    fun `template plugins only offer memory and file preset targets`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val state = createState(plugin)
+        val importable = state.getImportablePresets(AppRecord())
+        assertEquals(2, importable.size)
+        val memory = importable.first() as BasePluginPresetItem.Memory
+        assertEquals(plugin.name, memory.pluginName)
+        assertNull(memory.slot)
+        assertTrue(memory.isCurrent)
+        assertTrue(memory.available)
+        assertEquals(BasePluginPresetItem.File, importable.last())
+        assertEquals(2, state.getExportablePresets(AppRecord()).size)
+    }
+
+    @Test
+    fun `macro plugin preset availability follows the quick launch slots`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        val other = macroPlugin("batch-remove-entry")
+        val record = AppRecord(
+            pluginQuickLaunchSlots = mapOf(
+                0 to PluginQuickLaunch(pluginName = plugin.name, params = null),
+                1 to PluginQuickLaunch(pluginName = other.name, params = null),
+            ),
+        )
+        val state = createState(plugin)
+
+        val importable = state.getImportablePresets(record)
+        assertEquals(PluginQuickLaunch.SLOT_COUNT + 2, importable.size)
+        val root = importable.first() as BasePluginPresetItem.Memory
+        assertEquals(plugin.name, root.pluginName)
+        assertNull(root.slot)
+        assertTrue(root.isCurrent)
+        assertTrue(root.available)
+        assertEquals(BasePluginPresetItem.File, importable.last())
+        val slots = importable.drop(1).dropLast(1).map { it as BasePluginPresetItem.Memory }
+        assertEquals(List(PluginQuickLaunch.SLOT_COUNT) { it }, slots.map { it.slot })
+        // slot 0 holds this plugin, slot 1 holds another plugin, the other slots are empty
+        assertEquals(plugin.name, slots[0].pluginName)
+        assertTrue(slots[0].available)
+        assertEquals(other.name, slots[1].pluginName)
+        assertFalse(slots[1].available)
+        assertNull(slots[2].pluginName)
+        assertFalse(slots[2].available)
+
+        val exportableSlots = state.getExportablePresets(record)
+            .drop(1).dropLast(1).map { it as BasePluginPresetItem.Memory }
+        assertTrue(exportableSlots[0].available)
+        assertFalse(exportableSlots[1].available)
+        // empty slots can be exported to
+        assertTrue(exportableSlots[2].available)
+    }
+
+    @Test
+    fun `a dialog opened from a slot marks it as current`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        val state = createState(plugin, slot = 3)
+        val importable = state.getImportablePresets(AppRecord())
+        val root = importable.first() as BasePluginPresetItem.Memory
+        assertFalse(root.isCurrent)
+        val slots = importable.drop(1).dropLast(1).map { it as BasePluginPresetItem.Memory }
+        assertTrue(slots[3].isCurrent)
+        assertTrue(slots[3].available)
+        assertFalse(slots[2].isCurrent)
+    }
+
+    /* endregion */
+
+    /* region import and export */
+
+    @Test
+    fun `export to file and import back round trips`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val state = createState(plugin)
+        state.update(state.indexOf("bpm"), 90f)
+        val file = newTempDir().resolve("preset.json")
+
+        val exportMessage = runDialogAction(state) { state.export(BasePluginPresetTarget.File(file)) }
+        assertEquals(stringStatic(Strings.PluginDialogExportSuccess), exportMessage)
+
+        val preset = file.readText().parseJson<BasePluginPreset>()
+        assertEquals(plugin.name, preset.pluginName)
+        assertEquals(plugin.version, preset.pluginVersion)
+        val params = assertNotNull(preset.params)
+        assertEquals(90f, params.get("bpm")?.value)
+        // default values are not exported
+        assertNull(params.get("offset"))
+
+        val callbacks = Callbacks()
+        val freshState = createState(plugin, callbacks)
+        val importMessage = runDialogAction(freshState) { freshState.import(BasePluginPresetTarget.File(file)) }
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), importMessage)
+        assertEquals(
+            listOf((plugin.getDefaultParams() + mapOf("bpm" to 90f)).toParamMap()),
+            callbacks.loaded,
+        )
+    }
+
+    @Test
+    fun `import fails on plugin name mismatch`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val file = newTempDir().resolve("preset.json")
+        file.writeText(
+            BasePluginPreset(pluginName = "some-other-plugin", pluginVersion = 1, params = null).stringifyJson(),
+        )
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks)
+
+        val message = runDialogAction(state) { state.import(BasePluginPresetTarget.File(file)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportFailure), message)
+        assertEquals(emptyList(), callbacks.loaded)
+    }
+
+    @Test
+    fun `import fails on an unparseable file`() {
+        val plugin = templatePlugin("cvvc-oto-gen")
+        val file = newTempDir().resolve("preset.json").apply { writeText("not a preset") }
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks)
+
+        val message = runDialogAction(state) { state.import(BasePluginPresetTarget.File(file)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportFailure), message)
+        assertEquals(emptyList(), callbacks.loaded)
+    }
+
+    @Test
+    fun `export to memory writes the saved params file and import reads it back`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        val savedParamsFile = plugin.getSavedParamsFile().also { recordFiles += it }
+        savedParamsFile.delete()
+        val state = createState(plugin)
+        state.update(state.indexOf("from"), "^abc$")
+
+        val exportMessage = runDialogAction(state) { state.export(memoryTarget(plugin.name, slot = null)) }
+        assertEquals(stringStatic(Strings.PluginDialogExportSuccess), exportMessage)
+        assertTrue(savedParamsFile.exists())
+
+        val callbacks = Callbacks()
+        val freshState = createState(plugin, callbacks)
+        val importMessage = runDialogAction(freshState) { freshState.import(memoryTarget(plugin.name, slot = null)) }
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), importMessage)
+        assertEquals(
+            listOf((plugin.getDefaultParams() + mapOf("from" to "^abc$")).toParamMap()),
+            callbacks.loaded,
+        )
+    }
+
+    @Test
+    fun `import from memory without a saved file loads the defaults`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        plugin.getSavedParamsFile().delete()
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks)
+
+        val message = runDialogAction(state) { state.import(memoryTarget(plugin.name, slot = null)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), message)
+        assertEquals(listOf(plugin.getDefaultParams()), callbacks.loaded)
+    }
+
+    @Test
+    fun `export to a quick launch slot saves it in the app record`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        val store = AppRecordStore(AppRecord(), storeScope)
+        val state = createState(plugin, store = store)
+        state.update(state.indexOf("from"), "slot-value")
+
+        val exportMessage = runDialogAction(state) { state.export(memoryTarget(plugin.name, slot = 2)) }
+        assertEquals(stringStatic(Strings.PluginDialogExportSuccess), exportMessage)
+
+        awaitRecord(store) { it.pluginQuickLaunchSlots[2]?.pluginName == plugin.name }
+        val quickLaunch = assertNotNull(store.value.pluginQuickLaunchSlots[2])
+        assertEquals("slot-value", quickLaunch.params?.get("from")?.value)
+        assertFalse(quickLaunch.skipDialog)
+
+        val callbacks = Callbacks()
+        val freshState = createState(plugin, callbacks, store = store)
+        val importMessage = runDialogAction(freshState) { freshState.import(memoryTarget(plugin.name, slot = 2)) }
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), importMessage)
+        assertEquals(
+            listOf((plugin.getDefaultParams() + mapOf("from" to "slot-value")).toParamMap()),
+            callbacks.loaded,
+        )
+    }
+
+    @Test
+    fun `import from a quick launch slot loads the saved params`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        val slotParams = (plugin.getDefaultParams() + mapOf("from" to "xyz")).toParamMap()
+        val record = AppRecord(
+            pluginQuickLaunchSlots = mapOf(
+                0 to PluginQuickLaunch(
+                    pluginName = plugin.name,
+                    params = ParamTypedMap.from(slotParams, plugin.parameterDefs),
+                ),
+            ),
+        )
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks, store = AppRecordStore(record, cancelledScope()))
+
+        val message = runDialogAction(state) { state.import(memoryTarget(plugin.name, slot = 0)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportSuccess), message)
+        assertEquals(listOf(slotParams), callbacks.loaded)
+    }
+
+    @Test
+    fun `import from a quick launch slot of another plugin fails`() {
+        val plugin = macroPlugin("batch-edit-entry-name")
+        val record = AppRecord(
+            pluginQuickLaunchSlots = mapOf(
+                0 to PluginQuickLaunch(pluginName = "someone-else", params = null),
+            ),
+        )
+        val callbacks = Callbacks()
+        val state = createState(plugin, callbacks, store = AppRecordStore(record, cancelledScope()))
+
+        val message = runDialogAction(state) { state.import(memoryTarget(plugin.name, slot = 0)) }
+
+        assertEquals(stringStatic(Strings.PluginDialogImportFailure), message)
+        assertEquals(emptyList(), callbacks.loaded)
+    }
+
+    /* endregion */
+
+    companion object {
+
+        private val macroPlugins: List<Plugin> by lazy {
+            TestEnv.ensureLogDirectory()
+            loadPlugins(Plugin.Type.Macro, Language.English)
+        }
+
+        private val templatePlugins: List<Plugin> by lazy {
+            TestEnv.ensureLogDirectory()
+            loadPlugins(Plugin.Type.Template, Language.English)
+        }
+
+        private fun macroPlugin(name: String): Plugin = macroPlugins.first { it.name == name }
+
+        private fun templatePlugin(name: String): Plugin = templatePlugins.first { it.name == name }
+    }
+}

--- a/src/jvmTest/kotlin/ui/PreferencesEditorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/PreferencesEditorStateTest.kt
@@ -1,0 +1,562 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.action.KeyAction
+import com.sdercolin.vlabeler.model.action.KeyActionKeyBind
+import com.sdercolin.vlabeler.model.key.Key
+import com.sdercolin.vlabeler.model.key.KeySet
+import com.sdercolin.vlabeler.repository.ColorPaletteRepository
+import com.sdercolin.vlabeler.ui.AppState
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesEditorState
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesItem
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesPage
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesPages
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.ui.string.stringStatic
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import testutil.TestEnv
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [PreferencesEditorState].
+ *
+ * [PreferencesEditorState] only stores its [AppState] (it is dereferenced solely by [PreferencesItem.Button]
+ * `onClick` handlers and by composables, none of which are exercised here), so the tests pass an uninitialized
+ * [AppState] instance allocated without running its constructor, following the pattern proven safe in
+ * [ProjectCreatorStateTest]. All file system access goes through the app directory redirected by `VLABELER_APP_DIR`
+ * (repositories) or through temp directories (import/export), so no user data is ever touched.
+ */
+class PreferencesEditorStateTest {
+
+    private val tempDirs = mutableListOf<File>()
+    private val submitted = mutableListOf<AppConf?>()
+    private val applied = mutableListOf<AppConf>()
+    private val viewedPages = mutableListOf<PreferencesPage>()
+    private val snackbars = mutableListOf<String>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        // the state's init block loads the repositories; ensure the palette directory (inside the redirected app
+        // directory) exists so that the preset palettes are available
+        ColorPaletteRepository.directory.mkdirs()
+    }
+
+    @AfterTest
+    fun teardown() {
+        tempDirs.forEach { it.deleteRecursively() }
+        tempDirs.clear()
+        submitted.clear()
+        applied.clear()
+        viewedPages.clear()
+        snackbars.clear()
+        Log.muted = false
+    }
+
+    private fun newTempDir(): File = createTempDirectory("vlabeler-test").toFile().also { tempDirs += it }
+
+    private fun uninitializedAppState(): AppState {
+        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(AppState::class.java) as AppState
+    }
+
+    private fun createState(
+        initConf: AppConf = AppConf(),
+        initialPage: PreferencesPage? = null,
+        launchArgs: PreferencesEditorState.LaunchArgs? = null,
+    ) = PreferencesEditorState(
+        appState = uninitializedAppState(),
+        initConf = initConf,
+        submit = { submitted += it },
+        apply = { applied += it },
+        initialPage = initialPage,
+        onViewPage = { viewedPages += it },
+        showSnackbar = { snackbars += it },
+        launchArgs = launchArgs,
+    )
+
+    private fun PreferencesEditorState.pageItem(model: PreferencesPage) = pages.first { it.model == model }
+
+    private val canvasResolutionItem = PreferencesPages.ChartsCanvas.content
+        .flatMap { it.items }
+        .filterIsInstance<PreferencesItem.IntegerInput>()
+        .first { it.title == Strings.PreferencesChartsCanvasResolutionDefault }
+
+    private val autoSaveIntervalItem = PreferencesPages.AutoSave.content
+        .flatMap { it.items }
+        .filterIsInstance<PreferencesItem.IntegerInput>()
+        .first { it.title == Strings.PreferencesAutoSaveIntervalSec }
+
+    private val historyMaxSizeItem = PreferencesPages.History.content
+        .flatMap { it.items }
+        .filterIsInstance<PreferencesItem.IntegerInput>()
+        .first { it.title == Strings.PreferencesHistoryMaxSize }
+
+    @Suppress("UNCHECKED_CAST")
+    private val keyActionKeymapItem = PreferencesPages.KeymapKeyAction.content
+        .flatMap { it.items }
+        .filterIsInstance<PreferencesItem.Keymap<*>>()
+        .single() as PreferencesItem.Keymap<KeyAction>
+
+    private val defaultKeyBinds = KeyAction.entries.map { KeyActionKeyBind(it, it.defaultKeySet) }
+
+    /* region initialization */
+
+    @Test
+    fun `initial pages are the collapsed root pages and the first one is selected`() {
+        val state = createState()
+        assertEquals(PreferencesPages.rootPages.toList(), state.pages.map { it.model })
+        assertTrue(state.pages.all { it.level == 0 })
+        assertTrue(state.pages.none { it.isExpanded })
+        assertEquals(state.pages.first(), state.selectedPage)
+        assertFalse(state.needSave)
+        assertFalse(state.isLaunchArgsHandled)
+        assertNull(state.launchArgs)
+    }
+
+    @Test
+    fun `initial page expands its ancestors and gets selected`() {
+        val state = createState(initialPage = PreferencesPages.ChartsSpectrogram)
+        val charts = state.pageItem(PreferencesPages.Charts)
+        assertTrue(charts.isExpanded)
+        val chartsIndex = state.pages.indexOf(charts)
+        assertEquals(
+            PreferencesPages.Charts.children,
+            state.pages.subList(chartsIndex + 1, chartsIndex + 1 + PreferencesPages.Charts.children.size)
+                .map { it.model },
+        )
+        assertTrue(state.pages.first { it.model == PreferencesPages.ChartsSpectrogram }.level == 1)
+        assertEquals(PreferencesPages.ChartsSpectrogram, state.selectedPage.model)
+        // other root pages stay collapsed
+        assertFalse(state.pageItem(PreferencesPages.Editor).isExpanded)
+    }
+
+    @Test
+    fun `initial root page is selected without expansion`() {
+        val state = createState(initialPage = PreferencesPages.Playback)
+        assertEquals(PreferencesPages.Playback, state.selectedPage.model)
+        assertTrue(state.pages.none { it.isExpanded })
+    }
+
+    @Test
+    fun `launch args take precedence over the initial page`() {
+        val state = createState(
+            initialPage = PreferencesPages.View,
+            launchArgs = PreferencesEditorState.LaunchArgs.Keymap("search text"),
+        )
+        assertEquals(PreferencesPages.KeymapKeyAction, state.selectedPage.model)
+        assertTrue(state.pageItem(PreferencesPages.Keymap).isExpanded)
+        assertEquals("search text", (state.launchArgs as PreferencesEditorState.LaunchArgs.Keymap).searchText)
+        assertFalse(state.isLaunchArgsHandled)
+    }
+
+    @Test
+    fun `init fixes a missing color palette to the default`() {
+        val badConf = AppConf().let {
+            it.copy(
+                painter = it.painter.copy(
+                    spectrogram = it.painter.spectrogram.copy(colorPalette = "__not-existing-palette__"),
+                ),
+            )
+        }
+        val state = createState(initConf = badConf)
+        assertEquals(AppConf.Spectrogram.DEFAULT_COLOR_PALETTE, state.conf.painter.spectrogram.colorPalette)
+        // the saved conf keeps the original value, so the fix is pending as an unsaved change
+        assertEquals("__not-existing-palette__", state.savedConf.painter.spectrogram.colorPalette)
+        assertTrue(state.needSave)
+    }
+
+    @Test
+    fun `init fixes a missing font family to the default`() {
+        val badConf = AppConf().let {
+            it.copy(view = it.view.copy(fontFamilyName = "__not-existing-font__"))
+        }
+        val state = createState(initConf = badConf)
+        assertEquals(AppConf.View.DEFAULT_FONT_FAMILY_NAME, state.conf.view.fontFamilyName)
+        assertTrue(state.needSave)
+    }
+
+    @Test
+    fun `init keeps a valid conf untouched`() {
+        val state = createState()
+        assertEquals(AppConf(), state.conf)
+        assertEquals(AppConf(), state.savedConf)
+        assertFalse(state.needSave)
+    }
+
+    /* endregion */
+
+    /* region page navigation */
+
+    @Test
+    fun `toggle page expands and collapses its children`() {
+        val state = createState()
+        val charts = state.pageItem(PreferencesPages.Charts)
+
+        state.togglePage(charts)
+        assertTrue(charts.isExpanded)
+        val chartsIndex = state.pages.indexOf(charts)
+        val childItems = state.pages.subList(chartsIndex + 1, chartsIndex + 1 + PreferencesPages.Charts.children.size)
+        assertEquals(PreferencesPages.Charts.children, childItems.map { it.model })
+        assertTrue(childItems.all { it.level == 1 })
+
+        state.togglePage(charts)
+        assertFalse(charts.isExpanded)
+        assertEquals(PreferencesPages.rootPages.toList(), state.pages.map { it.model })
+    }
+
+    @Test
+    fun `collapsing the page containing the selection moves the selection to the parent`() {
+        val state = createState()
+        val charts = state.pageItem(PreferencesPages.Charts)
+        state.togglePage(charts)
+        state.selectPage(state.pageItem(PreferencesPages.ChartsWaveform))
+        assertEquals(PreferencesPages.ChartsWaveform, state.selectedPage.model)
+
+        state.togglePage(charts)
+
+        assertEquals(PreferencesPages.Charts, state.selectedPage.model)
+        assertEquals(listOf(PreferencesPages.ChartsWaveform, PreferencesPages.Charts), viewedPages)
+    }
+
+    @Test
+    fun `collapsing a page keeps an unrelated selection`() {
+        val state = createState()
+        val charts = state.pageItem(PreferencesPages.Charts)
+        state.togglePage(charts)
+        state.selectPage(state.pageItem(PreferencesPages.View))
+
+        state.togglePage(charts)
+
+        assertEquals(PreferencesPages.View, state.selectedPage.model)
+    }
+
+    @Test
+    fun `select page reports the viewed page`() {
+        val state = createState()
+        state.selectPage(state.pageItem(PreferencesPages.Playback))
+        assertEquals(PreferencesPages.Playback, state.selectedPage.model)
+        assertEquals(listOf<PreferencesPage>(PreferencesPages.Playback), viewedPages)
+    }
+
+    @Test
+    fun `select page by link expands the selected parent when the target is not listed`() {
+        val state = createState()
+        state.selectPage(state.pageItem(PreferencesPages.Editor))
+
+        state.selectPageByLink(PreferencesPages.EditorScissors)
+
+        assertTrue(state.pageItem(PreferencesPages.Editor).isExpanded)
+        assertEquals(PreferencesPages.EditorScissors, state.selectedPage.model)
+    }
+
+    @Test
+    fun `select page by link uses the existing page item when listed`() {
+        val state = createState()
+        val pageCount = state.pages.size
+        state.selectPageByLink(PreferencesPages.View)
+        assertEquals(PreferencesPages.View, state.selectedPage.model)
+        assertEquals(pageCount, state.pages.size)
+    }
+
+    /* endregion */
+
+    /* region editing, saving and resetting */
+
+    @Test
+    fun `update rewrites the working conf but not the saved conf`() {
+        val state = createState()
+        val newValue = AppConf.CanvasResolution.DEFAULT_DEFAULT + 25
+
+        state.update(canvasResolutionItem, newValue)
+
+        assertEquals(newValue, state.conf.painter.canvasResolution.default)
+        assertEquals(AppConf(), state.savedConf)
+        assertTrue(state.needSave)
+        assertTrue(applied.isEmpty())
+    }
+
+    @Test
+    fun `save applies the working conf`() {
+        val state = createState()
+        val newValue = AppConf.CanvasResolution.DEFAULT_DEFAULT + 25
+        state.update(canvasResolutionItem, newValue)
+
+        state.save()
+
+        assertEquals(listOf(state.conf), applied)
+        assertEquals(state.conf, state.savedConf)
+        assertFalse(state.needSave)
+    }
+
+    @Test
+    fun `finish positively with pending changes submits the conf`() {
+        val state = createState()
+        state.update(canvasResolutionItem, AppConf.CanvasResolution.DEFAULT_DEFAULT + 25)
+        state.finish(positive = true)
+        assertEquals(listOf<AppConf?>(state.conf), submitted)
+    }
+
+    @Test
+    fun `finish positively without pending changes submits null`() {
+        val state = createState()
+        state.finish(positive = true)
+        assertEquals(listOf<AppConf?>(null), submitted)
+    }
+
+    @Test
+    fun `finish negatively discards pending changes`() {
+        val state = createState()
+        state.update(canvasResolutionItem, AppConf.CanvasResolution.DEFAULT_DEFAULT + 25)
+        state.finish(positive = false)
+        assertEquals(listOf<AppConf?>(null), submitted)
+    }
+
+    @Test
+    fun `reset page only resets the items of the selected page`() {
+        val state = createState()
+        state.update(autoSaveIntervalItem, AppConf.AutoSave.DEFAULT_INTERVAL_SEC + 100)
+        state.update(historyMaxSizeItem, AppConf.History.DEFAULT_MAX_SIZE + 100)
+        state.selectPage(state.pageItem(PreferencesPages.AutoSave))
+
+        state.resetPage()
+
+        assertEquals(AppConf.AutoSave.DEFAULT_INTERVAL_SEC, state.conf.autoSave.intervalSec)
+        assertEquals(AppConf.History.DEFAULT_MAX_SIZE + 100, state.conf.history.maxSize)
+    }
+
+    @Test
+    fun `reset all restores the default conf`() {
+        val state = createState()
+        state.update(autoSaveIntervalItem, AppConf.AutoSave.DEFAULT_INTERVAL_SEC + 100)
+        state.update(historyMaxSizeItem, AppConf.History.DEFAULT_MAX_SIZE + 100)
+
+        state.resetAll()
+
+        assertEquals(AppConf(), state.conf)
+        assertFalse(state.needSave)
+    }
+
+    /* endregion */
+
+    /* region keymap editing */
+
+    @Test
+    fun `open keymap item edit dialog exposes the dialog args`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+
+        val args = assertNotNull(state.keymapItemEditDialogArgs)
+        assertEquals(keyBind, args.actionKeyBind)
+        assertEquals(keyActionKeymapItem, args.keymapItem)
+        assertEquals(defaultKeyBinds, args.allKeyBinds)
+        assertNull(state.keymapItemEditConflictDialogArgs)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun PreferencesEditorState.submitKeymapEdit(edited: KeyActionKeyBind?) {
+        val args = assertNotNull(keymapItemEditDialogArgs) as PreferencesEditorState.KeymapItemEditDialogArgs<KeyAction>
+        args.submit(edited)
+    }
+
+    @Test
+    fun `submitting null closes the dialog without changes`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+
+        state.submitKeymapEdit(null)
+
+        assertNull(state.keymapItemEditDialogArgs)
+        assertEquals(AppConf(), state.conf)
+    }
+
+    @Test
+    fun `submitting a non-conflicting key bind stores it in the keymap`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+        val newKeySet = KeySet(Key.J, setOf(Key.Ctrl, Key.Alt, Key.Shift))
+
+        state.submitKeymapEdit(KeyActionKeyBind(KeyAction.NewProject, newKeySet))
+
+        assertNull(state.keymapItemEditDialogArgs)
+        assertNull(state.keymapItemEditConflictDialogArgs)
+        assertEquals(mapOf(KeyAction.NewProject to newKeySet), state.conf.keymaps.keyActionMap)
+        assertTrue(state.needSave)
+    }
+
+    @Test
+    fun `submitting the default key bind removes the custom entry`() {
+        val state = createState()
+        val customKeySet = KeySet(Key.J, setOf(Key.Ctrl, Key.Alt, Key.Shift))
+        state.update(keyActionKeymapItem, listOf(KeyActionKeyBind(KeyAction.NewProject, customKeySet)))
+        val keyBind = KeyActionKeyBind(KeyAction.NewProject, customKeySet)
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+
+        state.submitKeymapEdit(KeyActionKeyBind(KeyAction.NewProject, KeyAction.NewProject.defaultKeySet))
+
+        assertEquals(emptyMap(), state.conf.keymaps.keyActionMap)
+    }
+
+    @Test
+    fun `submitting a conflicting key bind opens the conflict dialog without applying`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+        val conflictingKeySet = assertNotNull(KeyAction.OpenProject.defaultKeySet)
+
+        state.submitKeymapEdit(KeyActionKeyBind(KeyAction.NewProject, conflictingKeySet))
+
+        assertNull(state.keymapItemEditDialogArgs)
+        val conflictArgs = assertNotNull(state.keymapItemEditConflictDialogArgs)
+        assertEquals(KeyActionKeyBind(KeyAction.NewProject, conflictingKeySet), conflictArgs.editedKeyBind)
+        assertEquals(
+            listOf<Any>(KeyActionKeyBind(KeyAction.OpenProject, conflictingKeySet)),
+            conflictArgs.conflictingKeyBinds,
+        )
+        // nothing is applied until the conflict is resolved
+        assertEquals(emptyMap(), state.conf.keymaps.keyActionMap)
+    }
+
+    @Test
+    fun `cancelling the conflict dialog keeps the conf unchanged`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+        val conflictingKeySet = assertNotNull(KeyAction.OpenProject.defaultKeySet)
+        state.submitKeymapEdit(KeyActionKeyBind(KeyAction.NewProject, conflictingKeySet))
+
+        assertNotNull(state.keymapItemEditConflictDialogArgs).cancel()
+
+        assertNull(state.keymapItemEditConflictDialogArgs)
+        assertEquals(AppConf(), state.conf)
+    }
+
+    @Test
+    fun `keeping the conflict applies the edited key bind and keeps the conflicting one`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+        val conflictingKeySet = assertNotNull(KeyAction.OpenProject.defaultKeySet)
+        state.submitKeymapEdit(KeyActionKeyBind(KeyAction.NewProject, conflictingKeySet))
+
+        assertNotNull(state.keymapItemEditConflictDialogArgs).keep()
+
+        assertNull(state.keymapItemEditConflictDialogArgs)
+        assertEquals(mapOf(KeyAction.NewProject to conflictingKeySet), state.conf.keymaps.keyActionMap)
+    }
+
+    @Test
+    fun `removing the conflict unbinds the conflicting key binds`() {
+        val state = createState()
+        val keyBind = defaultKeyBinds.first { it.action == KeyAction.NewProject }
+        state.openKeymapItemEditDialog(keyBind, keyActionKeymapItem, defaultKeyBinds)
+        val conflictingKeySet = assertNotNull(KeyAction.OpenProject.defaultKeySet)
+        state.submitKeymapEdit(KeyActionKeyBind(KeyAction.NewProject, conflictingKeySet))
+
+        assertNotNull(state.keymapItemEditConflictDialogArgs).remove()
+
+        assertNull(state.keymapItemEditConflictDialogArgs)
+        assertEquals(
+            mapOf(KeyAction.NewProject to conflictingKeySet, KeyAction.OpenProject to null),
+            state.conf.keymaps.keyActionMap,
+        )
+    }
+
+    /* endregion */
+
+    /* region import and export */
+
+    @Test
+    fun `export writes the current conf as json`() {
+        val state = createState()
+        state.update(canvasResolutionItem, AppConf.CanvasResolution.DEFAULT_DEFAULT + 25)
+        val dir = newTempDir()
+        state.currentFilePicker = PreferencesEditorState.FilePicker.Export
+
+        state.handleFilePickerResult(PreferencesEditorState.FilePicker.Export, dir.absolutePath, "exported.json")
+
+        assertNull(state.currentFilePicker)
+        val written = dir.resolve("exported.json").readText().parseJson<AppConf>()
+        assertEquals(state.conf, written)
+        assertEquals(listOf(stringStatic(Strings.PreferencesEditorExportSuccess)), snackbars)
+    }
+
+    @Test
+    fun `export failure shows the failure snackbar`() {
+        val state = createState()
+        val missingDir = newTempDir().resolve("not-existing")
+
+        state.handleFilePickerResult(PreferencesEditorState.FilePicker.Export, missingDir.absolutePath, "out.json")
+
+        assertEquals(listOf(stringStatic(Strings.PreferencesEditorExportFailure)), snackbars)
+    }
+
+    @Test
+    fun `import replaces the working conf`() {
+        val state = createState()
+        val imported = AppConf().let {
+            it.copy(history = it.history.copy(maxSize = AppConf.History.DEFAULT_MAX_SIZE + 42))
+        }
+        val file = newTempDir().resolve("in.json").apply { writeText(imported.stringifyJson()) }
+
+        state.handleFilePickerResult(PreferencesEditorState.FilePicker.Import, file.parent, file.name)
+
+        assertNull(state.currentFilePicker)
+        assertEquals(imported, state.conf)
+        assertTrue(state.needSave)
+        assertEquals(listOf(stringStatic(Strings.PreferencesEditorImportSuccess)), snackbars)
+    }
+
+    @Test
+    fun `import of an invalid file keeps the conf and shows the failure snackbar`() {
+        val state = createState()
+        val file = newTempDir().resolve("in.json").apply { writeText("this is not json") }
+
+        state.handleFilePickerResult(PreferencesEditorState.FilePicker.Import, file.parent, file.name)
+
+        assertEquals(AppConf(), state.conf)
+        assertEquals(listOf(stringStatic(Strings.PreferencesEditorImportFailure)), snackbars)
+    }
+
+    @Test
+    fun `a cancelled file picker only closes itself`() {
+        val state = createState()
+        state.currentFilePicker = PreferencesEditorState.FilePicker.Import
+
+        state.handleFilePickerResult(PreferencesEditorState.FilePicker.Import, null, null)
+
+        assertNull(state.currentFilePicker)
+        assertEquals(AppConf(), state.conf)
+        assertTrue(snackbars.isEmpty())
+    }
+
+    @Test
+    fun `file picker definitions`() {
+        assertFalse(PreferencesEditorState.FilePicker.Import.writeMode)
+        assertNull(PreferencesEditorState.FilePicker.Import.initialFileName)
+        assertEquals(listOf("json"), PreferencesEditorState.FilePicker.Import.extensions)
+        assertTrue(PreferencesEditorState.FilePicker.Export.writeMode)
+        assertEquals("vLabeler.conf.json", PreferencesEditorState.FilePicker.Export.initialFileName)
+        assertEquals(listOf("json"), PreferencesEditorState.FilePicker.Export.extensions)
+    }
+
+    /* endregion */
+}

--- a/src/jvmTest/kotlin/ui/PreferencesKeymapStateTest.kt
+++ b/src/jvmTest/kotlin/ui/PreferencesKeymapStateTest.kt
@@ -1,0 +1,134 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.action.KeyAction
+import com.sdercolin.vlabeler.model.action.KeyActionKeyBind
+import com.sdercolin.vlabeler.model.key.Key
+import com.sdercolin.vlabeler.model.key.KeySet
+import com.sdercolin.vlabeler.repository.ColorPaletteRepository
+import com.sdercolin.vlabeler.ui.AppState
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesEditorState
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesItem
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesKeymapState
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesPages
+import com.sdercolin.vlabeler.ui.string.Language
+import testutil.TestEnv
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [PreferencesKeymapState]. See [PreferencesEditorStateTest] for the safety argument of the uninitialized
+ * [AppState] construction.
+ */
+class PreferencesKeymapStateTest {
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        ColorPaletteRepository.directory.mkdirs()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private fun uninitializedAppState(): AppState {
+        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(AppState::class.java) as AppState
+    }
+
+    private fun createEditorState(initConf: AppConf = AppConf()) = PreferencesEditorState(
+        appState = uninitializedAppState(),
+        initConf = initConf,
+        submit = {},
+        apply = {},
+        initialPage = null,
+        onViewPage = {},
+        showSnackbar = {},
+        launchArgs = null,
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private val keyActionKeymapItem = PreferencesPages.KeymapKeyAction.content
+        .flatMap { it.items }
+        .filterIsInstance<PreferencesItem.Keymap<*>>()
+        .single() as PreferencesItem.Keymap<KeyAction>
+
+    private fun createKeymapState(initConf: AppConf = AppConf()) =
+        PreferencesKeymapState(keyActionKeymapItem, createEditorState(initConf))
+
+    private val customKeySet = KeySet(Key.J, setOf(Key.Ctrl, Key.Alt, Key.Shift))
+
+    private fun confWithCustomBind(action: KeyAction, keySet: KeySet): AppConf = AppConf().let {
+        it.copy(keymaps = it.keymaps.copy(keyActionMap = mapOf(action to keySet)))
+    }
+
+    @Test
+    fun `all key binds cover every key action with its default key set`() {
+        val state = createKeymapState()
+        assertEquals(KeyAction.entries.size, state.allKeyBinds.size)
+        assertEquals(
+            KeyAction.entries.sortedBy { it.displayOrder }.map { KeyActionKeyBind(it, it.defaultKeySet) },
+            state.allKeyBinds,
+        )
+        assertEquals(state.allKeyBinds, state.displayedKeyBinds)
+        assertEquals("", state.searchText)
+    }
+
+    @Test
+    fun `a custom key bind replaces the default one`() {
+        val state = createKeymapState(confWithCustomBind(KeyAction.SaveProject, customKeySet))
+        assertEquals(KeyAction.entries.size, state.allKeyBinds.size)
+        assertEquals(
+            KeyActionKeyBind(KeyAction.SaveProject, customKeySet),
+            state.allKeyBinds.single { it.action == KeyAction.SaveProject },
+        )
+    }
+
+    @Test
+    fun `search filters the displayed key binds by title`() {
+        val state = createKeymapState()
+        state.search("save", Language.English)
+
+        assertEquals("save", state.searchText)
+        assertTrue(state.displayedKeyBinds.isNotEmpty())
+        assertTrue(
+            state.displayedKeyBinds.all {
+                it.getTitle(Language.English).contains("save", ignoreCase = true)
+            },
+        )
+        assertTrue(state.displayedKeyBinds.any { it.action == KeyAction.SaveProject })
+        // the full list stays intact
+        assertEquals(KeyAction.entries.size, state.allKeyBinds.size)
+    }
+
+    @Test
+    fun `clearing the search restores all key binds`() {
+        val state = createKeymapState()
+        state.search("save", Language.English)
+        state.search("", Language.English)
+        assertEquals(state.allKeyBinds, state.displayedKeyBinds)
+    }
+
+    @Test
+    fun `update refreshes the key binds and keeps the search text`() {
+        val state = createKeymapState()
+        state.search("save", Language.English)
+
+        state.update(confWithCustomBind(KeyAction.SaveProject, customKeySet), Language.English)
+
+        assertEquals("save", state.searchText)
+        assertEquals(
+            customKeySet,
+            state.displayedKeyBinds.single { it.action == KeyAction.SaveProject }.keySet,
+        )
+    }
+}

--- a/src/jvmTest/kotlin/ui/PreferencesPagesTraversalTest.kt
+++ b/src/jvmTest/kotlin/ui/PreferencesPagesTraversalTest.kt
@@ -84,13 +84,6 @@ class PreferencesPagesTraversalTest {
     private fun List<LocatedItem>.valued(): List<Pair<String, PreferencesItem.Valued<*>>> =
         mapNotNull { (location, item) -> (item as? PreferencesItem.Valued<*>)?.let { location to it } }
 
-    /**
-     * Items whose declared `defaultValue` does not match the default of the [AppConf] field they operate on.
-     * These are excluded from the default-consistency assertions and pinned in dedicated tests instead.
-     */
-    private fun isKnownDefaultMismatch(location: String) =
-        location.contains(Strings.PreferencesChartsMaxDataChunkSize.name)
-
     /** Produces a value for the item that differs from its default value, or null if none can be derived. */
     private fun mutatedValueFor(item: PreferencesItem.Valued<*>): Any? = when (item) {
         is PreferencesItem.Switch -> item.defaultValue.not()
@@ -172,7 +165,7 @@ class PreferencesPagesTraversalTest {
     fun `every valued item declares the default value of its own conf field`() {
         val items = allItems().valued()
         assertTrue(items.size >= 100, "expected the traversal to find at least 100 valued items, got ${items.size}")
-        items.filterNot { (location, _) -> isKnownDefaultMismatch(location) }
+        items
             .forEach { (location, item) ->
                 assertEquals(
                     item.defaultValue,
@@ -194,7 +187,6 @@ class PreferencesPagesTraversalTest {
     @Test
     fun `every valued item resets its page copy exactly back to the default conf`() {
         allItems().valued()
-            .filterNot { (location, _) -> isKnownDefaultMismatch(location) }
             .forEach { (location, item) ->
                 @Suppress("UNCHECKED_CAST")
                 val valuedItem = item as PreferencesItem.Valued<Any?>
@@ -266,23 +258,6 @@ class PreferencesPagesTraversalTest {
         }
     }
 
-    /**
-     * Pins a suspected copy-paste bug in [PreferencesPages.ChartsCanvas]: the "max data chunk size" item declares
-     * `defaultValue = AppConf.CanvasResolution.DEFAULT_STEP` (= 20) instead of
-     * `AppConf.Painter.DEFAULT_MAX_DATA_CHUNK_SIZE` (= 441000). Resetting the item (or the Charts/Canvas page) sets
-     * `painter.maxDataChunkSize` to 20, far below the item's own minimum of
-     * [AppConf.Painter.MIN_MAX_DATA_CHUNK_SIZE]. If this test fails, the bug has been fixed: remove this test and the
-     * corresponding known-mismatch exclusion above.
-     */
-    @Test
-    fun `known issue - max data chunk size item declares the canvas resolution step as its default`() {
-        val (_, item) = allItems().valued().single { (location, _) -> isKnownDefaultMismatch(location) }
-        assertEquals(AppConf.CanvasResolution.DEFAULT_STEP, item.defaultValue)
-        assertEquals(AppConf.Painter.DEFAULT_MAX_DATA_CHUNK_SIZE, item.select(AppConf()))
-        assertNotEquals(item.defaultValue, item.select(AppConf()))
-    }
-
-    @Test
     fun `keymap pages expose exactly one keymap item of their action type`() {
         val expectations = mapOf(
             PreferencesPages.KeymapKeyAction to ActionType.Key,

--- a/src/jvmTest/kotlin/ui/PreferencesPagesTraversalTest.kt
+++ b/src/jvmTest/kotlin/ui/PreferencesPagesTraversalTest.kt
@@ -1,0 +1,299 @@
+package ui
+
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.action.ActionType
+import com.sdercolin.vlabeler.model.action.KeyAction
+import com.sdercolin.vlabeler.model.action.KeyActionKeyBind
+import com.sdercolin.vlabeler.model.action.MouseClickAction
+import com.sdercolin.vlabeler.model.action.MouseClickActionKeyBind
+import com.sdercolin.vlabeler.model.action.MouseScrollAction
+import com.sdercolin.vlabeler.model.action.MouseScrollActionKeyBind
+import com.sdercolin.vlabeler.model.key.Key
+import com.sdercolin.vlabeler.model.key.KeySet
+import com.sdercolin.vlabeler.repository.ColorPaletteRepository
+import com.sdercolin.vlabeler.repository.FontRepository
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesItem
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesPage
+import com.sdercolin.vlabeler.ui.dialog.preferences.PreferencesPages
+import com.sdercolin.vlabeler.ui.string.Strings
+import com.sdercolin.vlabeler.util.parseJson
+import com.sdercolin.vlabeler.util.stringifyJson
+import testutil.TestEnv
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Exhaustive traversal of all [PreferencesPages] definitions.
+ *
+ * For every [PreferencesItem.Valued] item on every page, these tests assert that the item's `select`/`update`/`reset`
+ * lambdas operate on the same [AppConf] field, so a copy-paste error in the big declarative page definitions (a
+ * getter reading field A while the setter writes field B, an update touching more fields than it should, or two items
+ * writing to the same field) fails the suite. The harness itself is verified by
+ * [traversal harness detects an artificial select update field mismatch].
+ */
+class PreferencesPagesTraversalTest {
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        // Make the repository-backed selection items (spectrogram color palette, view font family) provide their
+        // real options. The app directory is redirected to the build directory via VLABELER_APP_DIR in tests, so
+        // only preset/built-in entries are loaded and no user data is touched.
+        ColorPaletteRepository.directory.mkdirs()
+        ColorPaletteRepository.load()
+        FontRepository.load()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Log.muted = false
+    }
+
+    private fun allPages(): List<PreferencesPage> {
+        val result = mutableListOf<PreferencesPage>()
+        fun visit(page: PreferencesPage) {
+            result.add(page)
+            page.children.forEach { visit(it) }
+        }
+        PreferencesPages.rootPages.forEach { visit(it) }
+        return result
+    }
+
+    /** A [PreferencesItem] together with a human-readable location used in assertion messages. */
+    private data class LocatedItem(val location: String, val item: PreferencesItem)
+
+    private fun allItems(): List<LocatedItem> = allPages().flatMap { page ->
+        // `content` is a `get() =` property, so it is captured exactly once here; all assertions of a test run
+        // operate on the same item instances.
+        page.content.flatMapIndexed { groupIndex, group ->
+            group.items.mapIndexed { itemIndex, item ->
+                val title = item.title?.name ?: item::class.simpleName
+                LocatedItem("${page.name}[$groupIndex][$itemIndex]($title)", item)
+            }
+        }
+    }
+
+    private fun List<LocatedItem>.valued(): List<Pair<String, PreferencesItem.Valued<*>>> =
+        mapNotNull { (location, item) -> (item as? PreferencesItem.Valued<*>)?.let { location to it } }
+
+    /**
+     * Items whose declared `defaultValue` does not match the default of the [AppConf] field they operate on.
+     * These are excluded from the default-consistency assertions and pinned in dedicated tests instead.
+     */
+    private fun isKnownDefaultMismatch(location: String) =
+        location.contains(Strings.PreferencesChartsMaxDataChunkSize.name)
+
+    /** Produces a value for the item that differs from its default value, or null if none can be derived. */
+    private fun mutatedValueFor(item: PreferencesItem.Valued<*>): Any? = when (item) {
+        is PreferencesItem.Switch -> item.defaultValue.not()
+        is PreferencesItem.IntegerInput -> {
+            val min = item.min
+            val max = item.max
+            listOfNotNull(item.defaultValue + 1, item.defaultValue - 1, min, max)
+                .first { it != item.defaultValue && (min == null || it >= min) && (max == null || it <= max) }
+        }
+        is PreferencesItem.FloatInput -> {
+            val min = item.min
+            val max = item.max
+            listOfNotNull(item.defaultValue + 1f, item.defaultValue - 1f, item.defaultValue / 2f, min, max)
+                .first { it != item.defaultValue && (min == null || it >= min) && (max == null || it <= max) }
+        }
+        is PreferencesItem.ColorStringInput ->
+            listOf(if (item.useAlpha) "#80123456" else "#123456", "#654321").first { it != item.defaultValue }
+        is PreferencesItem.StringInput -> item.defaultValue + "-modified"
+        is PreferencesItem.StringListInput -> item.defaultValue + "added-entry"
+        is PreferencesItem.Selection -> item.options.firstOrNull { it != item.defaultValue }
+        is PreferencesItem.Keymap<*> -> when (item.actionType) {
+            ActionType.Key -> listOf(
+                KeyActionKeyBind(KeyAction.NewProject, KeySet(Key.K, setOf(Key.Alt))),
+            )
+            ActionType.MouseClick -> listOf(
+                MouseClickActionKeyBind(MouseClickAction.MoveParameter, KeySet(Key.MouseRightClick, setOf(Key.Alt))),
+            )
+            ActionType.MouseScroll -> listOf(
+                MouseScrollActionKeyBind(MouseScrollAction.GoToNextEntry, KeySet(Key.MouseScrollUp, setOf(Key.Alt))),
+            )
+        }
+    }
+
+    /**
+     * Asserts that setting a non-default value via the item's `update` is read back by the item's `select`, actually
+     * changes the conf, and survives a serialization round trip. Returns the updated conf, or null if no alternative
+     * value exists for the item (single-option selections).
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun assertItemRoundTrip(location: String, item: PreferencesItem.Valued<*>): AppConf? {
+        val valuedItem = item as PreferencesItem.Valued<Any?>
+        val newValue = runCatching { mutatedValueFor(item) }
+            .getOrElse { fail("$location: cannot generate a modified test value", it) }
+            ?: return null
+        assertNotEquals(item.defaultValue, newValue, "$location: generated test value equals the default")
+
+        val updated = valuedItem.update(AppConf(), newValue)
+        assertEquals(newValue, valuedItem.select(updated), "$location: select does not read back the updated value")
+        assertNotEquals(AppConf(), updated, "$location: update did not change the conf")
+
+        val reserialized = updated.stringifyJson().parseJson<AppConf>()
+        assertEquals(newValue, valuedItem.select(reserialized), "$location: value lost in serialization round trip")
+
+        val reset = valuedItem.reset(updated)
+        assertEquals(item.defaultValue, valuedItem.select(reset), "$location: reset does not restore the default")
+        return updated
+    }
+
+    @Test
+    fun `all pages are reachable and distinct`() {
+        val pages = allPages()
+        assertEquals(pages.size, pages.distinct().size, "duplicated page in the tree")
+        // 9 root pages + 6 charts children + 3 keymap children + 6 editor children
+        assertEquals(24, pages.size)
+        pages.forEach { page ->
+            assertEquals(page.displayedName.name, page.name)
+        }
+    }
+
+    @Test
+    fun `every item enabled lambda evaluates on the default conf`() {
+        allItems().forEach { (_, item) ->
+            // executes the declarative `enabled` lambdas; must not throw
+            item.enabled(AppConf())
+        }
+    }
+
+    @Test
+    fun `every valued item declares the default value of its own conf field`() {
+        val items = allItems().valued()
+        assertTrue(items.size >= 100, "expected the traversal to find at least 100 valued items, got ${items.size}")
+        items.filterNot { (location, _) -> isKnownDefaultMismatch(location) }
+            .forEach { (location, item) ->
+                assertEquals(
+                    item.defaultValue,
+                    item.select(AppConf()),
+                    "$location: declared default value differs from the AppConf field default",
+                )
+            }
+    }
+
+    @Test
+    fun `every valued item round-trips a modified value and resets back to its default`() {
+        var mutated = 0
+        allItems().valued().forEach { (location, item) ->
+            if (assertItemRoundTrip(location, item) != null) mutated++
+        }
+        assertTrue(mutated >= 100, "expected at least 100 items to be mutated, got $mutated")
+    }
+
+    @Test
+    fun `every valued item resets its page copy exactly back to the default conf`() {
+        allItems().valued()
+            .filterNot { (location, _) -> isKnownDefaultMismatch(location) }
+            .forEach { (location, item) ->
+                @Suppress("UNCHECKED_CAST")
+                val valuedItem = item as PreferencesItem.Valued<Any?>
+                val newValue = mutatedValueFor(item) ?: return@forEach
+                val updated = valuedItem.update(AppConf(), newValue)
+                assertEquals(
+                    AppConf(),
+                    valuedItem.reset(updated),
+                    "$location: reset does not restore the exact default conf, the update touches other fields",
+                )
+            }
+    }
+
+    @Test
+    fun `valued items write to distinct conf fields`() {
+        val updatedConfs = allItems().valued().mapNotNull { (location, item) ->
+            @Suppress("UNCHECKED_CAST")
+            val valuedItem = item as PreferencesItem.Valued<Any?>
+            val newValue = runCatching { mutatedValueFor(item) }
+                .getOrElse { fail("$location: cannot generate a modified test value", it) }
+                ?: return@mapNotNull null
+            location to valuedItem.update(AppConf(), newValue)
+        }
+        val collisions = updatedConfs.groupBy({ it.second }, { it.first }).filterValues { it.size > 1 }
+        assertTrue(
+            collisions.isEmpty(),
+            "items produced identical updated confs (same field written): ${collisions.values}",
+        )
+    }
+
+    @Test
+    fun `traversal harness detects an artificial select update field mismatch`() {
+        // select reads view.hideSampleExtension but update writes misc.useCustomFileDialog
+        val mismatchedItem = PreferencesItem.Switch(
+            title = Strings.PreferencesViewHideSampleExtension,
+            description = null,
+            clickableTags = listOf(),
+            columnStyle = false,
+            defaultValue = AppConf().view.hideSampleExtension,
+            select = { it.view.hideSampleExtension },
+            update = { copy(misc = misc.copy(useCustomFileDialog = it)) },
+            enabled = { true },
+        )
+        assertFails { assertItemRoundTrip("artificial-mismatch", mismatchedItem) }
+    }
+
+    @Test
+    fun `traversal harness detects an artificial update touching an extra field`() {
+        // update writes the selected field but also flips an unrelated one, which reset cannot restore
+        val overreachingItem = PreferencesItem.Switch(
+            title = Strings.PreferencesViewHideSampleExtension,
+            description = null,
+            clickableTags = listOf(),
+            columnStyle = false,
+            defaultValue = AppConf().view.hideSampleExtension,
+            select = { it.view.hideSampleExtension },
+            update = {
+                copy(
+                    view = view.copy(hideSampleExtension = it),
+                    misc = misc.copy(useCustomFileDialog = true),
+                )
+            },
+            enabled = { true },
+        )
+        val newValue = AppConf().view.hideSampleExtension.not()
+        val updated = overreachingItem.update(AppConf(), newValue)
+        assertFails {
+            assertEquals(AppConf(), overreachingItem.reset(updated))
+        }
+    }
+
+    /**
+     * Pins a suspected copy-paste bug in [PreferencesPages.ChartsCanvas]: the "max data chunk size" item declares
+     * `defaultValue = AppConf.CanvasResolution.DEFAULT_STEP` (= 20) instead of
+     * `AppConf.Painter.DEFAULT_MAX_DATA_CHUNK_SIZE` (= 441000). Resetting the item (or the Charts/Canvas page) sets
+     * `painter.maxDataChunkSize` to 20, far below the item's own minimum of
+     * [AppConf.Painter.MIN_MAX_DATA_CHUNK_SIZE]. If this test fails, the bug has been fixed: remove this test and the
+     * corresponding known-mismatch exclusion above.
+     */
+    @Test
+    fun `known issue - max data chunk size item declares the canvas resolution step as its default`() {
+        val (_, item) = allItems().valued().single { (location, _) -> isKnownDefaultMismatch(location) }
+        assertEquals(AppConf.CanvasResolution.DEFAULT_STEP, item.defaultValue)
+        assertEquals(AppConf.Painter.DEFAULT_MAX_DATA_CHUNK_SIZE, item.select(AppConf()))
+        assertNotEquals(item.defaultValue, item.select(AppConf()))
+    }
+
+    @Test
+    fun `keymap pages expose exactly one keymap item of their action type`() {
+        val expectations = mapOf(
+            PreferencesPages.KeymapKeyAction to ActionType.Key,
+            PreferencesPages.KeymapMouseClickAction to ActionType.MouseClick,
+            PreferencesPages.KeymapMouseScrollAction to ActionType.MouseScroll,
+        )
+        expectations.forEach { (page, actionType) ->
+            val items = page.content.flatMap { it.items }
+            val keymapItem = items.filterIsInstance<PreferencesItem.Keymap<*>>().singleOrNull()
+                ?: fail("${page.name}: expected exactly one keymap item")
+            assertEquals(actionType, keymapItem.actionType, page.name)
+        }
+    }
+}

--- a/src/jvmTest/kotlin/ui/ProjectCreatorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/ProjectCreatorStateTest.kt
@@ -48,7 +48,7 @@ import kotlin.test.assertTrue
  *
  * The [AppRecordStore] is constructed with an already-cancelled scope so that its `collectAndWrite()` loop never
  * runs and nothing is ever written to the real application directory. This safety assumption is itself asserted in
- * [app record store on cancelled scope never updates or writes the record file].
+ * [app record store on cancelled scope updates in memory but never writes the record file].
  */
 class ProjectCreatorStateTest {
 
@@ -107,13 +107,14 @@ class ProjectCreatorStateTest {
     /* region AppRecordStore safety */
 
     @Test
-    fun `app record store on cancelled scope never updates or writes the record file`() {
+    fun `app record store on cancelled scope updates in memory but never writes the record file`() {
         val before = Triple(AppRecordFile.exists(), AppRecordFile.lastModified(), AppRecordFile.length())
         val store = AppRecordStore(AppRecord(), cancelledScope())
         store.update { copy(autoExport = true) }
         // longer than the 500 ms write throttle in AppRecordStore
         Thread.sleep(800)
-        assertEquals(AppRecord(), store.value)
+        // updates are synchronous and in-memory only; the write collector never runs on a cancelled scope
+        assertEquals(AppRecord(autoExport = true), store.value)
         val after = Triple(AppRecordFile.exists(), AppRecordFile.lastModified(), AppRecordFile.length())
         assertEquals(before, after)
     }


### PR DESCRIPTION
## Summary

Final batch from the [coverage plan Trello card](https://trello.com/c/WFKEU7I2) — checklist items 5–8: **160 new tests (873 total), line coverage 36.2% → 45.2%**, koverVerify bound raised 34 → 43.

### 5. Preferences editor (54 tests)
`PreferencesEditorState` navigation/expansion, editing with working-copy semantics, save/finish/reset (item/page/all), keymap editing with conflict resolution, import/export with exact snackbar messages — plus a **traversal harness over all 24 pages and 104 preference items** verifying each item's default, getter/setter field binding, serialization survival, reset exactness, and pairwise field distinctness (self-validated against artificial defects, kept as permanent `assertFails` checks).

### 6. io remainder (34 tests)
Quick-edit project construction through the real `quickProjectBuilder.js` of both UTAU labelers, `ImportProject` edge cases (malformed JSON, legacy formats, module dedup, compatibility checks), `Initialization` (directory setup, app-conf load/fallback/persist, migration, global repositories) against the redirected app dir, and labeler-conf install/load round trips.

### 7. Dialog states (72 tests)
Plugin/labeler dialog param editing and validation, preset import/export and saved-params round trips (redirected `RecordDir`), quick-launch slots via a live `AppRecordStore`, entry-selector expression parsing/evaluation with real JS, and the customization managers with full install → list → uninstall round trips of real labelers/plugins.

### 8. Housekeeping
Release workflows upgraded to `checkout@v4`/`setup-java@v4` (last Node-20 deprecations); coverage bound raised to 43.

### Bugs found by these tests — fixed in this PR (commit 6e64fbe3)
1. **Preferences "max data chunk size" wrong default**: declared `CanvasResolution.DEFAULT_STEP` (20) instead of `Painter.DEFAULT_MAX_DATA_CHUNK_SIZE` (441000) — resetting the item/page set a value below the item's own `min`; fixed, and the traversal harness now verifies it like every other item
2. **Import "meta" backcompat dead in debug**: the legacy-`meta` key is now stripped before strict entry decoding, so the compat branch works identically in debug and packaged runs (new regression test included)
3. **`AppRecordStore.update` race** (root cause of the `runMigration` double-update loss): the state flow is now updated atomically and synchronously via `MutableStateFlow.update`; persistence stays async/throttled. The previously untestable minor-version migration branch is now deterministic and tested.

Minor pinned quirks left as-is (documented behavior, not fixed): `EntrySelectorParam.check` false without a project; `LogicalExpression.parse` inconsistent exception types; `BasePluginDialogState.canSave` index-based list comparison

### Testability refactor candidates (described, not applied)
Extract `buildQuickEditRequest` from `startQuickEdit` (AppState-free); narrow host interface for `CustomizableItemManagerDialogState` (reload/showError/snackbar/closeDialog); make `importNewItem` `internal`; hoist `ParamEntrySelector`'s expression validity out of the composable.

## Test plan

- [x] `./gradlew jvmTest` — 873 tests, 0 failures, 0 skipped
- [x] `./gradlew koverVerify ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

