### PR TITLE
Coverage round 2 batch A: editor core, timescale, drag editions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,9 +151,9 @@ registerTestSubset(
 koverReport {
     defaults {
         verify {
-            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 45% on 2026-07-08).
+            // Guards against coverage regressions; raise the bound as coverage grows (baseline: 49% on 2026-07-09).
             rule("Minimal line coverage") {
-                minBound(43)
+                minBound(47)
             }
         }
     }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -108,7 +108,10 @@ Notes:
 
 State-holder classes (`ui/ProjectStore.kt`, `AppErrorState`, dialog states, ...) are plain classes over Compose
 `mutableStateOf` and are tested without rendering — see `ui/ProjectStoreTest.kt`, which drives the real
-implementations against fixture projects.
+implementations against fixture projects. For classes that require an `AppState` (which cannot be constructed in
+tests because it binds the IPC port and starts analytics/audio), `ui/EditorStateTest.kt` shows the furthest-going
+pattern: an uninitialized instance via `sun.misc.Unsafe` with real members injected reflectively, giving a
+functional editor against real sample loading and chart rendering.
 
 ### Environment gotchas
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/model/filter/EntryFilter.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/model/filter/EntryFilter.kt
@@ -94,8 +94,7 @@ data class EntryFilter(
 
     fun getFilteredIndexes(entries: List<Entry>, labelerConf: LabelerConf): List<Int> {
         if (advanced != null) {
-            val js = JavaScript()
-            return advanced.select(entries, labelerConf, js)
+            return JavaScript().use { js -> advanced.select(entries, labelerConf, js) }
         }
         return entries.indices.filter { matchBasic(entries[it]) }
     }

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/ChartStore.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/ChartStore.kt
@@ -84,7 +84,7 @@ class ChartStore {
         }
         currentSampleInfo = sampleInfo
         job?.cancel()
-        initializeStates(sampleInfo.chunkCount, sampleInfo.channels)
+        initializeStates(sampleInfo, appConf)
         ChartRepository.init(project, appConf, PAINTING_ALGORITHM_VERSION)
         return true
     }
@@ -163,14 +163,17 @@ class ChartStore {
     suspend fun awaitLoad() = job?.join()
 
     private fun initializeStates(
-        chunkCount: Int,
-        channelCount: Int,
+        sampleInfo: SampleInfo,
+        appConf: AppConf,
     ) {
-        repeat(chunkCount) { chunkIndex ->
-            repeat(channelCount) { channelIndex ->
+        repeat(sampleInfo.chunkCount) { chunkIndex ->
+            repeat(sampleInfo.channels) { channelIndex ->
                 waveformStatusList[channelIndex to chunkIndex] = ChartLoadingStatus.Loading
             }
-            spectrogramStatusList[chunkIndex] = ChartLoadingStatus.Loading
+            // matches the rendering condition, so the status does not stay Loading forever when disabled
+            if (sampleInfo.hasSpectrogram && appConf.painter.spectrogram.enabled) {
+                spectrogramStatusList[chunkIndex] = ChartLoadingStatus.Loading
+            }
         }
     }
 

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/Marker.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/Marker.kt
@@ -879,14 +879,32 @@ internal fun MarkerState.editEntryIfNeeded(
             else -> labelerConf.fields[pointIndex].name
         }
 
+        fun getChangedFieldNames(entry: EntryInPixel): List<String> {
+            val original = entriesInPixel.first { it.index == entry.index }
+            return buildList {
+                if (entry.start != original.start) add("start")
+                labelerConf.fields.forEachIndexed { index, field ->
+                    if (entry.points[index] != original.points[index]) add(field.name)
+                }
+                if (entry.end != original.end) add("end")
+            }
+        }
+
         val editions = edited.map { entry ->
             val entryInMillis = entryConverter.convertToMillis(entry)
             val entryIndexInEdited = updated.indexOfFirst { it.index == entry.index }
-            val editedFieldName = getEditedFieldName(getPointIndexAsSingleEntry(entryIndexInEdited, pointIndex))
+            val pointIndexAsSingleEntry = getPointIndexAsSingleEntry(entryIndexInEdited, pointIndex)
+            val fieldNames = if (pointIndexAsSingleEntry == MarkerCursorState.NONE_POINT_INDEX) {
+                // this entry does not own the dragged point (e.g. it is co-moved by a locked drag),
+                // so list the fields that actually changed instead
+                getChangedFieldNames(entry)
+            } else {
+                listOf(getEditedFieldName(pointIndexAsSingleEntry))
+            }
             Edition(
                 entry.index,
                 entryInMillis.entry,
-                fieldNames = listOf(editedFieldName),
+                fieldNames = fieldNames,
                 method = method,
             )
         }.toMutableList()

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/Marker.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/Marker.kt
@@ -862,7 +862,8 @@ private fun MarkerState.handleScissorsCut(
     cutEntry(entryIndex, timePosition, position)
 }
 
-private fun MarkerState.editEntryIfNeeded(
+// internal for testing: this is the drag-result -> Edition conversion, the core of committing a drag operation
+internal fun MarkerState.editEntryIfNeeded(
     updated: List<EntryInPixel>,
     editEntries: (List<Edition>) -> Unit,
     method: Edition.Method,

--- a/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerState.kt
+++ b/src/jvmMain/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerState.kt
@@ -101,7 +101,9 @@ class MarkerState(
         val endPointIndex = if (entryIndex == entryIndices.last()) {
             MarkerCursorState.END_POINT_INDEX
         } else {
-            startPointIndex + labelerConf.fields.size + 1
+            // the end border's flattened index, derived from the entry index directly (not from startPointIndex,
+            // which is overridden to START_POINT_INDEX for the first entry and would otherwise mis-compute it)
+            (entryIndex + 1) * (labelerConf.fields.size + 1) - 1
         }
         return when (pointIndex) {
             startPointIndex -> MarkerCursorState.START_POINT_INDEX
@@ -112,7 +114,9 @@ class MarkerState(
                 } else {
                     (startPointIndex + 1) until (startPointIndex + 1 + labelerConf.fields.size)
                 }
-                fieldPointIndexes.indexOfFirst { it == pointIndex }
+                val fieldIndex = fieldPointIndexes.indexOfFirst { it == pointIndex }
+                // the point does not belong to this entry; do not return -1, which collides with END_POINT_INDEX
+                if (fieldIndex < 0) MarkerCursorState.NONE_POINT_INDEX else fieldIndex
             }
         }
     }

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerEditEntryTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerEditEntryTest.kt
@@ -305,18 +305,18 @@ class MarkerEditEntryTest {
                         fieldNames = listOf("start"),
                         Edition.Method.Dragging,
                     ),
-                    // for entries other than the one owning the dragged point, the field name resolution falls
-                    // back to "end" (see getPointIndexAsSingleEntry returning -1 == END_POINT_INDEX)
+                    // entries co-moved by the locked drag do not own the dragged point, so their field names are
+                    // derived from what actually changed (the whole entry translated, so both borders moved)
                     Edition(
                         1,
                         entryB.copy(start = 210f, end = 360f),
-                        fieldNames = listOf("end"),
+                        fieldNames = listOf("start", "end"),
                         Edition.Method.Dragging,
                     ),
                     Edition(
                         2,
                         entryC.copy(start = 360f, end = 510f),
-                        fieldNames = listOf("end"),
+                        fieldNames = listOf("start", "end"),
                         Edition.Method.Dragging,
                     ),
                 ),

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerEditEntryTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerEditEntryTest.kt
@@ -1,0 +1,352 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.marker
+
+import com.sdercolin.vlabeler.ui.editor.Edition
+import testutil.TestLabelers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [editEntryIfNeeded], which converts a drag result (a list of updated [EntryInPixel]s) into [Edition]s.
+ *
+ * All states use sampleRate = 1000 Hz / resolution = 1 unless stated otherwise, so 1 ms == 1 px and the canvas is
+ * 1000 px long.
+ *
+ * Continuous scenario (nnsvs-singer, no fields): entries a = 100..200, b = 200..350, c = 350..500 with flattened
+ * point indexes -2 (start), 0 (border at 200), 1 (border at 350), -1 (end).
+ *
+ * Non-continuous scenario (utau-singer): 1 entry with start = 100, end = 600, points = [fixed = 400, preu = 250,
+ * ovl = 150, left = 100].
+ */
+class MarkerEditEntryTest {
+
+    private val start = MarkerCursorState.START_POINT_INDEX
+    private val end = MarkerCursorState.END_POINT_INDEX
+
+    private val entryA = MarkerStateFactory.entry(100f, 200f, name = "a")
+    private val entryB = MarkerStateFactory.entry(200f, 350f, name = "b")
+    private val entryC = MarkerStateFactory.entry(350f, 500f, name = "c")
+    private val utauEntry = MarkerStateFactory.entry(100f, 600f, points = listOf(400f, 250f, 150f, 100f))
+
+    private fun continuousState(editedIndexes: List<Int> = listOf(0, 1, 2)) = MarkerStateFactory.create(
+        labelerConf = TestLabelers.nnsvsSinger,
+        allEntries = listOf(entryA, entryB, entryC),
+        editedIndexes = editedIndexes,
+    )
+
+    private fun utauSingerState(resolution: Int = 1) = MarkerStateFactory.create(
+        labelerConf = TestLabelers.utauSinger,
+        allEntries = listOf(utauEntry),
+        resolution = resolution,
+    )
+
+    private fun MarkerState.collectEditions(
+        updated: List<EntryInPixel>,
+        pointIndex: Int,
+        method: Edition.Method = Edition.Method.Dragging,
+    ): List<List<Edition>> {
+        val recorded = mutableListOf<List<Edition>>()
+        editEntryIfNeeded(
+            updated = updated,
+            editEntries = { recorded.add(it) },
+            method = method,
+            pointIndex = pointIndex,
+        )
+        return recorded
+    }
+
+    // region no-op
+
+    @Test
+    fun noEditionWhenUpdatedEqualsEntriesInPixel() {
+        val state = continuousState()
+        val recorded = state.collectEditions(state.entriesInPixel, start)
+        assertEquals(emptyList(), recorded)
+    }
+
+    @Test
+    fun noEditionWhenDiffSetIsEmpty() {
+        val state = continuousState()
+        // the reversed list is not equal to entriesInPixel, but no single entry has changed
+        val recorded = state.collectEditions(state.entriesInPixel.reversed(), start)
+        assertEquals(emptyList(), recorded)
+    }
+
+    // endregion
+
+    // region single entry (utau-singer, non-continuous)
+
+    @Test
+    fun startEditProducesStartEdition() {
+        val state = utauSingerState()
+        val updated = listOf(state.entriesInPixel[0].copy(start = 150f))
+        val recorded = state.collectEditions(updated, start)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, utauEntry.copy(start = 150f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun endEditProducesEndEditionWithMethodPassedThrough() {
+        val state = utauSingerState()
+        val updated = listOf(state.entriesInPixel[0].copy(end = 550f))
+        val recorded = state.collectEditions(updated, end, method = Edition.Method.SetWithCursor)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, utauEntry.copy(end = 550f), fieldNames = listOf("end"), Edition.Method.SetWithCursor),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun fieldPointEditUsesFieldNameFromLabeler() {
+        val state = utauSingerState()
+        // point index 1 is "preu"
+        val updated = listOf(state.entriesInPixel[0].copy(points = listOf(400f, 350f, 150f, 100f)))
+        val recorded = state.collectEditions(updated, pointIndex = 1)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(
+                        0,
+                        utauEntry.copy(points = listOf(400f, 350f, 150f, 100f)),
+                        fieldNames = listOf("preu"),
+                        Edition.Method.Dragging,
+                    ),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun lastFieldPointEditUsesFieldNameFromLabeler() {
+        val state = utauSingerState()
+        // point index 3 is "left"
+        val updated = listOf(state.entriesInPixel[0].copy(points = listOf(400f, 250f, 150f, 120f)))
+        val recorded = state.collectEditions(updated, pointIndex = 3)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(
+                        0,
+                        utauEntry.copy(points = listOf(400f, 250f, 150f, 120f)),
+                        fieldNames = listOf("left"),
+                        Edition.Method.Dragging,
+                    ),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun editionValuesAreConvertedToMillisByResolution() {
+        // resolution 2: 1 px == 2 ms, so the entry (100..600 ms) is at 50..300 px
+        val state = utauSingerState(resolution = 2)
+        assertEquals(50f, state.entriesInPixel[0].start)
+        assertEquals(300f, state.entriesInPixel[0].end)
+        // dragging end to 350 px means 700 ms
+        val updated = listOf(state.entriesInPixel[0].copy(end = 350f))
+        val recorded = state.collectEditions(updated, end)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, utauEntry.copy(end = 700f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    // endregion
+
+    // region continuous mode (nnsvs-singer)
+
+    @Test
+    fun borderDragProducesEndAndStartEditionsForAdjacentEntries() {
+        val state = continuousState()
+        // border 0 (between "a" and "b") is dragged from 200 to 250; "c" is unchanged and produces no Edition
+        val updated = listOf(
+            state.entriesInPixel[0].copy(end = 250f),
+            state.entriesInPixel[1].copy(start = 250f),
+            state.entriesInPixel[2],
+        )
+        val recorded = state.collectEditions(updated, pointIndex = 0)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, entryA.copy(end = 250f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                    Edition(1, entryB.copy(start = 250f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun startDragWithoutLeftNeighborAddsNoCascadeEdition() {
+        val state = continuousState()
+        // "a" is the first entry of the group, so its moved start has no left neighbor to sync
+        val updated = listOf(
+            state.entriesInPixel[0].copy(start = 150f),
+            state.entriesInPixel[1],
+            state.entriesInPixel[2],
+        )
+        val recorded = state.collectEditions(updated, start)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, entryA.copy(start = 150f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun endDragWithoutRightNeighborAddsNoCascadeEdition() {
+        val state = continuousState()
+        // "c" is the last entry of the group, so its moved end has no right neighbor to sync
+        val updated = listOf(
+            state.entriesInPixel[0],
+            state.entriesInPixel[1],
+            state.entriesInPixel[2].copy(end = 550f),
+        )
+        val recorded = state.collectEditions(updated, end)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(2, entryC.copy(end = 550f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun middleEntryStartDragSyncsLeftNeighborEnd() {
+        val state = continuousState(editedIndexes = listOf(1))
+        // editing only "b": moving its start adds a leading Edition setting "a".end to the same value
+        val updated = listOf(state.entriesInPixel[0].copy(start = 150f))
+        val recorded = state.collectEditions(updated, start)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, entryA.copy(end = 150f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                    Edition(1, entryB.copy(start = 150f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun middleEntryEndDragSyncsRightNeighborStart() {
+        val state = continuousState(editedIndexes = listOf(1))
+        // editing only "b": moving its end appends an Edition setting "c".start to the same value
+        val updated = listOf(state.entriesInPixel[0].copy(end = 400f))
+        val recorded = state.collectEditions(updated, end)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(1, entryB.copy(end = 400f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                    Edition(2, entryC.copy(start = 400f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun innerBorderDragWithRightNeighborPresentAddsNoCascadeWhenOuterBordersUnchanged() {
+        val state = continuousState(editedIndexes = listOf(0, 1))
+        // editing "a" and "b" with "c" as right neighbor: dragging the inner border (200 -> 250) keeps the
+        // group's outer borders (100 and 350) unchanged, so no cascade Edition for "c" is added
+        val updated = listOf(
+            state.entriesInPixel[0].copy(end = 250f),
+            state.entriesInPixel[1].copy(start = 250f),
+        )
+        val recorded = state.collectEditions(updated, pointIndex = 0)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, entryA.copy(end = 250f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                    Edition(1, entryB.copy(start = 250f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    // endregion
+
+    // region multi-entry locked drag
+
+    @Test
+    fun lockedDragOfAllEntriesProducesOneEditionPerEntry() {
+        val state = continuousState()
+        // all three entries are moved by +10 px; no neighbor exists outside the group
+        val updated = state.entriesInPixel.map { it.moved(10f) }
+        val recorded = state.collectEditions(updated, start)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(
+                        0,
+                        entryA.copy(start = 110f, end = 210f),
+                        fieldNames = listOf("start"),
+                        Edition.Method.Dragging,
+                    ),
+                    // for entries other than the one owning the dragged point, the field name resolution falls
+                    // back to "end" (see getPointIndexAsSingleEntry returning -1 == END_POINT_INDEX)
+                    Edition(
+                        1,
+                        entryB.copy(start = 210f, end = 360f),
+                        fieldNames = listOf("end"),
+                        Edition.Method.Dragging,
+                    ),
+                    Edition(
+                        2,
+                        entryC.copy(start = 360f, end = 510f),
+                        fieldNames = listOf("end"),
+                        Edition.Method.Dragging,
+                    ),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun lockedDragOfMiddleEntrySyncsBothNeighbors() {
+        val state = continuousState(editedIndexes = listOf(1))
+        // "b" is moved by +10 px as a whole: both outer borders moved, so both neighbors are synced
+        val updated = listOf(state.entriesInPixel[0].moved(10f))
+        val recorded = state.collectEditions(updated, start)
+        assertEquals(
+            listOf(
+                listOf(
+                    Edition(0, entryA.copy(end = 210f), fieldNames = listOf("end"), Edition.Method.Dragging),
+                    Edition(
+                        1,
+                        entryB.copy(start = 210f, end = 360f),
+                        fieldNames = listOf("start"),
+                        Edition.Method.Dragging,
+                    ),
+                    Edition(2, entryC.copy(start = 360f), fieldNames = listOf("start"), Edition.Method.Dragging),
+                ),
+            ),
+            recorded,
+        )
+    }
+
+    // endregion
+}

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateIndexTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/marker/MarkerStateIndexTest.kt
@@ -141,6 +141,14 @@ class MarkerStateIndexTest {
     }
 
     @Test
+    fun getPointIndexAsSingleEntryReturnsNoneForAPointOfAnotherEntry() {
+        val state = continuousState()
+        // border 1 belongs to entry 2 (as its start), not to entry 0; the result must not collide with
+        // END_POINT_INDEX (-1), which would misattribute an edition's field to "end"
+        assertEquals(MarkerCursorState.NONE_POINT_INDEX, state.getPointIndexAsSingleEntry(0, 1))
+    }
+
+    @Test
     fun getPointIndexAsSingleEntryForLastEntryInContinuousMode() {
         val state = continuousState()
         // entry 2: border 1 is its start, the global end is its end

--- a/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/timescale/TimescaleTest.kt
+++ b/src/jvmTest/kotlin/com/sdercolin/vlabeler/ui/editor/labeler/timescale/TimescaleTest.kt
@@ -1,0 +1,191 @@
+package com.sdercolin.vlabeler.ui.editor.labeler.timescale
+
+import com.sdercolin.vlabeler.ui.editor.labeler.marker.EntryConverter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [Timescale.find] and the non-composable [TimescaleBarState].
+ *
+ * [Timescale.find] returns the first item (ordered from the smallest) whose minor step is at least 80 px wide under
+ * the given time-to-pixel conversion, falling back to the largest item (major = 1 h, minor = 30 min).
+ *
+ * [TimescaleBarState] lays out the ticks of the selected timescale on the screen: `position = index * stepPx -
+ * screenRange.start`, where major ticks carry a label produced by `getTimeText(index * major)` and minor ticks carry
+ * `null`. A minor tick that coincides with a major tick is merged into the major one.
+ */
+class TimescaleTest {
+
+    // region Timescale.find
+
+    @Test
+    fun findReturnsSmallestItemWhenExtremelyZoomedIn() {
+        // 1 ms = 1000 px: even the smallest minor step (0.1 ms -> 100 px) is wide enough
+        val item = Timescale.find { it * 1000 }
+        assertEquals(0.5, item.major)
+        assertEquals(0.1, item.minor)
+    }
+
+    @Test
+    fun findAtOneMillisecondPerPixel() {
+        // minor 50 ms -> 50 px is too narrow; minor 100 ms -> 100 px is the first that fits
+        val item = Timescale.find { it }
+        assertEquals(500.0, item.major)
+        assertEquals(100.0, item.minor)
+    }
+
+    @Test
+    fun findAcceptsMinorStepOfExactlyMinimumWidth() {
+        // minor 100 ms -> exactly 80 px, which satisfies the ">= 80" requirement
+        val item = Timescale.find { it * 0.8f }
+        assertEquals(500.0, item.major)
+        assertEquals(100.0, item.minor)
+    }
+
+    @Test
+    fun findSkipsMinorStepJustBelowMinimumWidth() {
+        // minor 100 ms -> 79 px is rejected; the next item (minor 500 ms -> 395 px) is selected
+        val item = Timescale.find { it * 0.79f }
+        assertEquals(1000.0, item.major)
+        assertEquals(500.0, item.minor)
+    }
+
+    @Test
+    fun findReturnsLastItemWhenExtremelyZoomedOut() {
+        // even the largest minor step (30 min -> 18 px) is too narrow, so the last item is used as fallback
+        val item = Timescale.find { it / 100000 }
+        assertEquals(3600000.0, item.major)
+        assertEquals(1800000.0, item.minor)
+    }
+
+    @Test
+    fun findWithEntryConverterSelectsItemByResolution() {
+        // 44100 Hz / resolution 100: 1 ms -> 0.441 px;
+        // minor 100 ms -> 44.1 px is too narrow, minor 500 ms -> 220.5 px fits
+        val converter = EntryConverter(44100f, 100)
+        val item = Timescale.find { converter.convertToPixel(it) }
+        assertEquals(1000.0, item.major)
+        assertEquals(500.0, item.minor)
+    }
+
+    // endregion
+
+    // region TimescaleBarState
+
+    @Test
+    fun barStateAtOneMillisecondPerPixelWithoutOffset() {
+        // 1000 Hz / resolution 1: 1 ms == 1 px, so the timescale is (major 500 ms, minor 100 ms)
+        val state = TimescaleBarState(sampleRate = 1000f, resolution = 1, screenRange = 0f..1000f)
+        assertEquals(
+            listOf(
+                0f to "0",
+                100f to null,
+                200f to null,
+                300f to null,
+                400f to null,
+                500f to "0.5",
+                600f to null,
+                700f to null,
+                800f to null,
+                900f to null,
+                1000f to "1",
+            ),
+            state.scalePositions,
+        )
+        assertEquals(
+            listOf(
+                0f to "0",
+                500f to "0.5",
+                1000f to "1",
+            ),
+            state.scalePositionsWithTexts,
+        )
+    }
+
+    @Test
+    fun barStateAppliesScrollOffset() {
+        // same scale as above, but scrolled to 250..1250 px:
+        // major ticks at absolute 500 and 1000 px appear at 250 and 750 px on screen
+        val state = TimescaleBarState(sampleRate = 1000f, resolution = 1, screenRange = 250f..1250f)
+        assertEquals(
+            listOf(
+                50f to null,
+                150f to null,
+                250f to "0.5",
+                350f to null,
+                450f to null,
+                550f to null,
+                650f to null,
+                750f to "1",
+                850f to null,
+                950f to null,
+            ),
+            state.scalePositions,
+        )
+        assertEquals(
+            listOf(
+                250f to "0.5",
+                750f to "1",
+            ),
+            state.scalePositionsWithTexts,
+        )
+    }
+
+    @Test
+    fun barStateFormatsMinuteScaleLabels() {
+        // 1000 Hz / resolution 500: 1 ms == 0.002 px;
+        // minor 30 s -> 60 px is too narrow, minor 1 min -> 120 px fits (major 5 min -> 600 px)
+        val state = TimescaleBarState(sampleRate = 1000f, resolution = 500, screenRange = 0f..1300f)
+        assertEquals(
+            listOf(
+                0f to "0",
+                120f to null,
+                240f to null,
+                360f to null,
+                480f to null,
+                600f to "5:00",
+                720f to null,
+                840f to null,
+                960f to null,
+                1080f to null,
+                1200f to "10:00",
+            ),
+            state.scalePositions,
+        )
+        assertEquals(
+            listOf(
+                0f to "0",
+                600f to "5:00",
+                1200f to "10:00",
+            ),
+            state.scalePositionsWithTexts,
+        )
+    }
+
+    @Test
+    fun barStateFormatsHourScaleLabelsUsingFallbackItem() {
+        // 1000 Hz / resolution 25000: 1 ms == 0.00004 px; no minor step reaches 80 px, so the fallback item
+        // (major 1 h -> 144 px, minor 30 min -> 72 px) is used
+        val state = TimescaleBarState(sampleRate = 1000f, resolution = 25000, screenRange = 0f..300f)
+        assertEquals(
+            listOf(
+                0f to "0",
+                72f to null,
+                144f to "1:00:00",
+                216f to null,
+                288f to "2:00:00",
+            ),
+            state.scalePositions,
+        )
+        assertEquals(
+            listOf(
+                0f to "0",
+                144f to "1:00:00",
+                288f to "2:00:00",
+            ),
+            state.scalePositionsWithTexts,
+        )
+    }
+
+    // endregion
+}

--- a/src/jvmTest/kotlin/ui/ChartStoreTest.kt
+++ b/src/jvmTest/kotlin/ui/ChartStoreTest.kt
@@ -1,0 +1,272 @@
+package ui
+
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.SampleInfo
+import com.sdercolin.vlabeler.repository.ChartRepository
+import com.sdercolin.vlabeler.ui.editor.ChartStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.TestWav
+import testutil.createTestProject
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [ChartStore], driven by real wav files loaded through the real sample loading path
+ * ([SampleInfo.load] and `loadSampleChunk` inside [ChartStore.load]).
+ *
+ * The charts are rendered into the [ChartRepository] singleton, which points into the per-test project's cache
+ * directory and is cleared in the teardown to keep the tests order-independent.
+ */
+class ChartStoreTest {
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var tempDir: File
+    private var project: Project? = null
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        scope.cancel()
+        project?.let { ChartRepository.clear(it) }
+        project = null
+        tempDir.deleteRecursively()
+        Log.muted = false
+    }
+
+    private fun createProject(): Project {
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        return createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        ).also { project = it }
+    }
+
+    private fun loadSampleInfo(project: Project, file: File, appConf: AppConf): SampleInfo = runBlocking {
+        SampleInfo.load(project, moduleName = "", file = file, appConf = appConf).getOrThrow()
+    }
+
+    /**
+     * Runs [ChartStore.load] and joins the rendering job deterministically via [ChartStore.awaitLoad].
+     */
+    private fun render(
+        store: ChartStore,
+        project: Project,
+        info: SampleInfo,
+        appConf: AppConf,
+        startingChunkIndex: Int = 0,
+        onRenderProgress: suspend () -> Unit = {},
+    ) {
+        store.load(
+            scope = scope,
+            project = project,
+            sampleInfo = info,
+            appConf = appConf,
+            density = Density(1f),
+            layoutDirection = LayoutDirection.Ltr,
+            startingChunkIndex = startingChunkIndex,
+            onRenderProgress = onRenderProgress,
+        )
+        runBlocking { store.awaitLoad() }
+    }
+
+    @Test
+    fun `prepareForNewLoading initializes statuses and the chart repository`() {
+        val project = createProject()
+        val appConf = AppConf()
+        val info = loadSampleInfo(project, project.rootSampleDirectory.resolve("_a_ka.wav"), appConf)
+        val store = ChartStore()
+
+        assertTrue(store.prepareForNewLoading(project, appConf, info))
+        assertEquals(ChartStore.ChartLoadingStatus.Loading, store.getWaveformStatus(0, 0))
+        assertEquals(ChartStore.ChartLoadingStatus.Loading, store.getSpectrogramStatus(0))
+        // power and fundamental statuses are only written when the corresponding charts are rendered
+        assertNull(store.getPowerGraphStatus(0, 0))
+        assertNull(store.getFundamentalGraphStatus(0))
+        assertTrue(project.cacheDirectory.resolve("charts").resolve("params.json").isFile)
+
+        // the same sample with the same painter parameters does not need a new loading
+        assertFalse(store.prepareForNewLoading(project, appConf, info))
+
+        // a painter configuration change requires a reset even for the same sample
+        val changedConf = appConf.copy(
+            painter = appConf.painter.copy(
+                amplitude = appConf.painter.amplitude.copy(
+                    normalize = appConf.painter.amplitude.normalize.not(),
+                ),
+            ),
+        )
+        assertTrue(store.prepareForNewLoading(project, changedConf, info))
+    }
+
+    @Test
+    fun `prepareForNewLoading resets when another sample is loaded`() {
+        val project = createProject()
+        val appConf = AppConf()
+        val otherWav = project.rootSampleDirectory.resolve("other.wav")
+        TestWav.write(otherWav, durationMs = 500)
+        val store = ChartStore()
+
+        val infoA = loadSampleInfo(project, project.rootSampleDirectory.resolve("_a_ka.wav"), appConf)
+        assertTrue(store.prepareForNewLoading(project, appConf, infoA))
+
+        val infoB = loadSampleInfo(project, otherWav, appConf)
+        assertTrue(store.prepareForNewLoading(project, appConf, infoB))
+        assertEquals(ChartStore.ChartLoadingStatus.Loading, store.getWaveformStatus(0, 0))
+    }
+
+    @Test
+    fun `load renders all charts into the repository and reports progress`() {
+        val project = createProject()
+        val wav = project.rootSampleDirectory.resolve("sine.wav")
+        TestWav.write(wav, durationMs = 1000, sampleRate = 44100, frequency = 440.0)
+        val appConf = AppConf().run {
+            copy(
+                painter = painter.copy(
+                    power = painter.power.copy(enabled = true),
+                    fundamental = painter.fundamental.copy(enabled = true),
+                ),
+            )
+        }
+        val info = loadSampleInfo(project, wav, appConf)
+        assertTrue(info.hasSpectrogram)
+        assertTrue(info.hasPower)
+        assertTrue(info.hasFundamental)
+        assertEquals(4, info.totalChartCount)
+
+        val store = ChartStore()
+        store.prepareForNewLoading(project, appConf, info)
+        assertFalse(store.hasCachedSample(info))
+
+        val progressCount = AtomicInteger(0)
+        render(store, project, info, appConf) { progressCount.incrementAndGet() }
+
+        assertEquals(info.totalChartCount, progressCount.get())
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, store.getWaveformStatus(0, 0))
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, store.getSpectrogramStatus(0))
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, store.getPowerGraphStatus(0, 0))
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, store.getFundamentalGraphStatus(0))
+        assertTrue(ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0).isFile)
+        assertTrue(ChartRepository.getSpectrogramImageFile(info, chunkIndex = 0).isFile)
+        assertTrue(ChartRepository.getPowerGraphImageFile(info, channelIndex = 0, chunkIndex = 0).isFile)
+        assertTrue(ChartRepository.getFundamentalGraphImageFile(info, chunkIndex = 0).isFile)
+        assertTrue(store.hasCachedSample(info))
+    }
+
+    @Test
+    fun `load reuses cached chart files without rerendering`() {
+        val project = createProject()
+        val appConf = AppConf()
+        val info = loadSampleInfo(project, project.rootSampleDirectory.resolve("_a_ka.wav"), appConf)
+        val firstStore = ChartStore()
+        assertTrue(firstStore.prepareForNewLoading(project, appConf, info))
+        render(firstStore, project, info, appConf)
+        val waveformFile = ChartRepository.getWaveformImageFile(info, channelIndex = 0, chunkIndex = 0)
+        val spectrogramFile = ChartRepository.getSpectrogramImageFile(info, chunkIndex = 0)
+        val stamps = listOf(waveformFile.lastModified(), spectrogramFile.lastModified())
+
+        // a new store instance always initializes its statuses, but the chart files are kept
+        val secondStore = ChartStore()
+        assertTrue(secondStore.prepareForNewLoading(project, appConf, info))
+        assertTrue(secondStore.hasCachedSample(info))
+
+        val progressCount = AtomicInteger(0)
+        render(secondStore, project, info, appConf) { progressCount.incrementAndGet() }
+
+        // the cached branch reports progress for every chart as well
+        assertEquals(info.totalChartCount, progressCount.get())
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, secondStore.getWaveformStatus(0, 0))
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, secondStore.getSpectrogramStatus(0))
+        assertEquals(stamps, listOf(waveformFile.lastModified(), spectrogramFile.lastModified()))
+    }
+
+    @Test
+    fun `load renders the chunks around the starting chunk first`() {
+        val project = createProject()
+        val wav = project.rootSampleDirectory.resolve("chunked.wav")
+        TestWav.write(wav, durationMs = 3000, sampleRate = 8000)
+        val appConf = AppConf().run {
+            copy(
+                painter = painter.copy(
+                    maxDataChunkSize = 8000,
+                    spectrogram = painter.spectrogram.copy(enabled = false),
+                ),
+            )
+        }
+        val info = loadSampleInfo(project, wav, appConf)
+        assertEquals(3, info.chunkCount)
+
+        // with one channel and only waveforms enabled, each progress callback completes exactly one chunk,
+        // so the order in which the chunk statuses turn loaded is the rendering order
+        fun renderAndRecordOrder(startingChunkIndex: Int): List<Int> {
+            val store = ChartStore()
+            assertTrue(store.prepareForNewLoading(project, appConf, info))
+            val loadedOrder = mutableListOf<Int>()
+            render(store, project, info, appConf, startingChunkIndex) {
+                (0 until info.chunkCount)
+                    .filter { store.getWaveformStatus(0, it) == ChartStore.ChartLoadingStatus.Loaded }
+                    .filterNot { it in loadedOrder }
+                    .forEach { loadedOrder.add(it) }
+            }
+            return loadedOrder
+        }
+
+        assertEquals(listOf(1, 0, 2), renderAndRecordOrder(startingChunkIndex = 1))
+        assertEquals(listOf(2, 1, 0), renderAndRecordOrder(startingChunkIndex = 2))
+        assertEquals(listOf(0, 1, 2), renderAndRecordOrder(startingChunkIndex = 0))
+    }
+
+    @Test
+    fun `clear resets the statuses and drops the loading job`() {
+        val project = createProject()
+        val appConf = AppConf()
+        val info = loadSampleInfo(project, project.rootSampleDirectory.resolve("_a_ka.wav"), appConf)
+        val store = ChartStore()
+
+        // clearing and awaiting an empty store is a no-op
+        store.clear()
+        runBlocking { store.awaitLoad() }
+        assertNull(store.getWaveformStatus(0, 0))
+
+        store.prepareForNewLoading(project, appConf, info)
+        render(store, project, info, appConf)
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, store.getWaveformStatus(0, 0))
+
+        store.clear()
+        assertNull(store.getWaveformStatus(0, 0))
+        assertNull(store.getSpectrogramStatus(0))
+        assertNull(store.getPowerGraphStatus(0, 0))
+        assertNull(store.getFundamentalGraphStatus(0))
+        runBlocking { store.awaitLoad() }
+    }
+}

--- a/src/jvmTest/kotlin/ui/ChartStoreTest.kt
+++ b/src/jvmTest/kotlin/ui/ChartStoreTest.kt
@@ -130,6 +130,21 @@ class ChartStoreTest {
     }
 
     @Test
+    fun `prepareForNewLoading leaves the spectrogram status unset when spectrogram is disabled`() {
+        val project = createProject()
+        val appConf = AppConf().run {
+            copy(painter = painter.copy(spectrogram = painter.spectrogram.copy(enabled = false)))
+        }
+        val info = loadSampleInfo(project, project.rootSampleDirectory.resolve("_a_ka.wav"), appConf)
+        val store = ChartStore()
+
+        assertTrue(store.prepareForNewLoading(project, appConf, info))
+        assertEquals(ChartStore.ChartLoadingStatus.Loading, store.getWaveformStatus(0, 0))
+        // the spectrogram will not be rendered, so its status must not be stuck at Loading
+        assertNull(store.getSpectrogramStatus(0))
+    }
+
+    @Test
     fun `prepareForNewLoading resets when another sample is loaded`() {
         val project = createProject()
         val appConf = AppConf()

--- a/src/jvmTest/kotlin/ui/EditorStateTest.kt
+++ b/src/jvmTest/kotlin/ui/EditorStateTest.kt
@@ -1,0 +1,806 @@
+package ui
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import com.sdercolin.vlabeler.audio.PlayerState
+import com.sdercolin.vlabeler.env.KeyboardViewModel
+import com.sdercolin.vlabeler.env.Log
+import com.sdercolin.vlabeler.model.AppConf
+import com.sdercolin.vlabeler.model.AppRecord
+import com.sdercolin.vlabeler.model.Project
+import com.sdercolin.vlabeler.model.action.KeyAction
+import com.sdercolin.vlabeler.model.filter.EntryFilter
+import com.sdercolin.vlabeler.repository.ChartRepository
+import com.sdercolin.vlabeler.repository.SampleInfoRepository
+import com.sdercolin.vlabeler.ui.AppDialogState
+import com.sdercolin.vlabeler.ui.AppDialogStateImpl
+import com.sdercolin.vlabeler.ui.AppErrorState
+import com.sdercolin.vlabeler.ui.AppErrorStateImpl
+import com.sdercolin.vlabeler.ui.AppProgressState
+import com.sdercolin.vlabeler.ui.AppProgressStateImpl
+import com.sdercolin.vlabeler.ui.AppRecordStore
+import com.sdercolin.vlabeler.ui.AppScreenState
+import com.sdercolin.vlabeler.ui.AppScreenStateImpl
+import com.sdercolin.vlabeler.ui.AppSnackbarState
+import com.sdercolin.vlabeler.ui.AppSnackbarStateImpl
+import com.sdercolin.vlabeler.ui.AppState
+import com.sdercolin.vlabeler.ui.AppUnsavedChangesState
+import com.sdercolin.vlabeler.ui.AppUnsavedChangesStateImpl
+import com.sdercolin.vlabeler.ui.AppViewState
+import com.sdercolin.vlabeler.ui.AppViewStateImpl
+import com.sdercolin.vlabeler.ui.ProjectStore
+import com.sdercolin.vlabeler.ui.ProjectStoreImpl
+import com.sdercolin.vlabeler.ui.Screen
+import com.sdercolin.vlabeler.ui.dialog.CommonConfirmationDialogAction
+import com.sdercolin.vlabeler.ui.dialog.EditEntriesTagDialogArgs
+import com.sdercolin.vlabeler.ui.dialog.EditExtraDialogArgs
+import com.sdercolin.vlabeler.ui.dialog.InputEntryNameDialogArgs
+import com.sdercolin.vlabeler.ui.dialog.InputEntryNameDialogPurpose
+import com.sdercolin.vlabeler.ui.dialog.MoveEntryDialogArgs
+import com.sdercolin.vlabeler.ui.dialog.SetEntryPropertyDialogArgs
+import com.sdercolin.vlabeler.ui.editor.ChartStore
+import com.sdercolin.vlabeler.ui.editor.Edition
+import com.sdercolin.vlabeler.ui.editor.EditorEntryContextAction
+import com.sdercolin.vlabeler.ui.editor.EditorState
+import com.sdercolin.vlabeler.ui.editor.ScrollFitViewModel
+import com.sdercolin.vlabeler.ui.editor.Tool
+import com.sdercolin.vlabeler.ui.editor.labeler.CanvasState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import testutil.TestEnv
+import testutil.TestFixtures
+import testutil.TestLabelers
+import testutil.createTestProject
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [EditorState].
+ *
+ * [EditorState] requires an [AppState], which cannot be constructed in tests because its real construction starts
+ * IPC/audio/tracking side effects. Instead, an [AppState] instance is allocated without running its constructor
+ * (the same approach as in [ProjectCreatorStateTest]) and the members that [EditorState] and its exercised
+ * collaborators dereference are injected reflectively with real implementations:
+ *
+ * - `appConf` (a [MutableState] delegate), `keyboardViewModel`, `scrollFitViewModel`, `mainScope`, `appRecordStore`
+ *   and `playerState` (safe to construct: no audio line is opened until playback);
+ * - the interface delegates ([AppErrorState], [AppViewState], [AppScreenState], [ProjectStore],
+ *   [AppUnsavedChangesState], [AppSnackbarState], [AppDialogState], [AppProgressState]) with their real
+ *   implementations, so project edits, dialogs and errors behave like in the application.
+ *
+ * The [AppRecordStore] uses an already-cancelled scope so nothing is written to the real application directory
+ * (asserted in [ProjectCreatorStateTest]). The `mainScope` is an unconfined child scope of the test scope so that
+ * coroutines launched by [AppState] functions run deterministically up to their first suspension point.
+ */
+class EditorStateTest {
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var tempDir: File
+    private lateinit var env: AppEnv
+    private val loadedProjects = mutableSetOf<Project>()
+
+    @BeforeTest
+    fun setup() {
+        TestEnv.ensureLogDirectory()
+        Log.muted = true
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        tempDir = createTempDirectory("vlabeler-test").toFile()
+    }
+
+    @AfterTest
+    fun teardown() {
+        scope.cancel()
+        loadedProjects.forEach {
+            ChartRepository.clear(it)
+            SampleInfoRepository.clear(it)
+        }
+        loadedProjects.clear()
+        tempDir.deleteRecursively()
+        Log.muted = false
+    }
+
+    private fun uninitializedAppState(): AppState {
+        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(AppState::class.java) as AppState
+    }
+
+    private fun AppState.setField(name: String, value: Any) {
+        AppState::class.java.getDeclaredField(name).apply {
+            isAccessible = true
+            set(this@setField, value)
+        }
+    }
+
+    private fun AppState.setDelegate(interfaceClass: Class<*>, value: Any) {
+        val field = AppState::class.java.declaredFields.single {
+            it.name.startsWith("\$\$delegate") && it.type == interfaceClass
+        }
+        field.isAccessible = true
+        field.set(this, value)
+    }
+
+    private fun cancelledScope(): CoroutineScope = CoroutineScope(Job().apply { cancel() })
+
+    private inner class AppEnv(appConf: AppConf) {
+        val appConfState: MutableState<AppConf> = mutableStateOf(appConf)
+        val errorState = AppErrorStateImpl()
+        val progressState = AppProgressStateImpl()
+        val screenState = AppScreenStateImpl()
+        val scrollFitViewModel = ScrollFitViewModel(scope)
+        val projectStore = ProjectStoreImpl(
+            scope = scope,
+            appConf = appConfState,
+            screenState = screenState,
+            scrollFitViewModel = scrollFitViewModel,
+            errorState = errorState,
+            progressState = progressState,
+        )
+        val unsavedChangesState = AppUnsavedChangesStateImpl()
+        val snackbarState = AppSnackbarStateImpl(SnackbarHostState())
+        val dialogState = AppDialogStateImpl(unsavedChangesState, projectStore, snackbarState)
+        val appRecordStore = AppRecordStore(AppRecord(), cancelledScope())
+        val mainScope = CoroutineScope(SupervisorJob(scope.coroutineContext[Job]) + Dispatchers.Unconfined)
+
+        val appState: AppState = uninitializedAppState().also { state ->
+            state.setField("mainScope", mainScope)
+            state.setField("keyboardViewModel", KeyboardViewModel(scope, appConf.keymaps))
+            state.setField("scrollFitViewModel", scrollFitViewModel)
+            state.setField("appRecordStore", appRecordStore)
+            state.setField("appConf\$delegate", appConfState)
+            state.setField("playerState", PlayerState(appConf, scope))
+            state.setDelegate(AppErrorState::class.java, errorState)
+            state.setDelegate(AppViewState::class.java, AppViewStateImpl(appRecordStore))
+            state.setDelegate(AppScreenState::class.java, screenState)
+            state.setDelegate(ProjectStore::class.java, projectStore)
+            state.setDelegate(AppUnsavedChangesState::class.java, unsavedChangesState)
+            state.setDelegate(AppSnackbarState::class.java, snackbarState)
+            state.setDelegate(AppDialogState::class.java, dialogState)
+            state.setDelegate(AppProgressState::class.java, progressState)
+            dialogState.initDialogState(state)
+            projectStore.initProjectStore(state)
+        }
+
+        val dialogArgs get() = dialogState.embeddedDialog?.args
+    }
+
+    /**
+     * Creates an [EditorState] wired to a real [ProjectStoreImpl] behind the reflective [AppState], mirroring the
+     * production wiring: the editor is registered as the current screen, so project edits are propagated back into
+     * the editor via [EditorState.updateProject].
+     */
+    private fun createEditor(
+        project: Project,
+        appConf: AppConf = AppConf(),
+        setup: (ProjectStoreImpl.() -> Unit)? = null,
+    ): EditorState {
+        env = AppEnv(appConf)
+        env.projectStore.newProject(project)
+        setup?.invoke(env.projectStore)
+        val editor = EditorState(env.projectStore.requireProject(), env.appState)
+        env.screenState.screen = Screen.Editor(editor)
+        return editor
+    }
+
+    /**
+     * Loads the current sample of the editor's project through the real loading path.
+     */
+    private fun loadSample(editor: EditorState, appConf: AppConf) {
+        val project = editor.project
+        SampleInfoRepository.init(project)
+        loadedProjects += project
+        runBlocking { editor.loadSample(appConf) }
+        assertIs<CanvasState.Loaded>(editor.canvasState)
+    }
+
+    /**
+     * An [AppConf] whose scissors actions never play audio and whose post-edit actions are disabled, so that
+     * committed entries are exactly the submitted ones.
+     */
+    private fun plainConf(
+        useOnScreenScissors: Boolean = true,
+        askForName: AppConf.ScissorsActions.Target = AppConf.ScissorsActions.Target.Former,
+    ) = AppConf(
+        editor = AppConf.Editor(
+            scissorsActions = AppConf.ScissorsActions(
+                askForName = askForName,
+                play = AppConf.ScissorsActions.Target.None,
+            ),
+            useOnScreenScissors = useOnScreenScissors,
+            postEditDone = AppConf.PostEditAction.DEFAULT_DONE.copy(enabled = false),
+        ),
+    )
+
+    /* region initial state and project updates */
+
+    @Test
+    fun `initial state is derived from the project and the app conf`() {
+        val editor = createEditor(otoProject)
+        assertEquals(CanvasState.Loading, editor.canvasState)
+        assertTrue(editor.isLoading)
+        assertFalse(editor.isError)
+        assertEquals(Tool.Cursor, editor.tool)
+        assertEquals(AppConf().painter.canvasResolution.default, editor.canvasResolution)
+        assertEquals(0 to 0, editor.renderProgress)
+        assertEquals(0, editor.entryLoadedCount)
+        assertNull(editor.getSampleInfo())
+        // single edit mode: only the current entry is loaded for editing
+        assertEquals(editor.project.getEntriesForEditing().second, editor.editedEntries)
+        assertEquals(listOf(0), editor.editedEntries.map { it.index })
+        assertEquals("- a", editor.entryTitle)
+        assertFalse(editor.entryStar)
+        assertFalse(editor.entryDone)
+        assertEquals("", editor.entryTag)
+        assertEquals(emptyList<String>(), editor.tagOptions)
+        assertFalse(editor.canUseOnScreenScissors)
+        // the screen range is unknown until the scroll state has been measured
+        assertNull(editor.getScreenRange(1000f, ScrollState(0)))
+    }
+
+    @Test
+    fun `entry note getters and tag options follow project edits`() {
+        val editor = createEditor(otoProject)
+        editor.editEntryTag(0, "zebra")
+        editor.editEntryTag(1, "apple")
+        editor.toggleEntryStar(0)
+        editor.toggleEntryDone(0)
+
+        assertEquals("zebra", editor.entryTag)
+        assertTrue(editor.entryStar)
+        assertTrue(editor.entryDone)
+        assertEquals(listOf("apple", "zebra"), editor.tagOptions)
+
+        editor.toggleEntryDone(0)
+        assertFalse(editor.entryDone)
+    }
+
+    @Test
+    fun `updateProject reloads the edited entries only when the editing target changes`() {
+        val editor = createEditor(otoProject)
+        assertEquals(0, editor.entryLoadedCount)
+        val initialEntries = editor.editedEntries
+
+        // an edit that does not touch the current editing target does not reload
+        editor.updateProject(editor.project.updateCurrentModule { editEntryTag(1, "other") })
+        assertEquals(0, editor.entryLoadedCount)
+        assertEquals(initialEntries, editor.editedEntries)
+
+        // switching the current entry reloads the edited entries
+        editor.updateProject(editor.project.updateCurrentModule { copy(currentIndex = 1) })
+        assertEquals(1, editor.entryLoadedCount)
+        assertEquals(listOf(1), editor.editedEntries.map { it.index })
+        assertEquals("a ka", editor.entryTitle)
+    }
+
+    /* endregion */
+
+    /* region editions */
+
+    @Test
+    fun `updateEntries stages editions and submitEntries commits them`() {
+        val editor = createEditor(otoProject, appConf = plainConf())
+        val original = editor.editedEntries.single()
+        val edited = original.entry.copy(end = original.entry.end + 5f)
+
+        editor.updateEntries(listOf(Edition(0, edited, listOf("end"), Edition.Method.Dragging)))
+        assertEquals(edited, editor.editedEntries.single().entry)
+        // the edition is not committed to the project yet
+        assertEquals(original.entry, env.projectStore.requireProject().currentModule.entries[0])
+
+        editor.submitEntries()
+        assertEquals(edited, env.projectStore.requireProject().currentModule.entries[0])
+        assertEquals(edited, editor.project.currentModule.entries[0])
+        // the already staged entries match the committed project, so no reload happens
+        assertEquals(0, editor.entryLoadedCount)
+
+        // a second submit without any change is a no-op
+        val committedProject = env.projectStore.requireProject()
+        editor.submitEntries()
+        assertSame(committedProject, env.projectStore.requireProject())
+    }
+
+    @Test
+    fun `submitEntries applies the default post-edit done action`() {
+        val editor = createEditor(otoProject)
+        val original = editor.editedEntries.single()
+        val edited = original.entry.copy(end = original.entry.end + 5f)
+
+        editor.submitEntries(listOf(Edition(0, edited, listOf("end"), Edition.Method.Dragging)))
+
+        val committed = editor.project.currentModule.entries[0]
+        assertEquals(edited.end, committed.end)
+        assertTrue(committed.notes.done)
+        // the edited entries are reloaded with the committed done flag
+        assertEquals(committed, editor.editedEntries.single().entry)
+    }
+
+    @Test
+    fun `editions of entries not loaded for editing are not staged and are discarded on submit`() {
+        val editor = createEditor(otoProject, appConf = plainConf())
+        val otherEntry = editor.project.currentModule.entries[1]
+
+        editor.updateEntries(
+            listOf(Edition(1, otherEntry.copy(end = otherEntry.end + 5f), listOf("end"), Edition.Method.Dragging)),
+        )
+        // single edit mode only loads the current entry, so the edited list does not grow
+        assertEquals(listOf(0), editor.editedEntries.map { it.index })
+
+        val before = env.projectStore.requireProject()
+        editor.submitEntries()
+        assertSame(before, env.projectStore.requireProject())
+    }
+
+    @Test
+    fun `updateEntries syncs the neighbor boundaries for a continuous labeler`() {
+        val editor = createEditor(nnsvsProject, appConf = plainConf()) {
+            jumpToModuleByNameAndEntry("doremi", 2)
+        }
+        assertTrue(editor.project.multipleEditMode)
+        assertEquals(listOf(0, 1, 2, 3, 4, 5), editor.editedEntries.map { it.index })
+
+        val target = editor.editedEntries[2].entry
+        val edited = target.copy(end = target.end + 50f)
+        editor.updateEntries(listOf(Edition(2, edited, listOf("end"), Edition.Method.Dragging)))
+
+        assertEquals(edited, editor.editedEntries[2].entry)
+        // the next entry's start is aligned to the edited end
+        assertEquals(edited.end, editor.editedEntries[3].entry.start)
+        // the previous entry's end is aligned to the (unchanged) edited start
+        assertEquals(target.start, editor.editedEntries[1].entry.end)
+
+        editor.submitEntries()
+        val module = editor.project.currentModule
+        assertEquals(edited.end, module.entries[2].end)
+        assertEquals(edited.end, module.entries[3].start)
+    }
+
+    @Test
+    fun `submitEntriesWithCascade commits the editions of other modules`() {
+        val editor = createEditor(utauSingerProject, appConf = plainConf()) {
+            jumpToModuleByNameAndEntry("C4", 0)
+        }
+        val current = editor.editedEntries.single().entry
+        val a3Entry = editor.project.modules.first { it.name == "A3" }.entries[0]
+
+        editor.updateEntries(
+            listOf(Edition(0, current.copy(end = current.end + 5f), listOf("end"), Edition.Method.Dragging)),
+        )
+        editor.updateCascadeEditions(
+            mapOf(
+                "A3" to listOf(
+                    Edition(0, a3Entry.copy(end = a3Entry.end + 7f), listOf("end"), Edition.Method.Dragging),
+                ),
+            ),
+        )
+        assertEquals(setOf("A3"), editor.cascadeEditions.keys)
+
+        editor.submitEntriesWithCascade()
+
+        val project = editor.project
+        assertEquals(current.end + 5f, project.modules.first { it.name == "C4" }.entries[0].end)
+        assertEquals(a3Entry.end + 7f, project.modules.first { it.name == "A3" }.entries[0].end)
+        assertTrue(editor.cascadeEditions.isEmpty())
+    }
+
+    /* endregion */
+
+    /* region scissors */
+
+    @Test
+    fun `commitEntryCut cuts the entry with the on-screen scissors input`() {
+        val editor = createEditor(otoProject, appConf = plainConf())
+        editor.onScreenScissorsState.start(0, 200f, 120f, "- a")
+        assertTrue(editor.onScreenScissorsState.isOn)
+        assertEquals(0, editor.onScreenScissorsState.entryIndex)
+        assertEquals(200f, editor.onScreenScissorsState.timePosition)
+        assertEquals(120f, editor.onScreenScissorsState.pixelPosition)
+        assertEquals("- a", editor.onScreenScissorsState.text)
+
+        editor.onScreenScissorsState.text = "cut"
+        editor.commitEntryCut()
+
+        assertFalse(editor.onScreenScissorsState.isOn)
+        val module = editor.project.currentModule
+        assertEquals(3, module.entries.size)
+        // askForName = Former: the former part takes the input name and ends at the cut position
+        assertEquals("cut", module.entries[0].name)
+        assertEquals(200f, module.entries[0].end)
+        assertEquals("- a", module.entries[1].name)
+        assertEquals(200f, module.entries[1].start)
+        // goTo = Latter moves the cursor to the new latter entry
+        assertEquals(1, module.currentIndex)
+    }
+
+    @Test
+    fun `commitEntryCut without a name only closes the scissors state`() {
+        val editor = createEditor(otoProject, appConf = plainConf())
+        val before = editor.project
+        editor.onScreenScissorsState.start(0, 200f, 120f, "")
+
+        editor.commitEntryCut()
+
+        assertFalse(editor.onScreenScissorsState.isOn)
+        assertSame(before, editor.project)
+    }
+
+    @Test
+    fun `cutEntry without a loaded sample is a no-op`() {
+        val editor = createEditor(otoProject, appConf = plainConf())
+        val before = editor.project
+
+        editor.cutEntry(0, 200f, 120f)
+
+        assertFalse(editor.onScreenScissorsState.isOn)
+        assertSame(before, editor.project)
+        assertNull(env.dialogArgs)
+    }
+
+    @Test
+    fun `cutEntry with on-screen scissors starts the input state`() {
+        val appConf = plainConf()
+        val editor = createEditor(nnsvsProject, appConf = appConf) {
+            jumpToModuleByNameAndEntry("doremi", 2)
+        }
+        loadSample(editor, appConf)
+        assertTrue(editor.canUseOnScreenScissors)
+
+        editor.cutEntry(2, 500f, 42f)
+
+        assertTrue(editor.onScreenScissorsState.isOn)
+        assertEquals(2, editor.onScreenScissorsState.entryIndex)
+        assertEquals(500f, editor.onScreenScissorsState.timePosition)
+        assertEquals(42f, editor.onScreenScissorsState.pixelPosition)
+        assertEquals("o", editor.onScreenScissorsState.text)
+    }
+
+    @Test
+    fun `cutEntry with askForName none cuts immediately with a default name`() {
+        val appConf = plainConf(askForName = AppConf.ScissorsActions.Target.None)
+        val editor = createEditor(nnsvsProject, appConf = appConf) {
+            jumpToModuleByNameAndEntry("doremi", 2)
+        }
+        loadSample(editor, appConf)
+        val beforeCount = editor.project.currentModule.entries.size
+
+        editor.cutEntry(2, 500f, 42f)
+
+        assertFalse(editor.onScreenScissorsState.isOn)
+        val module = editor.project.currentModule
+        assertEquals(beforeCount + 1, module.entries.size)
+        assertEquals(500f, module.entries[2].end)
+        assertEquals(500f, module.entries[3].start)
+        // goTo = Latter selects the new latter entry
+        assertEquals(3, module.currentIndex)
+    }
+
+    @Test
+    fun `cutEntry without on-screen scissors opens the cut name dialog`() {
+        val appConf = plainConf(useOnScreenScissors = false)
+        val editor = createEditor(otoProject, appConf = appConf)
+        loadSample(editor, appConf)
+
+        editor.cutEntry(0, 200f, 0f)
+
+        // the unconfined main scope has run the request up to the dialog suspension point
+        val args = assertIs<InputEntryNameDialogArgs>(env.dialogArgs)
+        assertEquals(0, args.index)
+        assertEquals("- a", args.initial)
+        assertEquals(InputEntryNameDialogPurpose.CutFormer, args.purpose)
+        assertFalse(editor.onScreenScissorsState.isOn)
+    }
+
+    @Test
+    fun `canUseOnScreenScissors requires the configuration and multiple edit mode`() {
+        assertFalse(createEditor(otoProject).canUseOnScreenScissors)
+        assertTrue(createEditor(nnsvsProject).canUseOnScreenScissors)
+        assertFalse(
+            createEditor(
+                nnsvsProject,
+                appConf = AppConf(editor = AppConf.Editor(useOnScreenScissors = false)),
+            ).canUseOnScreenScissors,
+        )
+    }
+
+    /* endregion */
+
+    /* region sample loading and canvas state */
+
+    @Test
+    fun `loadSample transitions to loaded and initializes the render progress`() {
+        val editor = createEditor(otoProject)
+        loadSample(editor, AppConf())
+
+        val loaded = assertIs<CanvasState.Loaded>(editor.canvasState)
+        assertEquals("_a_ka.wav", loaded.sampleInfo.name)
+        assertEquals(loaded.sampleInfo, editor.getSampleInfo())
+        assertEquals(loaded.sampleInfo.length, loaded.params.dataLength)
+        assertEquals(loaded.sampleInfo.chunkCount, loaded.params.chunkCount)
+        assertEquals(editor.canvasResolution, loaded.params.resolution)
+        assertFalse(editor.isLoading)
+        assertEquals(0 to loaded.sampleInfo.totalChartCount, editor.renderProgress)
+
+        editor.cancelLoading()
+        assertEquals(CanvasState.Loading, editor.canvasState)
+        assertEquals(0 to 0, editor.renderProgress)
+    }
+
+    @Test
+    fun `loadSample redirects when the sample directory is missing`() {
+        val sampleDir = TestFixtures.deploy(
+            "oto",
+            tempDir.resolve("missing-oto"),
+            wavFiles = listOf("_a_ka.wav"),
+        )
+        val project = createTestProject(
+            labeler = TestLabelers.utauOto,
+            sampleDirectory = sampleDir,
+            inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+        )
+        val editor = createEditor(project)
+        sampleDir.deleteRecursively()
+
+        runBlocking { editor.loadSample(AppConf()) }
+
+        assertEquals(CanvasState.Error, editor.canvasState)
+        assertTrue(editor.isError)
+        assertIs<CommonConfirmationDialogAction.RedirectSampleDirectory>(env.dialogArgs)
+    }
+
+    @Test
+    fun `changeResolution updates the resolution and the canvas params when loaded`() {
+        val editor = createEditor(otoProject)
+        editor.changeResolution(200)
+        assertEquals(200, editor.canvasResolution)
+        // without a loaded sample only the resolution changes
+        assertEquals(CanvasState.Loading, editor.canvasState)
+
+        loadSample(editor, AppConf())
+        editor.changeResolution(300)
+
+        assertEquals(300, editor.canvasResolution)
+        val loaded = assertIs<CanvasState.Loaded>(editor.canvasState)
+        assertEquals(300, loaded.params.resolution)
+        assertEquals(loaded.sampleInfo.length.toFloat() / 300, loaded.params.lengthInPixel)
+    }
+
+    @Test
+    fun `renderCharts renders through the chart store and clear resets it`() {
+        val editor = createEditor(otoProject)
+        loadSample(editor, AppConf())
+        val sampleInfo = assertNotNull(editor.getSampleInfo())
+        assertEquals(0 to sampleInfo.totalChartCount, editor.renderProgress)
+
+        editor.renderCharts(scope, sampleInfo, AppConf(), Density(1f), LayoutDirection.Ltr)
+        runBlocking { editor.chartStore.awaitLoad() }
+
+        assertEquals(sampleInfo.totalChartCount to sampleInfo.totalChartCount, editor.renderProgress)
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, editor.chartStore.getWaveformStatus(0, 0))
+        assertEquals(ChartStore.ChartLoadingStatus.Loaded, editor.chartStore.getSpectrogramStatus(0))
+        assertTrue(editor.chartStore.hasCachedSample(sampleInfo))
+
+        editor.clear()
+        assertNull(editor.chartStore.getWaveformStatus(0, 0))
+        assertNull(editor.chartStore.getSpectrogramStatus(0))
+    }
+
+    /* endregion */
+
+    /* region navigation and dialogs */
+
+    @Test
+    fun `navigation and module functions delegate to the project store`() {
+        val editor = createEditor(utauSingerProject) {
+            jumpToModuleByNameAndEntry("C4", 0)
+        }
+
+        editor.jumpToEntry("C4", 1)
+        assertEquals(1, editor.project.currentModule.currentIndex)
+        assertEquals("a ka", editor.entryTitle)
+
+        editor.jumpToModule("A3")
+        assertEquals("A3", editor.project.currentModule.name)
+
+        val c4Index = editor.project.modules.indexOfFirst { it.name == "C4" }
+        editor.jumpToModule(c4Index)
+        assertEquals("C4", editor.project.currentModule.name)
+
+        editor.jumpToModule("A3", targetEntryIndex = 1)
+        assertEquals("A3", editor.project.currentModule.name)
+        assertEquals(1, editor.project.currentModule.currentIndex)
+
+        editor.createDefaultEntry("C4", "_a_ka.wav")
+        assertEquals(5, editor.project.modules.first { it.name == "C4" }.entries.size)
+
+        editor.createDefaultEntries("C4", listOf("_a_ka.wav", "_i_ki.wav"))
+        assertEquals(7, editor.project.modules.first { it.name == "C4" }.entries.size)
+
+        val root = editor.project.rootSampleDirectory
+        editor.changeSampleDirectory("C4", root)
+        val c4 = editor.project.modules.first { it.name == "C4" }
+        assertEquals(root.absolutePath, c4.getSampleDirectory(editor.project).absolutePath)
+    }
+
+    @Test
+    fun `dialog functions open the corresponding embedded dialogs`() {
+        val editor = createEditor(otoProject)
+
+        editor.openEditEntryNameDialog(0, InputEntryNameDialogPurpose.Rename)
+        var nameArgs = assertIs<InputEntryNameDialogArgs>(env.dialogArgs)
+        assertEquals(0, nameArgs.index)
+        assertEquals("- a", nameArgs.initial)
+        assertEquals(InputEntryNameDialogPurpose.Rename, nameArgs.purpose)
+        // the oto labeler does not allow duplicate names; renaming excludes the entry's own name
+        assertEquals(listOf("a ka"), nameArgs.invalidOptions)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.OpenDuplicateEntryDialog(1))
+        nameArgs = assertIs(env.dialogArgs)
+        assertEquals(1, nameArgs.index)
+        assertEquals(InputEntryNameDialogPurpose.Duplicate, nameArgs.purpose)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.OpenRenameEntryDialog(1))
+        nameArgs = assertIs(env.dialogArgs)
+        assertEquals(InputEntryNameDialogPurpose.Rename, nameArgs.purpose)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.OpenMoveEntryDialog(1))
+        val moveArgs = assertIs<MoveEntryDialogArgs>(env.dialogArgs)
+        assertEquals(1, moveArgs.currentIndex)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.OpenRemoveEntryDialog(0))
+        val removeArgs = assertIs<CommonConfirmationDialogAction.RemoveEntry>(env.dialogArgs)
+        assertEquals(0, removeArgs.entryIndex)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.RemoveEntries(listOf(0, 1)))
+        val removeEntriesArgs = assertIs<CommonConfirmationDialogAction.RemoveEntries>(env.dialogArgs)
+        assertEquals(listOf(0, 1), removeEntriesArgs.entryIndexes)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.EditEntriesTag(listOf(0, 1), "common"))
+        val tagArgs = assertIs<EditEntriesTagDialogArgs>(env.dialogArgs)
+        assertEquals(listOf(0, 1), tagArgs.indexes)
+        assertEquals("common", tagArgs.initial)
+
+        editor.editEntryExtra(0)
+        val extraArgs = assertIs<EditExtraDialogArgs>(env.dialogArgs)
+        assertEquals(0, extraArgs.index)
+    }
+
+    @Test
+    fun `context filter actions update the project entry filter`() {
+        val editor = createEditor(otoProject)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterByEntryName("- a"))
+        assertEquals(listOf(0), editor.project.currentModule.filteredEntryIndexes)
+
+        // the sample name filter matches the sample name without its extension
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterBySampleName("_a_ka"))
+        assertEquals(listOf(0, 1), editor.project.currentModule.filteredEntryIndexes)
+
+        editor.editEntryTag(0, "x")
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterByTag("x"))
+        assertEquals(listOf(0), editor.project.currentModule.filteredEntryIndexes)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.SetEntriesStar(listOf(0), true))
+        assertTrue(editor.project.currentModule.entries[0].notes.star)
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterStarred())
+        assertEquals(EntryFilter(star = true), editor.project.entryFilter)
+        assertEquals(listOf(0), editor.project.currentModule.filteredEntryIndexes)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterUnstarred())
+        assertEquals(listOf(1), editor.project.currentModule.filteredEntryIndexes)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.SetEntriesDone(listOf(1), true))
+        assertTrue(editor.project.currentModule.entries[1].notes.done)
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterDone())
+        assertEquals(listOf(1), editor.project.currentModule.filteredEntryIndexes)
+
+        editor.consumeEditorEntryContextAction(EditorEntryContextAction.FilterUndone())
+        assertEquals(listOf(0), editor.project.currentModule.filteredEntryIndexes)
+    }
+
+    @Test
+    fun `pinned entry list filter submits to the project only when linked`() {
+        val editor = createEditor(otoProject)
+        assertFalse(editor.pinnedEntryListFilterState.linked)
+
+        editor.pinnedEntryListFilterState.editFilter { copy(searchText = "name:ka") }
+        // not linked: the project filter is untouched
+        assertNull(editor.project.entryFilter)
+
+        editor.pinnedEntryListFilterState.toggleLinked()
+        assertTrue(editor.pinnedEntryListFilterState.linked)
+        assertEquals(EntryFilter(searchText = "name:ka"), editor.project.entryFilter)
+        assertEquals(listOf(1), editor.project.currentModule.filteredEntryIndexes)
+
+        editor.pinnedEntryListFilterState.clear()
+        assertFalse(editor.pinnedEntryListFilterState.linked)
+        assertNull(editor.project.entryFilter)
+        assertEquals(listOf(0, 1), editor.project.currentModule.filteredEntryIndexes)
+    }
+
+    @Test
+    fun `handleSetPropertyKeyAction opens the set property dialog for bound properties`() {
+        val editor = createEditor(otoProject)
+
+        assertTrue(editor.handleSetPropertyKeyAction(KeyAction.SetProperty1))
+        val args = assertIs<SetEntryPropertyDialogArgs>(env.dialogArgs)
+        // property 0 ("left") of the oto labeler is bound to the first shortcut; its getter reads points[3]
+        assertEquals(0, args.propertyIndex)
+        assertEquals(editor.project.currentEntry.points[3], args.currentValue)
+
+        // no property of the oto labeler is bound to the 10th shortcut
+        assertFalse(editor.handleSetPropertyKeyAction(KeyAction.SetProperty10))
+        // non-property actions are not handled
+        assertFalse(editor.handleSetPropertyKeyAction(KeyAction.NavigateNextEntry))
+    }
+
+    /* endregion */
+
+    companion object {
+
+        private val sharedTempDir: File by lazy {
+            createTempDirectory("vlabeler-test").toFile().also { dir ->
+                Runtime.getRuntime().addShutdownHook(Thread { dir.deleteRecursively() })
+            }
+        }
+
+        /**
+         * A single-module oto project with entries "- a" and "a ka" on the real sample "_a_ka.wav".
+         */
+        private val otoProject: Project by lazy {
+            val sampleDir = TestFixtures.deploy(
+                "oto",
+                sharedTempDir.resolve("oto"),
+                wavFiles = listOf("_a_ka.wav"),
+            )
+            createTestProject(
+                labeler = TestLabelers.utauOto,
+                sampleDirectory = sampleDir,
+                inputFilePath = sampleDir.resolve("oto.ini").absolutePath,
+            )
+        }
+
+        /**
+         * A two-module utau-singer project: "A3" ("- aA3", "a kaA3") and "C4" ("- a", "a ka", "- i", "i ki").
+         */
+        private val utauSingerProject: Project by lazy {
+            val sampleDir = TestFixtures.deploy(
+                "utau-singer",
+                sharedTempDir.resolve("utau-singer"),
+                wavFiles = listOf("C4/_a_ka.wav", "C4/_i_ki.wav", "A3/_a_ka.wav"),
+            )
+            createTestProject(labeler = TestLabelers.utauSinger, sampleDirectory = sampleDir)
+        }
+
+        /**
+         * A continuous nnsvs-singer project in multiple edit mode with modules "doremi"
+         * (entries "pau", "d", "o", "r", "e", "pau") and "legato".
+         */
+        private val nnsvsProject: Project by lazy {
+            val sampleDir = TestFixtures.deploy(
+                "nnsvs-singer",
+                sharedTempDir.resolve("nnsvs-singer"),
+                wavFiles = listOf("wav/doremi.wav", "wav/legato.wav"),
+                wavDurationMs = 1500,
+            )
+            createTestProject(labeler = TestLabelers.nnsvsSinger, sampleDirectory = sampleDir)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First batch of [coverage round 2](https://trello.com/c/WFKEU7I2) (checklist items 1, 6, and the marker part of 8): **55 new tests (928 total), line coverage 45.2% → 49.7%**, koverVerify bound raised 43 → 47.

### EditorState (24 tests)
Tested through a **functional `AppState`** — uninitialized allocation with real members injected reflectively (real `ProjectStoreImpl`, `AppDialogStateImpl`, keyboard/scroll view models, cancelled-scope record store), so project edits round-trip exactly like production. Covers edited-entry staging/submission (continuous neighbor sync, cross-module cascade), scissors cutting flows (on-screen, immediate, dialog-requesting), **real sample loading** (canvas transitions, missing-directory error → redirect dialog), chart rendering end-to-end, resolution changes, dialog-opening and filter context actions, and the JS-backed property key action.

### ChartStore (6 tests)
Status init/invalidation, full render producing repository PNGs, cache reuse without rerender, render-priority ordering around the current chunk, clear semantics.

### Timescale (10 tests)
Tick item selection per zoom level and exact tick/label layouts, including scroll offsets and minute/hour label formats.

### `editEntryIfNeeded` (15 tests) — production refactor: one keyword
Made `internal` (was `private`) to unlock the drag→`Edition` conversion — the last untested piece of the marker pipeline. Tests cover field-name derivation, millis conversion, continuous-mode neighbor border cascades, and locked multi-entry drags with full `Edition` assertions.

### Bugs found by these tests — three fixed in this PR (commit 990d1074)
1. **`fieldNames` misattribution in multi-entry editions**: `getPointIndexAsSingleEntry`'s `indexOfFirst` returns -1 on no-match, colliding with `END_POINT_INDEX = -1`, so cascade/locked-drag editions for entries not owning the dragged point always get `["end"]`
2. **`EntryFilter.getFilteredIndexes` leaks a `JavaScript` engine** per advanced-filter evaluation (never closed)
3. `ChartStore.initializeStates` quirks: power/fundamental statuses stay null until rendered; spectrogram status initialized to `Loading` even when disabled (then never `Loaded`)
4. `EditorState.submitEntries` silently discards staged editions of entries not loaded for editing (possibly intended)

### Testability refactor suggestions (described, not applied)
Extract the mouse-scroll-action mapping from `handlePointerEvent`; make `updateResolutionByKeyAction` internal.

## Test plan

- [x] `./gradlew jvmTest` — 928 tests, 0 failures
- [x] `./gradlew koverVerify ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
